### PR TITLE
Use viper config file; allow persistence of project setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ Changes in this section will be included in the next release.
 
 #### Added
 
-- Allowed the ability to persist project selection with `select project --project foo". If set via this method, `--project` will no longer be a required flag for other commands.
+- Allowed the ability to persist project selection with `select project foo`. If set via this method, `--project` will no longer be a required flag for other commands.
 
 #### Changed
 
-- `projects list` will list projects by name. A * will denote the active project, if set.
+- `project list` will list projects by name. A * will denote the active project, if set.
 
 ### v0.1.30 - February 08 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+#### Added
+
+- Allowed the ability to persist project selection with `select project --project foo". If set via this method, `--project` will no longer be a required flag for other commands.
+
+#### Changed
+
+- `projects list` will list projects by name. A * will denote the active project, if set.
+
 ### v0.1.30 - February 08 2024
 
 #### Added

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -24,26 +24,23 @@ var (
 		Aliases: []string{"batch"},
 	}
 	createBatchCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new batch",
-		Long:   ``,
-		Run:    createBatch,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new batch",
+		Long:  ``,
+		Run:   createBatch,
 	}
 	getBatchCmd = &cobra.Command{
-		Use:    "get",
-		Short:  "get - Retrieves a batch",
-		Long:   ``,
-		Run:    getBatch,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "get",
+		Short: "get - Retrieves a batch",
+		Long:  ``,
+		Run:   getBatch,
 	}
 
 	jobsBatchCmd = &cobra.Command{
-		Use:    "jobs",
-		Short:  "jobs - Lists the jobs in a batch",
-		Long:   ``,
-		Run:    jobsBatch,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "jobs",
+		Short: "jobs - Lists the jobs in a batch",
+		Long:  ``,
+		Run:   jobsBatch,
 	}
 )
 

--- a/cmd/resim/commands/branch.go
+++ b/cmd/resim/commands/branch.go
@@ -21,18 +21,16 @@ var (
 		Aliases: []string{"branch"},
 	}
 	createBranchCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new branch",
-		Long:   ``,
-		Run:    createBranch,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new branch",
+		Long:  ``,
+		Run:   createBranch,
 	}
 	listBranchesCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - List branches for a project",
-		Long:   ``,
-		Run:    listBranches,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - List branches for a project",
+		Long:  ``,
+		Run:   listBranches,
 	}
 )
 

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -22,18 +22,16 @@ var (
 		Aliases: []string{"build"},
 	}
 	createBuildCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new build",
-		Long:   ``,
-		Run:    createBuild,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new build",
+		Long:  ``,
+		Run:   createBuild,
 	}
 	listBuildsCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - Lists existing builds",
-		Long:   ``,
-		Run:    listBuilds,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - Lists existing builds",
+		Long:  ``,
+		Run:   listBuilds,
 	}
 )
 

--- a/cmd/resim/commands/client.go
+++ b/cmd/resim/commands/client.go
@@ -175,16 +175,11 @@ func (c *CredentialCache) SaveCredentialCache() {
 		return
 	}
 
-	homedir, _ := os.UserHomeDir()
-	expectedDir := strings.ReplaceAll(ConfigPath, "$HOME", homedir)
-	// Check first if the directory exists, and if it does not, create it:
-	if _, err := os.Stat(expectedDir); os.IsNotExist(err) {
-		err := os.Mkdir(expectedDir, 0700)
-		if err != nil {
-			log.Println("error creating directory:", err)
-			return
-		}
+	expectedDir, err := GetConfigDir()
+	if err != nil {
+		return
 	}
+
 	path := filepath.Join(expectedDir, CredentialCacheFilename)
 	err = os.WriteFile(path, data, 0600)
 	if err != nil {

--- a/cmd/resim/commands/commands_test.go
+++ b/cmd/resim/commands/commands_test.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func sampleCommand() cobra.Command {
+	var testCmd = cobra.Command{
+		Use:           "resim",
+		Short:         "resim - Command Line Interface for ReSim",
+		Long:          ``,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PreRun:        RegisterViperFlagsAndSetClient,
+	}
+	return testCmd
+}
+
+func writeStubConfig(params map[string]interface{}) string {
+	// Writes a viper config to a temporary directory and returns the path
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "resim-")
+	os.MkdirAll(filepath.Join(tempDir, ".resim"), os.ModePerm)
+	os.Setenv("HOME", tempDir)
+	v := viper.New()
+	v.MergeConfigMap(params)
+	v.WriteConfigAs(os.ExpandEnv(ConfigPath) + "/resim.json")
+	return tempDir
+}
+
+func TestRequiredFlagNotProvided(t *testing.T) {
+	assert := assert.New(t)
+	var configParams = make(map[string]interface{})
+	configDir := writeStubConfig(configParams)
+	defer os.RemoveAll(configDir)
+	os.Setenv("HOME", configDir)
+	// SETUP
+	testCmd := sampleCommand()
+	testCmd.Flags().String("requiredFlag", "", "a required flag")
+	testCmd.Flags().String("notRequiredFlag", "", "a not required flag")
+	testCmd.MarkFlagRequired("requiredFlag")
+	var args = []string{}
+	RegisterViperFlags(&testCmd, args)
+	// TEST
+	assert.Equal(testCmd.Flag("requiredFlag").Annotations[cobra.BashCompOneRequiredFlag], []string{"true"})
+	assert.Equal(testCmd.Flag("notRequiredFlag").Annotations[cobra.BashCompOneRequiredFlag], []string(nil))
+}
+
+func TestRequiredFlagProvided(t *testing.T) {
+	assert := assert.New(t)
+	var configParams = make(map[string]interface{})
+	configParams["requiredFlag"] = "my saved value"
+	configDir := writeStubConfig(configParams)
+	defer os.RemoveAll(configDir)
+	os.Setenv("HOME", configDir)
+	fmt.Println("vipers:", viper.AllKeys())
+	fmt.Println("this: ", viper.GetString("requiredFlag"))
+	// SETUP
+	testCmd := sampleCommand()
+	testCmd.Flags().String("requiredFlag", "", "a required flag")
+	testCmd.Flags().String("notRequiredFlag", "", "a not required flag")
+	testCmd.MarkFlagRequired("requiredFlag")
+	RegisterViperFlags(&testCmd, []string{})
+	// TEST
+	// Note there is an implementation difference (but no behavioural difference) between a flag that was never set to required (nil) and one that was turned off.
+	assert.Equal(testCmd.Flag("requiredFlag").Annotations[cobra.BashCompOneRequiredFlag], []string{"false"})
+	assert.Equal(testCmd.Flag("notRequiredFlag").Annotations[cobra.BashCompOneRequiredFlag], []string(nil))
+}

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -21,32 +21,28 @@ var (
 		Aliases: []string{"experience"},
 	}
 	createExperienceCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new experience",
-		Long:   ``,
-		Run:    createExperience,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new experience",
+		Long:  ``,
+		Run:   createExperience,
 	}
 	listExperiencesCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - Lists experiences",
-		Long:   ``,
-		Run:    listExperiences,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - Lists experiences",
+		Long:  ``,
+		Run:   listExperiences,
 	}
 	tagExperienceCmd = &cobra.Command{
-		Use:    "tag",
-		Short:  "tag - Add a tag to an experience",
-		Long:   ``,
-		Run:    tagExperience,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "tag",
+		Short: "tag - Add a tag to an experience",
+		Long:  ``,
+		Run:   tagExperience,
 	}
 	untagExperienceCmd = &cobra.Command{
-		Use:    "untag",
-		Short:  "untag - Remove a tag from an experience",
-		Long:   ``,
-		Run:    untagExperience,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "untag",
+		Short: "untag - Remove a tag from an experience",
+		Long:  ``,
+		Run:   untagExperience,
 	}
 )
 

--- a/cmd/resim/commands/experience_tags.go
+++ b/cmd/resim/commands/experience_tags.go
@@ -22,25 +22,22 @@ var (
 		Aliases: []string{"experience-tag"},
 	}
 	createExperienceTagCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new experience tag",
-		Long:   ``,
-		Run:    createExperienceTag,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new experience tag",
+		Long:  ``,
+		Run:   createExperienceTag,
 	}
 	listExperienceTagsCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - List experience tags",
-		Long:   ``,
-		Run:    listExperienceTags,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - List experience tags",
+		Long:  ``,
+		Run:   listExperienceTags,
 	}
 	listExperiencesWithTagCmd = &cobra.Command{
-		Use:    "list-experiences",
-		Short:  "list-experiences - Lists the experiences for a tag",
-		Long:   ``,
-		Run:    listExperiencesWithTag,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list-experiences",
+		Short: "list-experiences - Lists the experiences for a tag",
+		Long:  ``,
+		Run:   listExperiencesWithTag,
 	}
 )
 

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -21,18 +21,16 @@ var (
 		Aliases: []string{"log"},
 	}
 	createLogCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new log entry",
-		Long:   ``,
-		Run:    createLog,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new log entry",
+		Long:  ``,
+		Run:   createLog,
 	}
 	listLogsCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - Lists the logs for a batch",
-		Long:   ``,
-		Run:    listLogs,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - Lists the logs for a batch",
+		Long:  ``,
+		Run:   listLogs,
 	}
 )
 

--- a/cmd/resim/commands/metrics_build.go
+++ b/cmd/resim/commands/metrics_build.go
@@ -21,18 +21,16 @@ var (
 		Aliases: []string{"metricsBuild, metricsBuilds, metricBuild, metricBuilds, metrics-build, metric-build, metric-builds"},
 	}
 	createMetricsBuildCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new metrics build",
-		Long:   ``,
-		Run:    createMetricsBuild,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new metrics build",
+		Long:  ``,
+		Run:   createMetricsBuild,
 	}
 	listMetricsBuildsCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - Lists existing metrics builds",
-		Long:   ``,
-		Run:    listMetricsBuilds,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - Lists existing metrics builds",
+		Long:  ``,
+		Run:   listMetricsBuilds,
 	}
 )
 

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -24,35 +25,38 @@ var (
 		Aliases: []string{"project"},
 	}
 	createProjectCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new project",
-		Long:   ``,
-		Run:    createProject,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new project",
+		Long:  ``,
+		Run:   createProject,
 	}
 
 	getProjectCmd = &cobra.Command{
-		Use:    "get",
-		Short:  "get - Gets details about a project",
-		Long:   ``,
-		Run:    getProject,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "get",
+		Short: "get - Gets details about a project",
+		Long:  ``,
+		Run:   getProject,
 	}
 
 	deleteProjectCmd = &cobra.Command{
-		Use:    "delete",
-		Short:  "delete - Deletes a project",
-		Long:   ``,
-		Run:    deleteProject,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "delete",
+		Short: "delete - Deletes a project",
+		Long:  ``,
+		Run:   deleteProject,
 	}
 
 	listProjectsCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - Lists projects",
-		Long:   ``,
-		Run:    listProjects,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - Lists projects",
+		Long:  ``,
+		Run:   listProjects,
+	}
+
+	selectProjectCmd = &cobra.Command{
+		Use:   "select",
+		Short: "select - Selects default project",
+		Long:  ``,
+		Run:   selectProject,
 	}
 )
 
@@ -83,6 +87,11 @@ func init() {
 
 	projectCmd.AddCommand(listProjectsCmd)
 
+	selectProjectCmd.Flags().String(projectKey, "", "The name or the ID of the project")
+	selectProjectCmd.MarkFlagRequired(projectKey)
+	selectProjectCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
+	projectCmd.AddCommand(selectProjectCmd)
+
 	rootCmd.AddCommand(projectCmd)
 }
 
@@ -111,8 +120,51 @@ func listProjects(ccmd *cobra.Command, args []string) {
 			break
 		}
 	}
+	// This command does not have a project flag, so viper must be injecting it from the config
+	defaultProjectUuid, _ := uuid.Parse(viper.GetString(projectKey))
+	for _, project := range allProjects {
+		var isActive string = ""
+		if *project.ProjectID == defaultProjectUuid {
+			isActive = "*"
+		} else {
+			isActive = " "
+		}
+		fmt.Println(isActive, *project.Name)
+	}
+}
 
-	OutputJson(allProjects)
+func selectProject(ccmd *cobra.Command, args []string) {
+	var project *api.Project
+	if viper.IsSet(projectKey) {
+		projectID := getProjectID(Client, viper.GetString(projectKey))
+		response, err := Client.GetProjectWithResponse(context.Background(), projectID)
+		if err != nil {
+			log.Fatal("unable to retrieve project:", err)
+		}
+		if response.HTTPResponse.StatusCode == http.StatusNotFound {
+			log.Fatal("failed to find project with requested id: ", projectID.String())
+		} else {
+			ValidateResponse(http.StatusOK, "unable to retrieve project", response.HTTPResponse, response.Body)
+		}
+		project = response.JSON200
+	} else {
+		log.Fatal("must specify either the project ID or the project name")
+	}
+	// Open the config file as an independent Viper instance. This instance does not have all the flags set.
+	// Therefore we can safely save it again without adding any additional flags.
+	v := viper.New()
+	v.SetConfigName("resim")
+	v.SetConfigType("json")
+	v.AddConfigPath(os.ExpandEnv(ConfigPath))
+	if err := v.ReadInConfig(); err != nil {
+		switch err.(type) {
+		case viper.ConfigFileNotFoundError, *fs.PathError:
+		default:
+			log.Fatal(fmt.Errorf("error reading config file: %v %T", err, err))
+		}
+	}
+	v.Set("project", project.ProjectID)
+	v.WriteConfigAs(os.ExpandEnv(ConfigPath) + "/resim.json")
 }
 
 func createProject(ccmd *cobra.Command, args []string) {

--- a/cmd/resim/commands/sweep.go
+++ b/cmd/resim/commands/sweep.go
@@ -23,26 +23,23 @@ var (
 		Aliases: []string{"sweep"},
 	}
 	createSweepCmd = &cobra.Command{
-		Use:    "create",
-		Short:  "create - Creates a new parameter sweep",
-		Long:   ``,
-		Run:    createSweep,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "create",
+		Short: "create - Creates a new parameter sweep",
+		Long:  ``,
+		Run:   createSweep,
 	}
 	getSweepCmd = &cobra.Command{
-		Use:    "get",
-		Short:  "get - Retrieves a parameter sweep",
-		Long:   ``,
-		Run:    getSweep,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "get",
+		Short: "get - Retrieves a parameter sweep",
+		Long:  ``,
+		Run:   getSweep,
 	}
 
 	listSweepCmd = &cobra.Command{
-		Use:    "list",
-		Short:  "list - Lists all parameter sweeps",
-		Long:   ``,
-		Run:    listSweeps,
-		PreRun: RegisterViperFlagsAndSetClient,
+		Use:   "list",
+		Short: "list - Lists all parameter sweeps",
+		Long:  ``,
+		Run:   listSweeps,
 	}
 )
 


### PR DESCRIPTION
# Description of change

This hooks up the config file writing-and-reading side of Viper, which was already being used to manage flags.
When writing to the config, we first read it into a blank Viper instance, so that we can persist different sets of flags from different call sites into the same config, while not persisting every single flag every time.

Also: Some minor rearrangement of the config-initialization functions in the aid of testability.
Also also: Moved the `RegisterViperFlagsAndSetClient` init call to the root command, where it flows down by default into every sub command.

## Guide to reproduce test results

```
$ rm ~/.resim/resim.json
$ cli project list
[... list of projects ]
$ cli branches list
2024/02/28 21:57:19 required flag(s) "project" not set
$ cli project select --project resim-sandbox-project
$ cli branches list
[
  {
    "branchID": [..list of branches continues ...]
$ cli project list
[..list of projects, again ]
* resim-sandbox-project
```

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.