### PR TITLE
User can get and delete project

### DIFF
--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
@@ -27,9 +29,26 @@ var (
 		Run:    createProject,
 		PreRun: RegisterViperFlags,
 	}
+
+	getProjectCmd = &cobra.Command{
+		Use:    "get",
+		Short:  "get - Gets details about a project",
+		Long:   ``,
+		Run:    getProject,
+		PreRun: RegisterViperFlags,
+	}
+
+	deleteProjectCmd = &cobra.Command{
+		Use:    "delete",
+		Short:  "delete - Deletes a project",
+		Long:   ``,
+		Run:    deleteProject,
+		PreRun: RegisterViperFlags,
+	}
 )
 
 const (
+	projectIDKey          = "project-id"
 	projectNameKey        = "name"
 	projectDescriptionKey = "description"
 	projectGithubKey      = "github"
@@ -42,6 +61,17 @@ func init() {
 	createProjectCmd.MarkFlagRequired(projectDescriptionKey)
 	createProjectCmd.Flags().Bool(projectGithubKey, false, "Whether to output format in github action friendly format")
 	projectCmd.AddCommand(createProjectCmd)
+
+	getProjectCmd.Flags().String(projectIDKey, "", "The ID of the project to get")
+	getProjectCmd.Flags().String(projectNameKey, "", "The Name of the project to get (e.g. my-project)")
+	getProjectCmd.MarkFlagsMutuallyExclusive(projectIDKey, projectNameKey)
+	projectCmd.AddCommand(getProjectCmd)
+
+	deleteProjectCmd.Flags().String(projectIDKey, "", "The ID of the project to delete")
+	deleteProjectCmd.Flags().String(projectNameKey, "", "The Name of the project to delete (e.g. my-project)")
+	deleteProjectCmd.MarkFlagsMutuallyExclusive(projectIDKey, projectNameKey)
+	projectCmd.AddCommand(deleteProjectCmd)
+
 	rootCmd.AddCommand(projectCmd)
 }
 
@@ -89,8 +119,65 @@ func createProject(ccmd *cobra.Command, args []string) {
 	}
 }
 
+func getProject(ccmd *cobra.Command, args []string) {
+	var project *api.Project
+	if viper.IsSet(projectIDKey) {
+		projectID, err := uuid.Parse(viper.GetString(projectIDKey))
+		if err != nil {
+			log.Fatal("unable to parse project ID: ", err)
+		}
+		response, err := Client.GetProjectWithResponse(context.Background(), projectID)
+		if err != nil {
+			log.Fatal("unable to retrieve project:", err)
+		}
+		if response.HTTPResponse.StatusCode == http.StatusNotFound {
+			log.Fatal("failed to find project with requested id: ", projectID.String())
+		} else {
+			ValidateResponse(http.StatusOK, "unable to retrieve project", response.HTTPResponse)
+		}
+		project = response.JSON200
+	} else if viper.IsSet(projectNameKey) {
+		projectName := viper.GetString(projectNameKey)
+		projectID := getProjectIDForName(Client, projectName)
+		response, err := Client.GetProjectWithResponse(context.Background(), projectID)
+		if err != nil {
+			log.Fatal("unable to retrieve project:", err)
+		}
+		ValidateResponse(http.StatusOK, "unable to retrieve project", response.HTTPResponse)
+		project = response.JSON200
+	} else {
+		log.Fatal("must specify either the project ID or the project name")
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", " ")
+	enc.Encode(project)
+}
+
+func deleteProject(ccmd *cobra.Command, args []string) {
+	var projectID uuid.UUID
+	if viper.IsSet(projectIDKey) {
+		projectID = uuid.MustParse(viper.GetString(projectIDKey))
+	} else if viper.IsSet(projectNameKey) {
+		projectName := viper.GetString(projectNameKey)
+		projectID = getProjectIDForName(Client, projectName)
+	} else {
+		log.Fatal("must specify either the project ID or the project name")
+	}
+	response, err := Client.DeleteProjectWithResponse(context.Background(), projectID)
+	if err != nil {
+		log.Fatal("unable to delete project:", err)
+	}
+	if response.HTTPResponse.StatusCode == http.StatusNotFound {
+		log.Fatal("failed to delete project. No project exists with requested id: ", projectID.String())
+	} else {
+		ValidateResponse(http.StatusNoContent, "unable to delete project", response.HTTPResponse)
+	}
+	fmt.Println("Delete project successfully!")
+}
+
 // TODO(https://app.asana.com/0/1205228215063249/1205227572053894/f): we should have first class support in API for this
-func getProjectIDForName(client api.ClientWithResponsesInterface, buildProjectName string) uuid.UUID {
+func getProjectIDForName(client api.ClientWithResponsesInterface, projectName string) uuid.UUID {
 	// Page through projects until we find the one we want:
 	var projectID uuid.UUID = uuid.Nil
 	var pageToken *string = nil
@@ -118,7 +205,7 @@ pageLoop:
 			if project.ProjectID == nil {
 				log.Fatal("project ID is empty")
 			}
-			if *project.Name == buildProjectName {
+			if *project.Name == projectName {
 				projectID = *project.ProjectID
 				break pageLoop
 			}
@@ -128,7 +215,7 @@ pageLoop:
 		}
 	}
 	if projectID == uuid.Nil {
-		log.Fatal("failed to find project with requested name: ", buildProjectName)
+		log.Fatal("failed to find project with requested name: ", projectName)
 	}
 	return projectID
 }


### PR DESCRIPTION
# Description of change

Allows the user to get and delete a project by name or id

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.