### PR TITLE
Fixing possible seg faults

### DIFF
--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -124,7 +124,10 @@ func createBatch(ccmd *cobra.Command, args []string) {
 	}
 
 	response, err := client.CreateBatchWithResponse(context.Background(), body)
-	ValidateResponse(http.StatusCreated, "failed to create batch", response.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("failed to create batch:", err)
+	}
+	ValidateResponse(http.StatusCreated, "failed to create batch", response.HTTPResponse)
 
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
@@ -160,7 +163,10 @@ func getBatch(ccmd *cobra.Command, args []string) {
 			log.Fatal("unable to parse batch ID: ", err)
 		}
 		response, err := client.GetBatchWithResponse(context.Background(), batchID)
-		ValidateResponse(http.StatusOK, "unable to retrieve batch", response.HTTPResponse, err)
+		if err != nil {
+			log.Fatal("failed to get batch:", err)
+		}
+		ValidateResponse(http.StatusOK, "unable to retrieve batch", response.HTTPResponse)
 		batch = response.JSON200
 	} else if viper.IsSet(batchNameKey) {
 		batchName := viper.GetString(batchNameKey)
@@ -170,7 +176,10 @@ func getBatch(ccmd *cobra.Command, args []string) {
 			response, err := client.ListBatchesWithResponse(context.Background(), &api.ListBatchesParams{
 				PageToken: pageToken,
 			})
-			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse, err)
+			if err != nil {
+				log.Fatal("failed to list batches:", err)
+			}
+			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse)
 			if response.JSON200.Batches == nil {
 				log.Fatal("unable to find batch: ", batchName)
 			}
@@ -240,7 +249,10 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 			response, err := client.ListBatchesWithResponse(context.Background(), &api.ListBatchesParams{
 				PageToken: pageToken,
 			})
-			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse, err)
+			if err != nil {
+				log.Fatal("failed to list batches:", err)
+			}
+			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse)
 			if response.JSON200.Batches == nil {
 				log.Fatal("unable to find batch: ", batchName)
 			}
@@ -269,7 +281,10 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 		response, err := client.ListJobsWithResponse(context.Background(), batchID, &api.ListJobsParams{
 			PageToken: pageToken,
 		})
-		ValidateResponse(http.StatusOK, "unable to list jobs", response.HTTPResponse, err)
+		if err != nil {
+			log.Fatal("unable to list jobs:", err)
+		}
+		ValidateResponse(http.StatusOK, "unable to list jobs", response.HTTPResponse)
 		if response.JSON200.Jobs == nil {
 			log.Fatal("unable to list jobs")
 		}

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -164,7 +164,7 @@ func getBatch(ccmd *cobra.Command, args []string) {
 		}
 		response, err := client.GetBatchWithResponse(context.Background(), batchID)
 		if err != nil {
-			log.Fatal("failed to get batch:", err)
+			log.Fatal("unable to retrieve batch:", err)
 		}
 		ValidateResponse(http.StatusOK, "unable to retrieve batch", response.HTTPResponse)
 		batch = response.JSON200
@@ -177,7 +177,7 @@ func getBatch(ccmd *cobra.Command, args []string) {
 				PageToken: pageToken,
 			})
 			if err != nil {
-				log.Fatal("failed to list batches:", err)
+				log.Fatal("unable to list batches:", err)
 			}
 			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse)
 			if response.JSON200.Batches == nil {
@@ -250,7 +250,7 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 				PageToken: pageToken,
 			})
 			if err != nil {
-				log.Fatal("failed to list batches:", err)
+				log.Fatal("unable to list batches:", err)
 			}
 			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse)
 			if response.JSON200.Batches == nil {
@@ -289,9 +289,7 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 			log.Fatal("unable to list jobs")
 		}
 		responseJobs := *response.JSON200.Jobs
-		for _, job := range responseJobs {
-			jobs = append(jobs, job)
-		}
+		jobs = append(jobs, responseJobs...)
 
 		if response.JSON200.NextPageToken != nil && *response.JSON200.NextPageToken != "" {
 			pageToken = response.JSON200.NextPageToken

--- a/cmd/resim/commands/branch.go
+++ b/cmd/resim/commands/branch.go
@@ -80,7 +80,10 @@ func createBranch(ccmd *cobra.Command, args []string) {
 	}
 
 	response, err := client.CreateBranchForProjectWithResponse(context.Background(), projectID, body)
-	ValidateResponse(http.StatusCreated, "unable to create branch", response.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("unable to create branch: ", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create branch", response.HTTPResponse)
 	if response.JSON201 == nil {
 		log.Fatal("empty branch returned")
 	}
@@ -109,7 +112,10 @@ pageLoop:
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
 			})
-		ValidateResponse(http.StatusOK, "failed to list branches", response.HTTPResponse, err)
+		if err != nil {
+			log.Fatal("failed to list branches:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list branches", response.HTTPResponse)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || response.JSON200.Branches == nil {

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -103,8 +103,11 @@ func createBuild(ccmd *cobra.Command, args []string) {
 			}
 
 			response, err := client.CreateBranchForProjectWithResponse(context.Background(), projectID, body)
+			if err != nil {
+				log.Fatal("failed to create branch:", err)
+			}
 			ValidateResponse(http.StatusCreated, fmt.Sprintf("failed to create a new branch with name %v", branchName),
-				response.HTTPResponse, err)
+				response.HTTPResponse)
 			branchID = *response.JSON201.BranchID
 			if !buildGithub {
 				fmt.Printf("Created branch with ID %v\n", branchID)
@@ -121,7 +124,10 @@ func createBuild(ccmd *cobra.Command, args []string) {
 	}
 
 	response, err := client.CreateBuildForBranchWithResponse(context.Background(), projectID, branchID, body)
-	ValidateResponse(http.StatusCreated, "unable to create build", response.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("unable to create build:", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create build", response.HTTPResponse)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}

--- a/cmd/resim/commands/client.go
+++ b/cmd/resim/commands/client.go
@@ -55,12 +55,9 @@ func GetClient(ctx context.Context) (*api.ClientWithResponses, error) {
 	return api.NewClientWithResponses(viper.GetString(urlKey), api.WithHTTPClient(oauthClient))
 }
 
-// Validate Response fails the command if the error is non-nil, the response is nil, or the
+// Validate Response fails the command if the response is nil, or the
 // status code is not what we expect.
-func ValidateResponse(expectedStatusCode int, message string, response *http.Response, err error) {
-	if err != nil {
-		log.Fatal(message, ": ", err)
-	}
+func ValidateResponse(expectedStatusCode int, message string, response *http.Response) {
 	if response == nil {
 		log.Fatal(message, ": ", "no response")
 	}

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -80,7 +80,10 @@ func createExperience(ccmd *cobra.Command, args []string) {
 	}
 
 	response, err := client.CreateExperienceWithResponse(context.Background(), body)
-	ValidateResponse(http.StatusCreated, "failed to create experience", response.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("failed to create experience: ", err)
+	}
+	ValidateResponse(http.StatusCreated, "failed to create experience", response.HTTPResponse)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}

--- a/cmd/resim/commands/experience_tags.go
+++ b/cmd/resim/commands/experience_tags.go
@@ -39,7 +39,10 @@ pageLoop:
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
 			})
-		ValidateResponse(http.StatusOK, "unable to create list experiences", listResponse.HTTPResponse, err)
+		if err != nil {
+			log.Fatal("unable to list experience tags:", err)
+		}
+		ValidateResponse(http.StatusOK, "unable to list experience tags", listResponse.HTTPResponse)
 		if listResponse.JSON200 == nil {
 			log.Fatal("empty response")
 		}

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -133,7 +133,7 @@ func createLog(ccmd *cobra.Command, args []string) {
 	// Create the log entry
 	logResponse, err := client.CreateLogWithResponse(context.Background(), logBatchID, logJobID, body)
 	if err != nil {
-		log.Fatal("unable to create job: ", err)
+		log.Fatal("unable to create log: ", err)
 	}
 	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse)
 	if logResponse.JSON201 == nil {
@@ -189,9 +189,7 @@ func listLogs(ccmd *cobra.Command, args []string) {
 			log.Fatal("unable to list logs")
 		}
 		responseLogs := *response.JSON200.Logs
-		for _, log := range responseLogs {
-			logs = append(logs, log)
-		}
+		logs = append(logs, responseLogs...)
 
 		if response.JSON200.NextPageToken != nil && *response.JSON200.NextPageToken != "" {
 			pageToken = response.JSON200.NextPageToken

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -117,21 +117,30 @@ func createLog(ccmd *cobra.Command, args []string) {
 
 	// Verify that the batch and job exist:
 	batchResponse, err := client.GetBatchWithResponse(context.Background(), logBatchID)
-	ValidateResponse(http.StatusOK, fmt.Sprintf("unabled to find batch with ID %v", logBatchID),
-		batchResponse.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("unable to get batch: ", err)
+	}
+	ValidateResponse(http.StatusOK, fmt.Sprintf("unable to find batch with ID %v", logBatchID),
+		batchResponse.HTTPResponse)
 
 	jobResponse, err := client.GetJobWithResponse(context.Background(), logBatchID, logJobID)
-	ValidateResponse(http.StatusOK, fmt.Sprintf("unabled to find job with ID %v", logJobID),
-		jobResponse.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("unable to get job: ", err)
+	}
+	ValidateResponse(http.StatusOK, fmt.Sprintf("unable to find job with ID %v", logJobID),
+		jobResponse.HTTPResponse)
 
 	// Create the log entry
 	logResponse, err := client.CreateLogWithResponse(context.Background(), logBatchID, logJobID, body)
-	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse, err)
+	if err != nil {
+		log.Fatal("unable to create job: ", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse)
 	if logResponse.JSON201 == nil {
 		log.Fatal("empty response")
 	}
 	myLog := logResponse.JSON201
-	if myLog.Location == nil {
+	if myLog.Location == nil || *myLog.Location == "" {
 		log.Fatal("empty location")
 	}
 	if myLog.LogID == nil {
@@ -172,7 +181,10 @@ func listLogs(ccmd *cobra.Command, args []string) {
 			PageToken: pageToken,
 			PageSize:  Ptr(100),
 		})
-		ValidateResponse(http.StatusOK, "unable to list logs", response.HTTPResponse, err)
+		if err != nil {
+			log.Fatal("unable to list logs: ", err)
+		}
+		ValidateResponse(http.StatusOK, "unable to list logs", response.HTTPResponse)
 		if response.JSON200.Logs == nil {
 			log.Fatal("unable to list logs")
 		}

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -73,7 +73,10 @@ func createProject(ccmd *cobra.Command, args []string) {
 	}
 
 	response, err := client.CreateProjectWithResponse(context.Background(), body)
-	ValidateResponse(http.StatusCreated, "failed to create project", response.HTTPResponse, err)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ValidateResponse(http.StatusCreated, "failed to create project", response.HTTPResponse)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}
@@ -103,7 +106,10 @@ pageLoop:
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
 			})
-		ValidateResponse(http.StatusOK, "failed to list projects", response.HTTPResponse, err)
+		if err != nil {
+			log.Fatal("failed to list projects:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list projects", response.HTTPResponse)
 		if response.JSON200 == nil {
 			log.Fatal("empty response")
 		}


### PR DESCRIPTION
# Description of change

Modifies the validate response code to not check the raw error, but we do that in-line. This is because if the error
exists, a response may be nil.

## Asana task link

[Asana task](https://app.asana.com/0/1204958435152584/1205290251624895/f)

## Guide to reproduce test results

You can very easily repro a seg fault on main by passing fake credentials, then try with this PR.

`go build -o resim ./cmd/resim`
`resim create build --help`

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [] This change is covered by tests that are already landed, or in this PR.
