### PR TITLE
Getting Styley

### DIFF
--- a/cmd/resim/commands/commands.go
+++ b/cmd/resim/commands/commands.go
@@ -48,6 +48,7 @@ func rootCommand(cmd *cobra.Command, args []string) {
 }
 
 func Execute() error {
+  ApplyReSimStyle(rootCmd)
 	return rootCmd.Execute()
 }
 

--- a/cmd/resim/commands/commands.go
+++ b/cmd/resim/commands/commands.go
@@ -48,7 +48,7 @@ func rootCommand(cmd *cobra.Command, args []string) {
 }
 
 func Execute() error {
-  ApplyReSimStyle(rootCmd)
+	ApplyReSimStyle(rootCmd)
 	return rootCmd.Execute()
 }
 

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -34,19 +34,11 @@ const (
 	experienceGithubKey      = "github"
 )
 
-func my_return_string(cmd *cobra.Command) error{
-  fmt.Println("isnt it a lovely day")
-  return nil
-}
-
 func init() {
-	createExperienceCmd.Flags().String(experienceNameKey, "", "[Required] The name of the experience")
-	createExperienceCmd.MarkFlagRequired(experienceNameKey)
-	createExperienceCmd.Flags().String(experienceDescriptionKey, "", "[Required] The description of the experience")
-	createExperienceCmd.MarkFlagRequired(experienceDescriptionKey)
-	createExperienceCmd.Flags().String(experienceLocationKey, "", "[Required] The location of the experience, e.g. an S3 URI for the experience folder")
-	createExperienceCmd.MarkFlagRequired(experienceLocationKey)
-	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "[Optional] Whether to output format in github action friendly format")
+	createExperienceCmd.Flags().String(experienceNameKey, "", "The name of the experience")
+	createExperienceCmd.Flags().String(experienceDescriptionKey, "", "The description of the experience")
+	createExperienceCmd.Flags().String(experienceLocationKey, "", "The location of the experience, e.g. an S3 URI for the experience folder")
+	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "Whether to output format in github action friendly format")
 	experienceCmd.AddCommand(createExperienceCmd)
 	rootCmd.AddCommand(experienceCmd)
 }

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -36,8 +36,11 @@ const (
 
 func init() {
 	createExperienceCmd.Flags().String(experienceNameKey, "", "The name of the experience")
+	createExperienceCmd.MarkFlagRequired(experienceNameKey)
 	createExperienceCmd.Flags().String(experienceDescriptionKey, "", "The description of the experience")
+	createExperienceCmd.MarkFlagRequired(experienceDescriptionKey)
 	createExperienceCmd.Flags().String(experienceLocationKey, "", "The location of the experience, e.g. an S3 URI for the experience folder")
+	createExperienceCmd.MarkFlagRequired(experienceLocationKey)
 	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "Whether to output format in github action friendly format")
 	experienceCmd.AddCommand(createExperienceCmd)
 	rootCmd.AddCommand(experienceCmd)

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -34,14 +34,21 @@ const (
 	experienceGithubKey      = "github"
 )
 
+func my_return_string(cmd *cobra.Command) error{
+  fmt.Println("isnt it a lovely day")
+  return nil
+}
+
 func init() {
-	createExperienceCmd.Flags().String(experienceNameKey, "", "The name of the experience")
+	createExperienceCmd.Flags().String(experienceNameKey, "", "[Required] The name of the experience")
 	createExperienceCmd.MarkFlagRequired(experienceNameKey)
-	createExperienceCmd.Flags().String(experienceDescriptionKey, "", "The description of the experience")
+	createExperienceCmd.Flags().String(experienceDescriptionKey, "", "[Required] The description of the experience")
 	createExperienceCmd.MarkFlagRequired(experienceDescriptionKey)
-	createExperienceCmd.Flags().String(experienceLocationKey, "", "The location of the experience, e.g. an S3 URI for the experience folder")
+	createExperienceCmd.Flags().String(experienceLocationKey, "", "[Required] The location of the experience, e.g. an S3 URI for the experience folder")
 	createExperienceCmd.MarkFlagRequired(experienceLocationKey)
-	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "Whether to output format in github action friendly format")
+	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "[Optional] Whether to output format in github action friendly format")
+  fmt.Print(createExperienceCmd.UsageTemplate())
+  createExperienceCmd.SetUsageFunc(ResimUsage)
 	experienceCmd.AddCommand(createExperienceCmd)
 	rootCmd.AddCommand(experienceCmd)
 }

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -47,8 +47,6 @@ func init() {
 	createExperienceCmd.Flags().String(experienceLocationKey, "", "[Required] The location of the experience, e.g. an S3 URI for the experience folder")
 	createExperienceCmd.MarkFlagRequired(experienceLocationKey)
 	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "[Optional] Whether to output format in github action friendly format")
-  fmt.Print(createExperienceCmd.UsageTemplate())
-  createExperienceCmd.SetUsageFunc(ResimUsage)
 	experienceCmd.AddCommand(createExperienceCmd)
 	rootCmd.AddCommand(experienceCmd)
 }

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -1,31 +1,74 @@
+// Enables applying custom ReSim styling to help and usage text.
+//
+// Cobra provides two methods for doing this:
+// 1. Using cobra.Command.SetUsageFunc() allows an arbitrary function to be
+// provided to produce the command usage help text. This is powerful, but
+// also requires the author of the function to implement all functionality.
+// 2. Using cobra.Command.SetUsageTemplate() allows the existing text template
+// for usage to be modified or replaced. This gives the author control over the
+// contents of usage message and takes advantage of all the built in cobra 
+// functionality for generating the data in the text template. Further, text
+// templates are quite powerful because they can be used to execute arbitrary 
+// functions, including user defined functions. That may be added using:
+// cobra.AddTemplateFunc("key", UserFunction). Therefore we follow this approach
+// here in defining ReSim's custom styling.
+//
+// In this file, first the ReSimUsageTemplate is defined. Below this any
+// custom template functions are defined. Finally a styling helper:
+// ApplyReSimStyle is defined. Style templates are inherited by child commands
+// so this function need only be applied once to the root command (rootCmd).
+
 package commands
 
 import (
-	"fmt"
-	"strings"
 	"text/template"
-	"unicode"
 
 	"github.com/spf13/cobra"
+	"github.com/fatih/color"
 )
 
-func trimRightSpace(s string) string {
-	return strings.TrimRightFunc(s, unicode.IsSpace)
-}
+var ReSimUsageTemplate string = 
+`{{StyleHeading "USAGE"}}{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+{{StyleHeading "ALIASES"}}
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+{{StyleHeading "EXAMPLES"}}
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+{{StyleHeading "AVAILABLE COMMANDS"}}{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+{{StyleHeading "ADDITIONAL COMMANDS"}}{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+{{StyleHeading "FLAGS"}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+{{StyleHeading "GLOBAL FLAGS"}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+{{StyleHeading "ADDITIONAL HELP TOPICS"}}
+{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
 
 var templateFuncs = template.FuncMap{
-	"trimTrailingWhitespaces": trimRightSpace,
-	"gt":                      cobra.Gt,
-	"eq":                      cobra.Eq,
+  "StyleHeading": color.New(color.Bold).SprintFunc(),
 }
 
-func ResimUsage(c *cobra.Command) error {
-  fmt.Println("testing 123")
-//  t := template.New("top")
-//  t.Funcs(templateFuncs)
-//  template.Must(t.Parse(c.UsageTemplate()))
-//  err := t.Execute(c.OutOrStderr(), c)
-//  c.PrintErrln(err);
-//  return err
-  return nil
+func styleHeading(s string) string {
+    return color.New(color.Bold).SprintFunc()(s)
+}
+
+func ApplyReSimStyle(cmd *cobra.Command) {
+  cobra.AddTemplateFuncs(templateFuncs) 
+  cmd.SetUsageTemplate(ReSimUsageTemplate)
 }

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+	"unicode"
+
+	"github.com/spf13/cobra"
+)
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+var templateFuncs = template.FuncMap{
+	"trimTrailingWhitespaces": trimRightSpace,
+	"gt":                      cobra.Gt,
+	"eq":                      cobra.Eq,
+}
+
+func ResimUsage(c *cobra.Command) error {
+  fmt.Println("testing 123")
+//  t := template.New("top")
+//  t.Funcs(templateFuncs)
+//  template.Must(t.Parse(c.UsageTemplate()))
+//  err := t.Execute(c.OutOrStderr(), c)
+//  c.PrintErrln(err);
+//  return err
+  return nil
+}

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -60,7 +60,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 `
 
 var templateFuncs = template.FuncMap{
-	"StyleHeading": color.New(color.Bold).SprintFunc(),
+	"StyleHeading": styleHeading,
 }
 
 func styleHeading(s string) string {

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -6,9 +6,9 @@
 // also requires the author of the function to implement all functionality.
 // 2. Using cobra.Command.SetUsageTemplate() allows the existing text template
 // for usage to be modified or replaced. This gives the author control over the
-// contents of usage message and takes advantage of all the built in cobra 
+// contents of usage message and takes advantage of all the built in cobra
 // functionality for generating the data in the text template. Further, text
-// templates are quite powerful because they can be used to execute arbitrary 
+// templates are quite powerful because they can be used to execute arbitrary
 // functions, including user defined functions. That may be added using:
 // cobra.AddTemplateFunc("key", UserFunction). Therefore we follow this approach
 // here in defining ReSim's custom styling.
@@ -23,12 +23,11 @@ package commands
 import (
 	"text/template"
 
-	"github.com/spf13/cobra"
 	"github.com/fatih/color"
+	"github.com/spf13/cobra"
 )
 
-var ReSimUsageTemplate string = 
-`{{StyleHeading "USAGE"}}{{if .Runnable}}
+var ReSimUsageTemplate string = `{{StyleHeading "USAGE"}}{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
@@ -61,14 +60,14 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 `
 
 var templateFuncs = template.FuncMap{
-  "StyleHeading": color.New(color.Bold).SprintFunc(),
+	"StyleHeading": color.New(color.Bold).SprintFunc(),
 }
 
 func styleHeading(s string) string {
-    return color.New(color.Bold).SprintFunc()(s)
+	return color.New(color.Bold).SprintFunc()(s)
 }
 
 func ApplyReSimStyle(cmd *cobra.Command) {
-  cobra.AddTemplateFuncs(templateFuncs) 
-  cmd.SetUsageTemplate(ReSimUsageTemplate)
+	cobra.AddTemplateFuncs(templateFuncs)
+	cmd.SetUsageTemplate(ReSimUsageTemplate)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/deepmap/oapi-codegen v1.13.4
+	github.com/fatih/color v1.13.0
 	github.com/google/uuid v1.3.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
@@ -208,6 +210,9 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=


### PR DESCRIPTION
This PR sets us up to be able customize the style of help, usage and error 
messages. The effect of the PR is *almost* a noop on current behavior. It
makes a very small change to the styling of section headings in usage
messages (see images below), in order to demonstrate the functionality. 

The main aim of the PR is to set us up with the ability to make greater 
customization in the future. For example, the next PR (#45 ) will aim to 
separate Flags into required and optional sections per a customer request.

Old:
![image](https://github.com/resim-ai/api-client/assets/1348072/4714d634-1729-40d6-9e84-937f7f17a0bf)
New:
![image](https://github.com/resim-ai/api-client/assets/1348072/a550212a-fcac-47b8-8cc6-4d0f7941e9b0)

[Asana task](https://app.asana.com/0/1205228215063249/1205227572053881/f)
## Guide to reproduce test results
run any `resim` command with `--help` and verify the new heading styling.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.