### PR TITLE
Fixes CLI Bug for Create Log

### DIFF
--- a/cmd/resim/commands/log.go
+++ b/cmd/resim/commands/log.go
@@ -108,7 +108,7 @@ func createLog(ccmd *cobra.Command, args []string) {
 
 	// Create the log entry
 	logResponse, err := client.CreateLogWithResponse(context.Background(), logBatchID, logJobID, body)
-	ValidateResponse(http.StatusCreated, "unable to create log", jobResponse.HTTPResponse, err)
+	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse, err)
 	if logResponse.JSON201 == nil {
 		log.Fatal("empty response")
 	}


### PR DESCRIPTION
# Description of change

Fixes a bug in the CLI where the logs creation was not checking the correct status code.

## Asana task link

[Asana task](https://app.asana.com/0/1205228215063249/1205290251624866/f)

## Guide to reproduce test results

`go build -o resim ./cmd/resim`
`resim create build --help`

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [] This change is covered by tests that are already landed, or in this PR.
