### PR TITLE
Add "batches wait" command that will continuously poll until a batch reaches a final state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes in this section will be included in the next release.
 #### Added
 
 - Allowed the ability to persist project selection with `select project foo`. If set via this method, `--project` will no longer be a required flag for other commands.
+- Added `batch wait` command that will continuously poll (default: 30s) until a batch reaches a final state (success, failure, cancelled, etc)
 
 #### Changed
 

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -88,9 +88,6 @@ func init() {
 
 	projectCmd.AddCommand(listProjectsCmd)
 
-	// selectProjectCmd.Flags().String(projectKey, "", "The name or the ID of the project")
-	// selectProjectCmd.MarkFlagRequired(projectKey)
-	// selectProjectCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
 	projectCmd.AddCommand(selectProjectCmd)
 
 	rootCmd.AddCommand(projectCmd)


### PR DESCRIPTION
# Description of change

The `batches wait` command will allow CI jobs to pause and wait for test completion before handling. The command lifts some concepts from the `batches get` command like the (optional, in `get`) status-based exit codes.

To keep interfaces clean it is a separate command, not new options to `get`, with the fetch code factored out.

## Guide to reproduce test results

```
$ resim batches wait --project-id/-name ... 
```

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.