### PR TITLE
Creating Batches with Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.1.29 - November 30 2023
+
+#### Added
+
+- Introduces the ability to specify build parameters when creating batches.
+
 ### v0.1.28 - November 30 2023
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes in this section will be included in the next release.
 
 #### Added
 
-- Introduces the ability to specify build parameters when creating batches.
+- Introduces the ability to specify build parameters when creating batches. For example: `batch create ... --parameter "param1:foo","param2:bar"`. This will pass a `parameters.json` file upon test execution, just as with sweeps.
 
 ### v0.1.28 - November 30 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,14 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 ### Unreleased
 
 Changes in this section will be included in the next release.
-#### Changed
-
-- The CLI validates image URIs when builds and metrics builds are created.
-
-### v0.1.29 - November 30 2023
 
 #### Added
 
 - Introduces the ability to specify build parameters when creating batches. For example: `batch create ... --parameter "param1:foo","param2:bar"`. This will pass a `parameters.json` file upon test execution, just as with sweeps.
+
+#### Changed
+
+- The CLI validates image URIs when builds and metrics builds are created.
 
 ### v0.1.28 - November 30 2023
 

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -654,12 +654,6 @@ func (s *EndToEndTestSuite) createBatch(buildID string, experienceIDs []string, 
 			Value: metricsBuildID,
 		})
 	}
-	if len(metricsBuildID) > 0 {
-		createCommand.Flags = append(createCommand.Flags, Flag{
-			Name:  "--metrics-build-id",
-			Value: metricsBuildID,
-		})
-	}
 	if len(parameters) > 0 {
 		for key, value := range parameters {
 			createCommand.Flags = append(createCommand.Flags, Flag{

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -1566,7 +1566,7 @@ func (s *EndToEndTestSuite) TestParameterizedBatch() {
 	metricsBuildID := uuid.MustParse(metricsBuildIDString)
 
 	// Create a batch with (only) experience names using the --experiences flag with some parameters
-	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, []string{experienceName}, []string{}, "", GithubTrue, expectedParameterMap), ExpectNoError)
+	output = s.runCommand(s.createBatch(buildIDString, []string{}, []string{}, []string{}, []string{experienceName}, []string{}, metricsBuildIDString, GithubTrue, expectedParameterMap), ExpectNoError)
 	s.Contains(output.StdOut, GithubCreatedBatch)
 	batchIDStringGH := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
 	batchID := uuid.MustParse(batchIDStringGH)


### PR DESCRIPTION
# Description of change

Introduces an additional, optional (repeated) flag for specifying parameters to pass to a build when creating a batch. This enables a parameter override without having to create a sweep.

## Guide to reproduce test results

```CONFIG=staging go test -v -tags end_to_end -count 1 ./testing -testify.m TestParameterizedBatch```

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.