### PR TITLE
Separating required and optional flags in help messages

### DIFF
--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -49,7 +49,7 @@ var ReSimUsageTemplate string = `{{StyleHeading "USAGE"}}{{if .Runnable}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
 {{StyleHeading "ADDITIONAL COMMANDS"}}{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}{{FlagUsageBuilder .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}{{FlagSetUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 {{StyleHeading "GLOBAL FLAGS"}}
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
@@ -75,8 +75,8 @@ var flagTemplateFuncs = template.FuncMap{
 }
 
 var resimTemplateFuncs = template.FuncMap{
-	"StyleHeading":     styleHeading,
-	"FlagUsageBuilder": flagUsageBuilder,
+	"StyleHeading":  styleHeading,
+	"FlagSetUsages": flagSetUsages,
 }
 
 var BashCompOneRequiredFlag string = "cobra_annotation_bash_completion_one_required_flag"
@@ -125,7 +125,7 @@ func flagTemplateWriter(w io.Writer, data interface{}) error {
 	return tmpl.Execute(w, data)
 }
 
-func flagUsageBuilder(flags *pflag.FlagSet) string {
+func flagSetUsages(flags *pflag.FlagSet) string {
 	allFlags := flagSetsBuilder(flags)
 	var doc bytes.Buffer
 	flagTemplateWriter(&doc, &allFlags)

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -79,7 +79,11 @@ var resimTemplateFuncs = template.FuncMap{
 	"FlagSetUsages": flagSetUsages,
 }
 
-var BashCompOneRequiredFlag string = "cobra_annotation_bash_completion_one_required_flag"
+// Cobra flags do not have a dedicated data member to indicate whether they
+// are required. However they do have a catch-all "annotations" map as a data
+// member. This rather verbose string is the key used to indicate that a flag
+// is required in the annotations map.
+const bashCompOneRequiredFlag string = "cobra_annotation_bash_completion_one_required_flag"
 
 type FlagSets struct {
 	requiredFlags pflag.FlagSet
@@ -105,9 +109,10 @@ func (fs FlagSets) OptionalUsages() string {
 func flagSetsBuilder(flags *pflag.FlagSet) FlagSets {
 	var allFlags FlagSets
 	flags.VisitAll(func(flag *pflag.Flag) {
-		requiredAnnotation, found := flag.Annotations[BashCompOneRequiredFlag]
+		requiredAnnotation, found := flag.Annotations[bashCompOneRequiredFlag]
 		if !found {
 			allFlags.optionalFlags.AddFlag(flag)
+			// TODO(https://app.asana.com/0/1205272835002601/1205380178885154/f)
 			return
 		}
 		if requiredAnnotation[0] == "true" {

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -21,11 +21,11 @@
 package commands
 
 import (
-  "bytes"
-  "io"
-  "strings"
+	"bytes"
+	"io"
+	"strings"
 	"text/template"
-  "unicode"
+	"unicode"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -71,35 +71,35 @@ var FlagSetUsageTemplate string = `{{if .HasRequired}}
 `
 
 var flagTemplateFuncs = template.FuncMap{
-	"StyleHeading":        styleHeading,
+	"StyleHeading": styleHeading,
 }
 
 var resimTemplateFuncs = template.FuncMap{
-	"StyleHeading":        styleHeading,
-  "FlagUsageBuilder": flagUsageBuilder,
+	"StyleHeading":     styleHeading,
+	"FlagUsageBuilder": flagUsageBuilder,
 }
 
 var BashCompOneRequiredFlag string = "cobra_annotation_bash_completion_one_required_flag"
 
 type FlagSets struct {
-  requiredFlags pflag.FlagSet
-  optionalFlags pflag.FlagSet
+	requiredFlags pflag.FlagSet
+	optionalFlags pflag.FlagSet
 }
 
 func (fs FlagSets) HasRequired() bool {
-  return fs.requiredFlags.HasFlags()
+	return fs.requiredFlags.HasFlags()
 }
 
 func (fs FlagSets) RequiredUsages() string {
-  return strings.TrimRightFunc(fs.requiredFlags.FlagUsages(), unicode.IsSpace)
+	return strings.TrimRightFunc(fs.requiredFlags.FlagUsages(), unicode.IsSpace)
 }
 
 func (fs FlagSets) HasOptional() bool {
-  return fs.optionalFlags.HasFlags()
+	return fs.optionalFlags.HasFlags()
 }
 
 func (fs FlagSets) OptionalUsages() string {
-  return strings.TrimRightFunc(fs.optionalFlags.FlagUsages(), unicode.IsSpace)
+	return strings.TrimRightFunc(fs.optionalFlags.FlagUsages(), unicode.IsSpace)
 }
 
 func flagSetsBuilder(flags *pflag.FlagSet) FlagSets {
@@ -107,29 +107,29 @@ func flagSetsBuilder(flags *pflag.FlagSet) FlagSets {
 	flags.VisitAll(func(flag *pflag.Flag) {
 		requiredAnnotation, found := flag.Annotations[BashCompOneRequiredFlag]
 		if !found {
-      allFlags.optionalFlags.AddFlag(flag)
+			allFlags.optionalFlags.AddFlag(flag)
 			return
 		}
 		if requiredAnnotation[0] == "true" {
 			allFlags.requiredFlags.AddFlag(flag)
 		} else {
-      allFlags.optionalFlags.AddFlag(flag)
-    }
+			allFlags.optionalFlags.AddFlag(flag)
+		}
 	})
-  return allFlags
+	return allFlags
 }
 
 func flagTemplateWriter(w io.Writer, data interface{}) error {
-  tmpl := template.New("flags").Funcs(flagTemplateFuncs)
+	tmpl := template.New("flags").Funcs(flagTemplateFuncs)
 	template.Must(tmpl.Parse(FlagSetUsageTemplate))
 	return tmpl.Execute(w, data)
 }
 
 func flagUsageBuilder(flags *pflag.FlagSet) string {
-  allFlags := flagSetsBuilder(flags)
-  var doc bytes.Buffer
-  flagTemplateWriter(&doc, &allFlags)
-  return doc.String()
+	allFlags := flagSetsBuilder(flags)
+	var doc bytes.Buffer
+	flagTemplateWriter(&doc, &allFlags)
+	return doc.String()
 }
 
 func styleHeading(s string) string {

--- a/cmd/resim/commands/styling.go
+++ b/cmd/resim/commands/styling.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+  "github.com/spf13/pflag"
 )
 
 var ReSimUsageTemplate string = `{{StyleHeading "USAGE"}}{{if .Runnable}}
@@ -65,6 +66,10 @@ var templateFuncs = template.FuncMap{
 
 func styleHeading(s string) string {
 	return color.New(color.Bold).SprintFunc()(s)
+}
+
+func filterFlagsRequired(flags *pflag.FlagSet) string {
+  return "A test message"
 }
 
 func ApplyReSimStyle(cmd *cobra.Command) {

--- a/cmd/resim/commands/styling_test.go
+++ b/cmd/resim/commands/styling_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var headingRequired string = "REQUIRED"
-var headingOptional string = "OPTIONAL"
+const headingRequired string = "REQUIRED"
+const headingOptional string = "OPTIONAL"
 
 func helperTestCommand() cobra.Command {
 	var testCmd = cobra.Command{
@@ -79,18 +79,18 @@ func TestRequiredFlags(t *testing.T) {
 
 func TestBothFlags(t *testing.T) {
 	// SETUP
-	identifier_o := "Easy to find description for optional"
-	identifier_r := "Easy to find description for required"
+	identifierO := "Easy to find description for optional"
+	identifierR := "Easy to find description for required"
 	testCmd := helperTestCommand()
-	testCmd.Flags().String("optionalflag", "o", identifier_o)
-	testCmd.Flags().String("requiredflag", "r", identifier_r)
+	testCmd.Flags().String("optionalflag", "o", identifierO)
+	testCmd.Flags().String("requiredflag", "r", identifierR)
 	testCmd.MarkFlagRequired("requiredflag")
 	usageMsg := testCmd.UsageString()
 	// VERIFICATION
-	if !strings.Contains(usageMsg, identifier_o) {
+	if !strings.Contains(usageMsg, identifierO) {
 		t.Fail()
 	}
-	if !strings.Contains(usageMsg, identifier_r) {
+	if !strings.Contains(usageMsg, identifierR) {
 		t.Fail()
 	}
 	if !strings.Contains(usageMsg, headingRequired) {

--- a/cmd/resim/commands/styling_test.go
+++ b/cmd/resim/commands/styling_test.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+var headingRequired string = "REQUIRED"
+var headingOptional string = "OPTIONAL"
+
+func helperTestCommand() cobra.Command {
+	var testCmd = cobra.Command{
+		Use:           "resim",
+		Short:         "resim - Command Line Interface for ReSim",
+		Long:          ``,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	ApplyReSimStyle(&testCmd)
+	return testCmd
+}
+
+func TestNoFlags(t *testing.T) {
+	// SETUP
+	testCmd := helperTestCommand()
+	usageMsg := testCmd.UsageString()
+	// VERIFICATION
+	// Contains "Usage"
+	if !strings.Contains(usageMsg, "USAGE") {
+		t.Fail()
+	}
+	// Contains no flag headings
+	if strings.Contains(usageMsg, headingRequired) {
+		t.Fail()
+	}
+	if strings.Contains(usageMsg, headingOptional) {
+		t.Fail()
+	}
+}
+
+func TestOptionalFlags(t *testing.T) {
+	// SETUP
+	identifier := "Easy to find description for optional"
+	testCmd := helperTestCommand()
+	testCmd.Flags().String("optionalflag", "o", identifier)
+	usageMsg := testCmd.UsageString()
+	// VERIFICATION
+	if !strings.Contains(usageMsg, identifier) {
+		t.Fail()
+	}
+	if strings.Contains(usageMsg, headingRequired) {
+		t.Fail()
+	}
+	if !strings.Contains(usageMsg, headingOptional) {
+		t.Fail()
+	}
+}
+
+func TestRequiredFlags(t *testing.T) {
+	// SETUP
+	identifier := "Easy to find description for required"
+	testCmd := helperTestCommand()
+	testCmd.Flags().String("requiredflag", "r", identifier)
+	testCmd.MarkFlagRequired("requiredflag")
+	usageMsg := testCmd.UsageString()
+	// VERIFICATION
+	if !strings.Contains(usageMsg, identifier) {
+		t.Fail()
+	}
+	if !strings.Contains(usageMsg, headingRequired) {
+		t.Fail()
+	}
+	if strings.Contains(usageMsg, headingOptional) {
+		t.Fail()
+	}
+}
+
+func TestBothFlags(t *testing.T) {
+	// SETUP
+	identifier_o := "Easy to find description for optional"
+	identifier_r := "Easy to find description for required"
+	testCmd := helperTestCommand()
+	testCmd.Flags().String("optionalflag", "o", identifier_o)
+	testCmd.Flags().String("requiredflag", "r", identifier_r)
+	testCmd.MarkFlagRequired("requiredflag")
+	usageMsg := testCmd.UsageString()
+	// VERIFICATION
+	if !strings.Contains(usageMsg, identifier_o) {
+		t.Fail()
+	}
+	if !strings.Contains(usageMsg, identifier_r) {
+		t.Fail()
+	}
+	if !strings.Contains(usageMsg, headingRequired) {
+		t.Fail()
+	}
+	if !strings.Contains(usageMsg, headingOptional) {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Per user request we are styling the help messages such that required and optional flags 
are in separate sections. Here is an example from `resim experiences create`
```
USAGE
  resim experiences create [flags]

REQUIRED FLAGS
      --description string   The description of the experience
      --location string      The location of the experience, e.g. an S3 URI for the experience folder
      --name string          The name of the experience

OPTIONAL FLAGS
      --github   Whether to output format in github action friendly format
  -h, --help     help for create
``` 
If there are no required flags or no optional flags then the sections are omitted.
Here is an example from `resim --help`
```
AVAILABLE COMMANDS
  batches     batches contains commands for creating and managing batches
  branches    branches contains commands for creating and managing branches
  builds      builds contains commands for creating and managing builds
  completion  Generate the autocompletion script for the specified shell
  experiences experiences contains commands for creating and managing experiences
  help        Help about any command
  logs        logs contains commands for creating and listing test logs. This is not expected to be used directly by users, but via CI/CD systems.
  projects    projects contains commands for creating and managing projects

OPTIONAL FLAGS
      --auth-url string        The URL of the authentication endpoint.
      --client-id string       Authentication credentials client ID
      --client-secret string   Authentication credentials client secret
  -h, --help                   help for resim
      --url string             The URL of the API.

```
[Asana task](https://app.asana.com/0/1205272835002601/1205358727558476/fl)
run any resim command with --help and verify the new styling.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.