### PR TITLE
validate experience locations on experience creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes in this section will be included in the next release.
 #### Added
 
 - Introduces the ability to specify build parameters when creating batches. For example: `batch create ... --parameter "param1:foo","param2:bar"`. This will pass a `parameters.json` file upon test execution, just as with sweeps.
+- The `experience create` command now returns a list of files found in the storage location to help with validation.
 
 ### v0.1.29 - December 21 2023
 

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -137,12 +137,33 @@ func createExperience(ccmd *cobra.Command, args []string) {
 		log.Fatal("no experience ID")
 	}
 
+	validationResponse, err := Client.ValidateExperienceLocationWithResponse(context.Background(), api.ExperienceLocation{
+		Location: experience.Location,
+	})
+	if err != nil {
+		log.Fatal("could not validate experience after creation", err)
+	}
+
+	var objectsInExperience *[]string
+	var objectsCount *int
+
+	if validationResponse.JSON200 != nil {
+		objectsInExperience = validationResponse.JSON200.Objects
+		objectsCount = validationResponse.JSON200.ObjectCount
+	}
+
 	// Report the results back to the user
 	if experienceGithub {
 		fmt.Printf("experience_id=%s\n", experience.ExperienceID.String())
 	} else {
 		fmt.Println("Created experience successfully!")
 		fmt.Printf("Experience ID: %s\n", experience.ExperienceID.String())
+		if objectsCount != nil && *objectsCount > 0 {
+			fmt.Printf("ReSim found %v file(s) in experience location:\n", *objectsCount)
+			OutputJson(*objectsInExperience)
+		} else {
+			fmt.Println("WARNING: ReSim could not find any files in the provided location.")
+		}
 	}
 }
 


### PR DESCRIPTION
# Description of change


```
➜  api-client git:(ben/experience-validation) ✗ ./resim --url https://dev-env-pr-527.api.dev.resim.io/v1/ --auth-url https://resim-dev.us.auth0.com/ experience create --description 'testig vlaidation' --name "delete-me-again-12" --location 's3://dev-dev-env-pr-527-e2e/'
Creating an experience...
Created experience successfully!
Experience ID: 61bce4ab-924d-4362-8241-95ad5235ff2c
ReSim found 3 file(s) in experience location:
[
  "experiences/914a1708-5682-4895-b0e3-f37d2abdb1af/ben.jpg",
  "experiences/914a1708-5682-4895-b0e3-f37d2abdb1af/thing/woosh.jpeg",
  "test-object/file.name"
]
➜  api-client git:(ben/experience-validation) ✗ ./resim --url https://dev-env-pr-527.api.dev.resim.io/v1/ --auth-url https://resim-dev.us.auth0.com/ experience create --description 'testig vlaidation' --name "delete-me-again-13" --location 's3://dev-dev-env-pr-527-e2e/foo/'
Creating an experience...
Created experience successfully!
Experience ID: f49407c5-e705-408c-95a8-8db283449722
WARNING: ReSim could not find any files in the provided location.
```
Not to be released until the endpoint is available in prod. Not sure how to cover this with the e2e test without uploading stuff to s3

https://app.asana.com/0/1203294986954613/1206312758338186/f

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.