### PR TITLE
check the cached token is valid before we try to reuse/cache it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.1.28 - November 30 2023
+
+#### Changed
+- Fixed a bug in the handling of invalid/expired cached tokens.
+
 ### v0.1.27 - November 29 2023
 
 #### Added

--- a/cmd/resim/commands/client.go
+++ b/cmd/resim/commands/client.go
@@ -91,7 +91,8 @@ func GetClient(ctx context.Context) (*api.ClientWithResponses, *CredentialCache,
 		}
 
 		cache.ClientID = clientID
-		if token, ok := cache.Tokens[clientID]; ok {
+		token, ok := cache.Tokens[clientID]
+		if ok && token.Valid() {
 			cache.TokenSource = config.TokenSource(ctx, &token)
 		} else {
 			response, err := config.DeviceAuth(ctx, oauth2.SetAuthURLParam("audience", "https://api.resim.ai"))
@@ -165,7 +166,9 @@ func (c *CredentialCache) SaveCredentialCache() {
 	if err != nil {
 		log.Println("error getting token:", err)
 	}
-	c.Tokens[c.ClientID] = *token
+	if token != nil {
+		c.Tokens[c.ClientID] = *token
+	}
 
 	data, err := json.Marshal(c.Tokens)
 	if err != nil {


### PR DESCRIPTION
# Description of change

With an expired token in my cache.json, I was getting:
```
./resim sweeps list
2023/11/29 10:20:11 error getting token: oauth2: "invalid_grant" "Unknown or invalid refresh token."
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104886160]

goroutine 1 [running]:
github.com/resim-ai/api-client/cmd/resim/commands.(*CredentialCache).SaveCredentialCache(0x1400040d6b0)
	/Users/ben/resim-ai/api-client/cmd/resim/commands/client.go:168 +0xb0
github.com/resim-ai/api-client/cmd/resim/commands.RegisterViperFlagsAndSetClient(0x14000420400?, {0x10488fc42?, 0x4?, 0x10488fbda?})
	/Users/ben/resim-ai/api-client/cmd/resim/commands/commands.go:86 +0x200
github.com/spf13/cobra.(*Command).execute(0x104dcb8e0, {0x104e09380, 0x0, 0x0})
	/Users/ben/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:929 +0x5dc
github.com/spf13/cobra.(*Command).ExecuteC(0x104dc73e0)
	/Users/ben/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/ben/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/resim-ai/api-client/cmd/resim/commands.Execute()
	/Users/ben/resim-ai/api-client/cmd/resim/commands/commands.go:56 +0x118
main.main()
	/Users/ben/resim-ai/api-client/cmd/resim/cli.go:19 +0x14c
```

Adding the check for token.Valid() causes me to be prompted if the token is expired, as expected:

```
cp ~/.resim/bad-cache.json ~/.resim/cache.json
./resim sweeps list
If your browser hasn't opened automatically, please open
https://resim.us.auth0.com/activate?user_code=...
```

## Guide to reproduce test results

Have an invalid/expired token in your cache.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.