### PR TITLE
CLI Orders Lists by Timestamp as Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # resim CLI Changelog
 
+### Changed
+
+- Any list commands will now, by default, order by recency, listing newest items first
+
 ## [v0.1.21] 2023-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # resim CLI Changelog
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # resim CLI Changelog
 
+## Unreleased
+
 ### Changed
 
 - Any list commands will now, by default, order by recency, listing newest items first

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
+	. "github.com/resim-ai/api-client/ptr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -179,6 +180,7 @@ func getBatch(ccmd *cobra.Command, args []string) {
 		for {
 			response, err := Client.ListBatchesWithResponse(context.Background(), &api.ListBatchesParams{
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 			if err != nil {
 				log.Fatal("unable to list batches:", err)
@@ -247,7 +249,9 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 	pageLoop:
 		for {
 			response, err := Client.ListBatchesWithResponse(context.Background(), &api.ListBatchesParams{
+				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 			if err != nil {
 				log.Fatal("unable to list batches:", err)
@@ -279,6 +283,7 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 	var pageToken *string = nil
 	for {
 		response, err := Client.ListJobsWithResponse(context.Background(), batchID, &api.ListJobsParams{
+			PageSize:  Ptr(100),
 			PageToken: pageToken,
 		})
 		if err != nil {

--- a/cmd/resim/commands/branch.go
+++ b/cmd/resim/commands/branch.go
@@ -74,6 +74,7 @@ func listBranches(ccmd *cobra.Command, args []string) {
 			context.Background(), projectID, &api.ListBranchesForProjectParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("failed to list branches:", err)
@@ -147,6 +148,7 @@ pageLoop:
 			context.Background(), projectID, &api.ListBranchesForProjectParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("failed to list branches:", err)

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -89,6 +89,7 @@ func listBuilds(ccmd *cobra.Command, args []string) {
 			context.Background(), projectID, branchID, &api.ListBuildsForBranchParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("failed to list builds:", err)

--- a/cmd/resim/commands/experience_tags.go
+++ b/cmd/resim/commands/experience_tags.go
@@ -38,6 +38,7 @@ pageLoop:
 			context.Background(), &api.ListExperienceTagsParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("unable to list experience tags:", err)

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -96,6 +96,7 @@ func listProjects(ccmd *cobra.Command, args []string) {
 			context.Background(), &api.ListProjectsParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("failed to list projects:", err)
@@ -231,6 +232,7 @@ pageLoop:
 			context.Background(), &api.ListProjectsParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("failed to list projects:", err)


### PR DESCRIPTION
# Description of change

The CLI orders lists of projects, branches, builds, batches by timestamp.

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.