### PR TITLE
batch create supports new flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 ### Unreleased
 
+### v0.1.23 - September 29 2023
+
+#### Added
+
+- The `experiences` command now has:
+  - `tag` and `untag` subcommands for tagging and untagging experiences
+  - A `list` subcommand for listing experiences
+
+- There is a new `experience-tags` command with the following subcommands:
+  - `create`
+  - `list-experiences` for listing the experiences with a given tag
+
+#### Changed
+
+- The `batch create` subcommand now supports specifying experiences and experience tags by name or ID, using the new `--experiences` and `--experience-tags` flags. (The existing flags are still supported.)
+
 ### v0.1.22 - September 19 2023
 
 #### Added

--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -157,7 +157,7 @@ type Experience struct {
 	Description       *string            `json:"description,omitempty"`
 	ExperienceID      *ExperienceID      `json:"experienceID,omitempty"`
 	Location          *string            `json:"location,omitempty"`
-	Name              *string            `json:"name,omitempty"`
+	Name              *ExperienceName    `json:"name,omitempty"`
 	OrgID             *OrgID             `json:"orgID,omitempty"`
 	UserID            *UserID            `json:"userID,omitempty"`
 }
@@ -165,18 +165,24 @@ type Experience struct {
 // ExperienceID defines model for experienceID.
 type ExperienceID = openapi_types.UUID
 
+// ExperienceName defines model for experienceName.
+type ExperienceName = string
+
 // ExperienceTag defines model for experienceTag.
 type ExperienceTag struct {
 	CreationTimestamp *CreationTimestamp `json:"creationTimestamp,omitempty"`
 	Description       *string            `json:"description,omitempty"`
 	ExperienceTagID   *ExperienceTagID   `json:"experienceTagID,omitempty"`
-	Name              *string            `json:"name,omitempty"`
+	Name              *ExperienceTagName `json:"name,omitempty"`
 	OrgID             *OrgID             `json:"orgID,omitempty"`
 	UserID            *UserID            `json:"userID,omitempty"`
 }
 
 // ExperienceTagID defines model for experienceTagID.
 type ExperienceTagID = openapi_types.UUID
+
+// ExperienceTagName defines model for experienceTagName.
+type ExperienceTagName = string
 
 // FileName defines model for fileName.
 type FileName = string
@@ -395,10 +401,12 @@ type ListBatchesParams struct {
 
 // CreateBatchJSONBody defines parameters for CreateBatch.
 type CreateBatchJSONBody struct {
-	BuildID          *BuildID           `json:"buildID,omitempty"`
-	ExperienceIDs    *[]ExperienceID    `json:"experienceIDs"`
-	ExperienceTagIDs *[]ExperienceTagID `json:"experienceTagIDs"`
-	MetricsBuildID   *MetricsBuildID    `json:"metricsBuildID,omitempty"`
+	BuildID            *BuildID             `json:"buildID,omitempty"`
+	ExperienceIDs      *[]ExperienceID      `json:"experienceIDs"`
+	ExperienceNames    *[]ExperienceName    `json:"experienceNames"`
+	ExperienceTagIDs   *[]ExperienceTagID   `json:"experienceTagIDs"`
+	ExperienceTagNames *[]ExperienceTagName `json:"experienceTagNames"`
+	MetricsBuildID     *MetricsBuildID      `json:"metricsBuildID,omitempty"`
 }
 
 // ListJobsParams defines parameters for ListJobs.

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -49,8 +49,10 @@ var (
 const (
 	buildIDKey            = "build-id"
 	experienceIDsKey      = "experience-ids"
+	experiencesKey        = "experiences"
 	experienceTagIDsKey   = "experience-tag-ids"
 	experienceTagNamesKey = "experience-tag-names"
+	experienceTagsKey     = "experience-tags"
 	batchIDKey            = "batch-id"
 	batchNameKey          = "batch-name"
 	batchGithubKey        = "github"
@@ -64,8 +66,11 @@ func init() {
 	createBatchCmd.MarkFlagRequired(buildIDKey)
 	createBatchCmd.Flags().String(batchMetricsBuildKey, "", "The ID of the metrics build to use in this batch.")
 	createBatchCmd.Flags().String(experienceIDsKey, "", "Comma-separated list of experience ids to run.")
+	createBatchCmd.Flags().String(experiencesKey, "", "List of experience names or list of experience IDs to run, comma-separated")
+	// these separate ID and name flags are kept for backwards compatibility
 	createBatchCmd.Flags().String(experienceTagIDsKey, "", "Comma-separated list of experience tag ids to run.")
 	createBatchCmd.Flags().String(experienceTagNamesKey, "", "Comma-separated list of experience tag names to run.")
+	createBatchCmd.Flags().String(experienceTagsKey, "", "List of experience tag names or list of experience tag IDs to run, comma-separated.")
 	// TODO(simon) We want at least one of the above flags. The function we want
 	// is: .MarkFlagsOneRequired this was merged into Cobra recently:
 	// https://github.com/spf13/cobra/pull/1952 - but we need to wait for a stable
@@ -92,12 +97,16 @@ func createBatch(ccmd *cobra.Command, args []string) {
 		fmt.Println("Creating a batch...")
 	}
 
-	// Parse the UUIDs from the command line
+	// Parse the build ID
 	buildID, err := uuid.Parse(viper.GetString(buildIDKey))
 	if err != nil || buildID == uuid.Nil {
 		log.Fatal("failed to parse build ID: ", err)
 	}
-	experienceIDs := parseUUIDs(viper.GetString(experienceIDsKey))
+
+	// Parse the experiences key into 2 slices
+	experienceIDs, experienceNames := parseUUIDsAndNames(viper.GetString(experiencesKey))
+
+	experienceTagIDs, experienceTagNames := parseUUIDsAndNames(viper.GetString(experienceTagsKey))
 
 	metricsBuildID := uuid.Nil
 	if viper.IsSet(batchMetricsBuildKey) {
@@ -107,36 +116,41 @@ func createBatch(ccmd *cobra.Command, args []string) {
 		}
 	}
 
-	if !viper.IsSet(experienceIDsKey) && !viper.IsSet(experienceTagIDsKey) && !viper.IsSet(experienceTagNamesKey) {
+	if !viper.IsSet(experienceIDsKey) && !viper.IsSet(experienceTagIDsKey) && !viper.IsSet(experienceTagNamesKey) && !viper.IsSet(experiencesKey) && !viper.IsSet(experienceTagsKey) {
 		log.Fatal("failed to create batch: you must choose at least one experience or experience tag to run")
 	}
 
 	if viper.IsSet(experienceTagIDsKey) && viper.IsSet(experienceTagNamesKey) {
 		log.Fatal(fmt.Sprintf("failed to create batch: %v and %v are mutually exclusive parameters", experienceTagNamesKey, experienceTagIDsKey))
 	}
-
-	// Obtain experience tag ids.
-	var experienceTagIDs []uuid.UUID
-	// If the user passes IDs directly, parse them:
-	if viper.GetString(experienceTagIDsKey) != "" {
-		experienceTagIDs = parseUUIDs(viper.GetString(experienceTagIDsKey))
-	}
-	// If the user passes names, grab the ids:
-	if viper.GetString(experienceTagNamesKey) != "" {
-		experienceTagIDs = parseExperienceTagNames(Client, viper.GetString(experienceTagNamesKey))
-	}
-
-	// Build the request body and make the request
+	// Build the request body
 	body := api.CreateBatchJSONRequestBody{
 		BuildID:          &buildID,
 		ExperienceIDs:    &experienceIDs,
 		ExperienceTagIDs: &experienceTagIDs,
 	}
 
+	if experienceIDs != nil {
+		body.ExperienceIDs = &experienceIDs
+	}
+
+	if experienceNames != nil {
+		body.ExperienceNames = &experienceNames
+	}
+
+	if experienceTagIDs != nil {
+		body.ExperienceTagIDs = &experienceTagIDs
+	}
+
+	if experienceTagNames != nil {
+		body.ExperienceTagNames = &experienceTagNames
+	}
+
 	if metricsBuildID != uuid.Nil {
 		body.MetricsBuildID = &metricsBuildID
 	}
 
+	// Make the request
 	response, err := Client.CreateBatchWithResponse(context.Background(), body)
 	if err != nil {
 		log.Fatal("failed to create batch:", err)

--- a/cmd/resim/commands/uuid.go
+++ b/cmd/resim/commands/uuid.go
@@ -25,3 +25,26 @@ func parseUUIDs(commaSeparatedUUIDs string) []uuid.UUID {
 	}
 	return result
 }
+
+func parseUUIDsAndNames(commaSeparatedInput string) ([]uuid.UUID, []string) {
+	if commaSeparatedInput == "" {
+		return []uuid.UUID{}, []string{}
+	}
+
+	resultUUIDs := make([]uuid.UUID, 0)
+	resultStrings := make([]string, 0)
+
+	strs := strings.Split(commaSeparatedInput, ",")
+
+	for i := 0; i < len(strs); i++ {
+		str := strings.TrimSpace(strs[i])
+		v, err := uuid.Parse(str)
+		if err == nil {
+			resultUUIDs = append(resultUUIDs, v)
+		} else {
+			resultStrings = append(resultStrings, str)
+		}
+	}
+
+	return resultUUIDs, resultStrings
+}

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -497,7 +497,9 @@ func (s *EndToEndTestSuite) createExperience(name string, description string, lo
 	return []CommandBuilder{experienceCommand, createCommand}
 }
 
-func (s *EndToEndTestSuite) createBatch(buildID string, experienceIDs []string, experienceTagIDs []string, experienceTagNames []string, metricsBuildID string, github bool) []CommandBuilder {
+func (s *EndToEndTestSuite) createExperienceTag(name string, description string)
+
+func (s *EndToEndTestSuite) createBatch(buildID string, experienceIDs []string, experienceTagIDs []string, experienceTagNames []string, experiences []string, experienceTags []string, metricsBuildID string, github bool) []CommandBuilder {
 	// We build a create batch command with the build-id, experience-ids, experience-tag-ids, and experience-tag-names flags
 	// We do not require any specific combination of these flags, and validate in tests that the CLI only allows one of TagIDs or TagNames
 	// and that at least one of the experiences flags is provided.
@@ -533,6 +535,20 @@ func (s *EndToEndTestSuite) createBatch(buildID string, experienceIDs []string, 
 		createCommand.Flags = append(createCommand.Flags, Flag{
 			Name:  "--experience-tag-names",
 			Value: experienceTags,
+		})
+	}
+	if len(experiences) > 0 {
+		experiencesString := strings.Join(experiences, ",")
+		createCommand.Flags = append(createCommand.Flags, Flag{
+			Name:  "--experiences",
+			Value: experiencesString,
+		})
+	}
+	if len(experienceTags) > 0 {
+		experienceTagsString := strings.Join(experienceTags, ",")
+		createCommand.Flags = append(createCommand.Flags, Flag{
+			Name:  "--experience-tags",
+			Value: experienceTagsString,
 		})
 	}
 	if len(metricsBuildID) > 0 {
@@ -1045,14 +1061,32 @@ func (s *EndToEndTestSuite) TestBatchAndLogs() {
 	metricsBuildIDString := output.StdOut[len(GithubCreatedMetricsBuild) : len(output.StdOut)-1]
 	metricsBuildID := uuid.MustParse(metricsBuildIDString)
 
-	// Create a batch without metrics with the github flag set and check the output
-	output = s.runCommand(s.createBatch(buildIDString, []string{experienceIDString1, experienceIDString2}, []string{}, []string{}, "", GithubTrue), ExpectNoError)
+	// Create a batch with (only) experience names using the --experiences flag
+	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, []string{experienceName1, experienceName2}, []string{}, "", GithubTrue), ExpectNoError)
 	s.Contains(output.StdOut, GithubCreatedBatch)
 	batchIDStringGH := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
 	uuid.MustParse(batchIDStringGH)
 
+	// Create a batch with mixed experience names and IDs in the --experiences flag
+	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, []string{experienceName1, experienceIDString2}, []string{}, "", GithubTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedBatch)
+	batchIDStringGH = output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
+	uuid.MustParse(batchIDStringGH)
+
+	// // Create a batch with mixed IDs in the --experiences flag and a tag name in the --experiences flag
+	// output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, []string{}, []string{}, "", GithubTrue), ExpectNoError)
+	// s.Contains(output.StdOut, GithubCreatedBatch)
+	// batchIDStringGH = output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
+	// uuid.MustParse(batchIDStringGH)
+
+	// Create a batch without metrics with the github flag set and check the output
+	output = s.runCommand(s.createBatch(buildIDString, []string{experienceIDString1, experienceIDString2}, []string{}, []string{}, []string{}, []string{}, "", GithubTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedBatch)
+	batchIDStringGH = output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
+	uuid.MustParse(batchIDStringGH)
+
 	// Now create a batch without the github flag, but with metrics
-	output = s.runCommand(s.createBatch(buildIDString, []string{experienceIDString1, experienceIDString2}, []string{}, []string{}, metricsBuildIDString, GithubFalse), ExpectNoError)
+	output = s.runCommand(s.createBatch(buildIDString, []string{experienceIDString1, experienceIDString2}, []string{}, []string{}, []string{}, []string{}, metricsBuildIDString, GithubFalse), ExpectNoError)
 	s.Contains(output.StdOut, CreatedBatch)
 	s.Empty(output.StdErr)
 
@@ -1071,13 +1105,13 @@ func (s *EndToEndTestSuite) TestBatchAndLogs() {
 	batchNameParts := strings.Split(batchNameString, "-")
 	s.Equal(3, len(batchNameParts))
 	// Try a batch without any experiences:
-	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, "", GithubFalse), ExpectError)
+	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, []string{}, []string{}, "", GithubFalse), ExpectError)
 	s.Contains(output.StdErr, FailedToCreateBatch)
 	// Try a batch without a build id:
-	output = s.runCommand(s.createBatch("", []string{experienceIDString1, experienceIDString2}, []string{}, []string{}, "", GithubFalse), ExpectError)
+	output = s.runCommand(s.createBatch("", []string{experienceIDString1, experienceIDString2}, []string{}, []string{}, []string{}, []string{}, "", GithubFalse), ExpectError)
 	s.Contains(output.StdErr, InvalidBuildID)
 	// Try a batch with both experience tag ids and experience tag names (even if fake):
-	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{"tag-id"}, []string{"tag-name"}, "", GithubFalse), ExpectError)
+	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{"tag-id"}, []string{"tag-name"}, []string{}, []string{}, "", GithubFalse), ExpectError)
 	s.Contains(output.StdErr, BranchTagMutuallyExclusive)
 
 	// Get batch passing the status flag. We need to manually execute and grab the exit code:


### PR DESCRIPTION
# Description of change

Adds new flags for `batch create` and adds commands to work with `experience-tags`

## Guide to reproduce test results



## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.