### PR TITLE
Properly Report Error Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Changes in this section will be included in the next release.
 - Introduces the ability to specify build parameters when creating batches. For example: `batch create ... --parameter "param1:foo","param2:bar"`. This will pass a `parameters.json` file upon test execution, just as with sweeps.
 - The `experience create` command now returns a list of files found in the storage location to help with validation.
 
+#### Changed
+- Fixed a bug in the reporting of error messages from commands.
+
+
 ### v0.1.29 - December 21 2023
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Changes in this section will be included in the next release.
 #### Changed
 - Fixed a bug in the reporting of error messages from commands.
 
-
 ### v0.1.29 - December 21 2023
 
 #### Changed

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -207,7 +207,7 @@ func createBatch(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("failed to create batch:", err)
 	}
-	ValidateResponse(http.StatusCreated, "failed to create batch", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "failed to create batch", response.HTTPResponse, response.Body)
 
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
@@ -251,7 +251,7 @@ func getBatch(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("unable to retrieve batch:", err)
 		}
-		ValidateResponse(http.StatusOK, "unable to retrieve batch", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "unable to retrieve batch", response.HTTPResponse, response.Body)
 		batch = response.JSON200
 	} else if viper.IsSet(batchNameKey) {
 		batchName := viper.GetString(batchNameKey)
@@ -265,7 +265,7 @@ func getBatch(ccmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatal("unable to list batches:", err)
 			}
-			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse)
+			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse, response.Body)
 			if response.JSON200.Batches == nil {
 				log.Fatal("unable to find batch: ", batchName)
 			}
@@ -336,7 +336,7 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatal("unable to list batches:", err)
 			}
-			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse)
+			ValidateResponse(http.StatusOK, "unable to list batches", response.HTTPResponse, response.Body)
 			if response.JSON200.Batches == nil {
 				log.Fatal("unable to find batch: ", batchName)
 			}
@@ -369,7 +369,7 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("unable to list jobs:", err)
 		}
-		ValidateResponse(http.StatusOK, "unable to list jobs", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "unable to list jobs", response.HTTPResponse, response.Body)
 		if response.JSON200.Jobs == nil {
 			log.Fatal("unable to list jobs")
 		}

--- a/cmd/resim/commands/branch.go
+++ b/cmd/resim/commands/branch.go
@@ -79,7 +79,7 @@ func listBranches(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list branches:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list branches", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list branches", response.HTTPResponse, response.Body)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || response.JSON200.Branches == nil {
@@ -120,7 +120,7 @@ func createBranch(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("unable to create branch: ", err)
 	}
-	ValidateResponse(http.StatusCreated, "unable to create branch", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "unable to create branch", response.HTTPResponse, response.Body)
 	if response.JSON201 == nil {
 		log.Fatal("empty branch returned")
 	}
@@ -177,7 +177,7 @@ pageLoop:
 		if err != nil {
 			log.Fatal("failed to list branches:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list branches", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list branches", response.HTTPResponse, response.Body)
 		if response.JSON200 == nil {
 			log.Fatal("empty response")
 		}

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -96,7 +96,7 @@ func listBuilds(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list builds:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list builds", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list builds", response.HTTPResponse, response.Body)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || response.JSON200.Builds == nil {
@@ -161,7 +161,7 @@ func createBuild(ccmd *cobra.Command, args []string) {
 				log.Fatal("failed to create branch:", err)
 			}
 			ValidateResponse(http.StatusCreated, fmt.Sprintf("failed to create a new branch with name %v", branchName),
-				response.HTTPResponse)
+				response.HTTPResponse, response.Body)
 			branchID = *response.JSON201.BranchID
 			if !buildGithub {
 				fmt.Printf("Created branch with ID %v\n", branchID)
@@ -181,7 +181,7 @@ func createBuild(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("unable to create build:", err)
 	}
-	ValidateResponse(http.StatusCreated, "unable to create build", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "unable to create build", response.HTTPResponse, response.Body)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -128,7 +128,7 @@ func createExperience(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("failed to create experience: ", err)
 	}
-	ValidateResponse(http.StatusCreated, "failed to create experience", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "failed to create experience", response.HTTPResponse, response.Body)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}
@@ -161,7 +161,7 @@ func listExperiences(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list experiences:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list experiences", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list experiences", response.HTTPResponse, response.Body)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || len(*response.JSON200.Experiences) == 0 {
@@ -200,7 +200,7 @@ func tagExperience(ccmd *cobra.Command, args []string) {
 	if response.HTTPResponse.StatusCode == 409 {
 		log.Fatal("failed to tag experience, it may already be tagged ", experienceTagName)
 	}
-	ValidateResponse(http.StatusCreated, "failed to tag experience", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "failed to tag experience", response.HTTPResponse, response.Body)
 }
 
 func untagExperience(ccmd *cobra.Command, args []string) {
@@ -226,5 +226,5 @@ func untagExperience(ccmd *cobra.Command, args []string) {
 	if response.HTTPResponse.StatusCode == 404 {
 		log.Fatal("failed to untag experience, it may not be tagged ", experienceTagName)
 	}
-	ValidateResponse(http.StatusNoContent, "failed to untag experience", response.HTTPResponse)
+	ValidateResponse(http.StatusNoContent, "failed to untag experience", response.HTTPResponse, response.Body)
 }

--- a/cmd/resim/commands/experience_tags.go
+++ b/cmd/resim/commands/experience_tags.go
@@ -86,7 +86,7 @@ func createExperienceTag(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("failed to create experience tag: ", err)
 	}
-	ValidateResponse(http.StatusCreated, "failed to create experience tag", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "failed to create experience tag", response.HTTPResponse, response.Body)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}
@@ -112,7 +112,7 @@ func listExperienceTags(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list experience tags: ", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list experience tags", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list experience tags", response.HTTPResponse, response.Body)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || len(*response.JSON200.ExperienceTags) == 0 {
@@ -149,7 +149,7 @@ func listExperiencesWithTag(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list experiences: ", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list experiences", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list experiences", response.HTTPResponse, response.Body)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || len(*response.JSON200.Experiences) == 0 {
@@ -196,7 +196,7 @@ pageLoop:
 		if err != nil {
 			log.Fatal("unable to list experience tags:", err)
 		}
-		ValidateResponse(http.StatusOK, "unable to list experience tags", listResponse.HTTPResponse)
+		ValidateResponse(http.StatusOK, "unable to list experience tags", listResponse.HTTPResponse, listResponse.Body)
 		if listResponse.JSON200 == nil {
 			log.Fatal("empty response")
 		}

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -113,21 +113,21 @@ func createLog(ccmd *cobra.Command, args []string) {
 		log.Fatal("unable to get batch: ", err)
 	}
 	ValidateResponse(http.StatusOK, fmt.Sprintf("unable to find batch with ID %v", logBatchID),
-		batchResponse.HTTPResponse)
+		batchResponse.HTTPResponse, batchResponse.Body)
 
 	jobResponse, err := Client.GetJobWithResponse(context.Background(), logBatchID, logJobID)
 	if err != nil {
 		log.Fatal("unable to get job: ", err)
 	}
 	ValidateResponse(http.StatusOK, fmt.Sprintf("unable to find job with ID %v", logJobID),
-		jobResponse.HTTPResponse)
+		jobResponse.HTTPResponse, jobResponse.Body)
 
 	// Create the log entry
 	logResponse, err := Client.CreateLogWithResponse(context.Background(), logBatchID, logJobID, body)
 	if err != nil {
 		log.Fatal("unable to create log: ", err)
 	}
-	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse, logResponse.Body)
 	if logResponse.JSON201 == nil {
 		log.Fatal("empty response")
 	}
@@ -171,7 +171,7 @@ func listLogs(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("unable to list logs: ", err)
 		}
-		ValidateResponse(http.StatusOK, "unable to list logs", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "unable to list logs", response.HTTPResponse, response.Body)
 		if response.JSON200.Logs == nil {
 			log.Fatal("unable to list logs")
 		}

--- a/cmd/resim/commands/metrics_build.go
+++ b/cmd/resim/commands/metrics_build.go
@@ -71,7 +71,7 @@ func listMetricsBuilds(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list metrics builds:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list metrics builds", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list metrics builds", response.HTTPResponse, response.Body)
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || response.JSON200.MetricsBuilds == nil {
@@ -123,7 +123,7 @@ func createMetricsBuild(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("unable to create metrics build:", err)
 	}
-	ValidateResponse(http.StatusCreated, "unable to create metrics build", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "unable to create metrics build", response.HTTPResponse, response.Body)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -101,7 +101,7 @@ func listProjects(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list projects:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list projects", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list projects", response.HTTPResponse, response.Body)
 		if response.JSON200 == nil {
 			log.Fatal("empty response")
 		}
@@ -147,7 +147,7 @@ func createProject(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ValidateResponse(http.StatusCreated, "failed to create project", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "failed to create project", response.HTTPResponse, response.Body)
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
 	}
@@ -176,7 +176,7 @@ func getProject(ccmd *cobra.Command, args []string) {
 		if response.HTTPResponse.StatusCode == http.StatusNotFound {
 			log.Fatal("failed to find project with requested id: ", projectID.String())
 		} else {
-			ValidateResponse(http.StatusOK, "unable to retrieve project", response.HTTPResponse)
+			ValidateResponse(http.StatusOK, "unable to retrieve project", response.HTTPResponse, response.Body)
 		}
 		project = response.JSON200
 	} else {
@@ -202,7 +202,7 @@ func deleteProject(ccmd *cobra.Command, args []string) {
 	if response.HTTPResponse.StatusCode == http.StatusNotFound {
 		log.Fatal("failed to delete project. No project exists with requested id: ", projectID.String())
 	} else {
-		ValidateResponse(http.StatusNoContent, "unable to delete project", response.HTTPResponse)
+		ValidateResponse(http.StatusNoContent, "unable to delete project", response.HTTPResponse, response.Body)
 	}
 	fmt.Println("Deleted project successfully!")
 }
@@ -238,7 +238,7 @@ pageLoop:
 		if err != nil {
 			log.Fatal("failed to list projects:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list projects", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list projects", response.HTTPResponse, response.Body)
 		if response.JSON200 == nil {
 			log.Fatal("empty response")
 		}

--- a/cmd/resim/commands/sweep.go
+++ b/cmd/resim/commands/sweep.go
@@ -204,7 +204,7 @@ func createSweep(ccmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("failed to create sweep:", err)
 	}
-	ValidateResponse(http.StatusCreated, "failed to create sweep", response.HTTPResponse)
+	ValidateResponse(http.StatusCreated, "failed to create sweep", response.HTTPResponse, response.Body)
 
 	if response.JSON201 == nil {
 		log.Fatal("empty response")
@@ -245,7 +245,7 @@ func getSweep(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("unable to retrieve sweep:", err)
 		}
-		ValidateResponse(http.StatusOK, "unable to retrieve sweep", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "unable to retrieve sweep", response.HTTPResponse, response.Body)
 		sweep = response.JSON200
 	} else if viper.IsSet(sweepNameKey) {
 		sweepName := viper.GetString(sweepNameKey)
@@ -259,7 +259,7 @@ func getSweep(ccmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatal("unable to list sweeps:", err)
 			}
-			ValidateResponse(http.StatusOK, "unable to list sweeps", response.HTTPResponse)
+			ValidateResponse(http.StatusOK, "unable to list sweeps", response.HTTPResponse, response.Body)
 			if response.JSON200.Sweeps == nil {
 				log.Fatal("unable to find sweep: ", sweepName)
 			}
@@ -321,7 +321,7 @@ func listSweeps(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("failed to list parameter sweeps:", err)
 		}
-		ValidateResponse(http.StatusOK, "failed to list parameter sweeps", response.HTTPResponse)
+		ValidateResponse(http.StatusOK, "failed to list parameter sweeps", response.HTTPResponse, response.Body)
 		if response.JSON200 == nil {
 			log.Fatal("empty response")
 		}


### PR DESCRIPTION
# Description of change

There was a bug in the previous versions of the CLI: any response errors were lost because the steam had already been read by the middleware. This meant when we tried to read again there was always an error "body closed". This change captures the error message and passes it through to validation steps.

## Guide to reproduce test results

N/A

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.