### PR TITLE
Systems CLI support #2: System Create, Get, List

### DIFF
--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -218,8 +218,8 @@ func createBuild(ccmd *cobra.Command, args []string) {
 
 	// Check if the branch exists, by listing branches, returning uuid.Nil if branch not found:
 	branchName := viper.GetString(buildBranchKey)
-	branchID := getBranchID(Client, projectID, branchName, false)
-
+	branchID := getBranchID(Client, projectID, branchName, false) // we don't fail on error for branches, because we can autocreate
+	systemID := getSystemID(Client, projectID, viper.GetString(buildSystemKey), true)
 	if branchID == uuid.Nil {
 		if viper.GetBool(buildAutoCreateBranchKey) {
 			if !buildGithub {
@@ -250,6 +250,7 @@ func createBuild(ccmd *cobra.Command, args []string) {
 		Description: &buildDescription,
 		ImageUri:    &buildImageURI,
 		Version:     &buildVersion,
+		SystemID:    &systemID,
 	}
 
 	response, err := Client.CreateBuildForBranchWithResponse(context.Background(), projectID, branchID, body)

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -44,11 +44,26 @@ var (
 		Long:  ``,
 		Run:   untagExperience,
 	}
+
+	addSystemExperienceCmd = &cobra.Command{
+		Use:   "add-system",
+		Short: "add-system - Add a system as compatible with an experience",
+		Long:  ``,
+		Run:   addSystemToExperience,
+	}
+	removeSystemExperienceCmd = &cobra.Command{
+		Use:   "remove-system",
+		Short: "remove-system - Remove a system as compatible with an experience",
+		Long:  ``,
+		Run:   removeSystemFromExperience,
+	}
 )
 
 const (
 	experienceProjectKey       = "project"
+	experienceSystemKey        = "system"
 	experienceNameKey          = "name"
+	experienceKey              = "experience"
 	experienceIDKey            = "id"
 	experienceDescriptionKey   = "description"
 	experienceLocationKey      = "location"
@@ -70,9 +85,11 @@ func init() {
 	createExperienceCmd.Flags().MarkDeprecated(experienceLaunchProfileKey, "launch profiles are deprecated in favor of systems to define resource requirements")
 	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "Whether to output format in github action friendly format")
 	experienceCmd.AddCommand(createExperienceCmd)
+
 	listExperiencesCmd.Flags().String(experienceProjectKey, "", "The name or ID of the project to list the experiences within")
 	listExperiencesCmd.MarkFlagRequired(experienceProjectKey)
 	experienceCmd.AddCommand(listExperiencesCmd)
+	// Experience tag sub-commands:
 	tagExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
 	tagExperienceCmd.MarkFlagRequired(experienceProjectKey)
 	tagExperienceCmd.Flags().String(experienceTagKey, "", "The name of the tag to add")
@@ -80,6 +97,7 @@ func init() {
 	tagExperienceCmd.Flags().String(experienceIDKey, "", "The ID of the experience to tag")
 	tagExperienceCmd.MarkFlagRequired(experienceNameKey)
 	experienceCmd.AddCommand(tagExperienceCmd)
+
 	untagExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
 	untagExperienceCmd.MarkFlagRequired(experienceProjectKey)
 	untagExperienceCmd.Flags().String(experienceTagKey, "", "The name of the tag to remove")
@@ -87,6 +105,22 @@ func init() {
 	untagExperienceCmd.Flags().String(experienceIDKey, "", "The ID of the experience to untag")
 	untagExperienceCmd.MarkFlagRequired(experienceNameKey)
 	experienceCmd.AddCommand(untagExperienceCmd)
+	// Systems-related sub-commands:
+	addSystemExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
+	addSystemExperienceCmd.MarkFlagRequired(experienceProjectKey)
+	addSystemExperienceCmd.Flags().String(experienceSystemKey, "", "The name or ID of the system to add")
+	addSystemExperienceCmd.MarkFlagRequired(experienceSystemKey)
+	addSystemExperienceCmd.Flags().String(experienceKey, "", "The name or ID of the experience register as compatible with the system")
+	addSystemExperienceCmd.MarkFlagRequired(experienceKey)
+	experienceCmd.AddCommand(addSystemExperienceCmd)
+	removeSystemExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
+	removeSystemExperienceCmd.MarkFlagRequired(experienceProjectKey)
+	removeSystemExperienceCmd.Flags().String(experienceSystemKey, "", "The name or ID  of the system to remove")
+	removeSystemExperienceCmd.MarkFlagRequired(experienceSystemKey)
+	removeSystemExperienceCmd.Flags().String(experienceKey, "", "The name or ID of the experience to deregister as compatible with the system")
+	removeSystemExperienceCmd.MarkFlagRequired(experienceKey)
+	experienceCmd.AddCommand(removeSystemExperienceCmd)
+
 	rootCmd.AddCommand(experienceCmd)
 }
 
@@ -250,4 +284,122 @@ func untagExperience(ccmd *cobra.Command, args []string) {
 		log.Fatal("failed to untag experience, it may not be tagged ", experienceTagName)
 	}
 	ValidateResponse(http.StatusNoContent, "failed to untag experience", response.HTTPResponse, response.Body)
+}
+
+func addSystemToExperience(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(experienceProjectKey))
+
+	systemName := viper.GetString(experienceSystemKey)
+	if systemName == "" {
+		log.Fatal("empty system name")
+	}
+	systemID := getSystemID(Client, projectID, systemName, true)
+
+	if viper.GetString(experienceKey) == "" {
+		log.Fatal("empty experience name")
+	}
+	experienceID := getExperienceID(Client, projectID, viper.GetString(experienceKey), true)
+
+	response, err := Client.AddSystemToExperienceWithResponse(
+		context.Background(), projectID,
+		systemID,
+		experienceID,
+	)
+	if err != nil {
+		log.Fatal("failed to register experience with system", err)
+	}
+	if response.HTTPResponse.StatusCode == 409 {
+		log.Fatal("failed to register experience with system, it may already be registered ", systemName)
+	}
+	ValidateResponse(http.StatusCreated, "failed to register experience with system", response.HTTPResponse, response.Body)
+}
+
+func removeSystemFromExperience(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(experienceProjectKey))
+
+	systemName := viper.GetString(experienceSystemKey)
+	if systemName == "" {
+		log.Fatal("empty system name")
+	}
+	systemID := getSystemID(Client, projectID, systemName, true)
+	if viper.GetString(experienceKey) == "" {
+		log.Fatal("empty experience name")
+	}
+	experienceID := getExperienceID(Client, projectID, viper.GetString(experienceKey), true)
+
+	response, err := Client.RemoveSystemFromExperienceWithResponse(
+		context.Background(), projectID,
+		systemID,
+		experienceID,
+	)
+	if err != nil {
+		log.Fatal("failed to deregister experience with system", err)
+	}
+	if response.HTTPResponse.StatusCode == 409 {
+		log.Fatal("failed to deregister experience with system, it may not be registered ", systemName)
+	}
+	ValidateResponse(http.StatusNoContent, "failed to deregister experience with system", response.HTTPResponse, response.Body)
+}
+
+// TODO(https://app.asana.com/0/1205228215063249/1205227572053894/f): we should have first class support in API for this
+func checkExperienceID(client api.ClientWithResponsesInterface, projectID uuid.UUID, identifier string) uuid.UUID {
+	// Page through experiences until we find the one with either a name or an ID
+	// that matches the identifier string.
+	experienceID := uuid.Nil
+	// First try the assumption that identifier is a UUID.
+	err := uuid.Validate(identifier)
+	if err == nil {
+		// The identifier is a uuid - but does it refer to an existing experience?
+		potentialExperienceID := uuid.MustParse(identifier)
+		response, _ := client.GetExperienceWithResponse(context.Background(), projectID, potentialExperienceID)
+		if response.HTTPResponse.StatusCode == http.StatusOK {
+			// Experience found with ID
+			return potentialExperienceID
+		}
+	}
+	// If we're here then either the identifier is not a UUID or the UUID was not
+	// found. Users could choose to name experiences with UUIDs so regardless of how
+	// we got here we now search for identifier as a string name.
+	var pageToken *string = nil
+pageLoop:
+	for {
+		response, err := client.ListExperiencesWithResponse(
+			context.Background(), projectID, &api.ListExperiencesParams{
+				PageSize:  Ptr(100),
+				PageToken: pageToken,
+			})
+		if err != nil {
+			log.Fatal("failed to list experiences:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list experiences", response.HTTPResponse, response.Body)
+		if response.JSON200 == nil {
+			log.Fatal("empty response")
+		}
+		pageToken = response.JSON200.NextPageToken
+		experiences := *response.JSON200.Experiences
+		for _, experience := range experiences {
+			if experience.Name == nil {
+				log.Fatal("experience has no name")
+			}
+			if experience.ExperienceID == nil {
+				log.Fatal("experience ID is empty")
+			}
+			if *experience.Name == identifier {
+				experienceID = *experience.ExperienceID
+				break pageLoop
+			}
+		}
+		if pageToken == nil || *pageToken == "" {
+			break
+		}
+	}
+	return experienceID
+}
+
+func getExperienceID(client api.ClientWithResponsesInterface, projectID uuid.UUID, identifier string, failWhenNotFound bool) uuid.UUID {
+	experienceID := checkExperienceID(client, projectID, identifier)
+	if experienceID == uuid.Nil && failWhenNotFound {
+		log.Fatal("failed to find experience with name or ID: ", identifier)
+	}
+	return experienceID
 }

--- a/cmd/resim/commands/system.go
+++ b/cmd/resim/commands/system.go
@@ -2,13 +2,201 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
 	. "github.com/resim-ai/api-client/ptr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+var (
+	systemCmd = &cobra.Command{
+		Use:     "systems",
+		Short:   "systems contains commands for creating and managing systems",
+		Long:    ``,
+		Aliases: []string{"system"},
+	}
+	createSystemCmd = &cobra.Command{
+		Use:   "create",
+		Short: "create - Creates a new system",
+		Long:  ``,
+		Run:   createSystem,
+	}
+	getSystemCmd = &cobra.Command{
+		Use:   "get",
+		Short: "get - Return details of a system",
+		Long:  ``,
+		Run:   getSystem,
+	}
+	listSystemsCmd = &cobra.Command{
+		Use:   "list",
+		Short: "list - Lists existing systems",
+		Long:  ``,
+		Run:   listSystems,
+	}
+)
+
+const (
+	systemNameKey                       = "name"
+	systemDescriptionKey                = "description"
+	systemBuildVCPUsKey                 = "build-vcpus"
+	systemMetricsBuildVCPUsKey          = "metricsbuild-vcpus"
+	systemBuildGPUsKey                  = "build-gpus"
+	systemMetricsBuildGPUsKey           = "metrics-build-gpus"
+	systemBuildMemoryMiBKey             = "build-memory-mib"
+	systemMetricsBuildMemoryMibKey      = "metrics-build-memory-mib"
+	systemBuildSharedMemoryMBKey        = "build-shared-memory-mb"
+	systemMetricsBuildSharedMemoryMbKey = "metrics-shared-build-memory-mb"
+	systemProjectKey                    = "project"
+	systemKey                           = "system"
+	systemGithubKey                     = "github"
+	//Defaults:
+	DefaultCPUs           = 4
+	DefaultGPUs           = 0
+	DefaultMemoryMiB      = 16384
+	DefaultSharedMemoryMB = 64
+)
+
+func init() {
+	createSystemCmd.Flags().String(systemProjectKey, "", "The name or ID of the project to create the system in")
+	createSystemCmd.MarkFlagRequired(systemProjectKey)
+	createSystemCmd.Flags().String(systemNameKey, "", "The name of the system, unique per project")
+	createSystemCmd.MarkFlagRequired(systemNameKey)
+	createSystemCmd.Flags().String(systemDescriptionKey, "", "The description of the system")
+	createSystemCmd.MarkFlagRequired(systemDescriptionKey)
+	createSystemCmd.Flags().Int(systemBuildVCPUsKey, DefaultCPUs, "The number of vCPUs required to execute the build (default: 4)")
+	createSystemCmd.Flags().Int(systemMetricsBuildVCPUsKey, DefaultCPUs, "The number of vCPUs required to execute the metrics build (default: 4)")
+	createSystemCmd.Flags().Int(systemBuildGPUsKey, DefaultGPUs, "The number of GPUs required to execute the build (default: 0)")
+	createSystemCmd.Flags().Int(systemMetricsBuildGPUsKey, DefaultGPUs, "The number of GPUs required to execute the metrics build (default: 0)")
+	createSystemCmd.Flags().Int(systemBuildMemoryMiBKey, DefaultMemoryMiB, "The amount of memory in MiB required to execute the build (default: 16384)")
+	createSystemCmd.Flags().Int(systemMetricsBuildMemoryMibKey, DefaultMemoryMiB, "The amount of memory in MiB required to execute the metrics build (default: 16384)")
+	createSystemCmd.Flags().Int(systemBuildSharedMemoryMBKey, DefaultSharedMemoryMB, "The amount of shared memory in MB required to execute the build (default: 64)")
+	createSystemCmd.Flags().Int(systemMetricsBuildSharedMemoryMbKey, DefaultSharedMemoryMB, "The amount of shared memory in MB required to execute the metrics build (default: 64)")
+	createSystemCmd.Flags().Bool(systemGithubKey, false, "Whether to output format in github action friendly format")
+	createSystemCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
+
+	getSystemCmd.Flags().String(systemProjectKey, "", "Get system associated with this project")
+	getSystemCmd.MarkFlagRequired(systemProjectKey)
+	getSystemCmd.Flags().String(systemKey, "", "The name or ID of the system to get details for")
+	getSystemCmd.MarkFlagRequired(systemKey)
+
+	listSystemsCmd.Flags().String(systemProjectKey, "", "List systems associated with this project")
+	listSystemsCmd.MarkFlagRequired(systemProjectKey)
+
+	listSystemsCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
+
+	systemCmd.AddCommand(createSystemCmd)
+	systemCmd.AddCommand(getSystemCmd)
+	systemCmd.AddCommand(listSystemsCmd)
+	rootCmd.AddCommand(systemCmd)
+}
+
+func getSystem(ccmd *cobra.Command, args []string) {
+	var system *api.System
+	projectID := getProjectID(Client, viper.GetString(systemProjectKey))
+	systemID := getSystemID(Client, projectID, viper.GetString(systemKey), true)
+	response, err := Client.GetSystemWithResponse(context.Background(), projectID, systemID)
+	if err != nil {
+		log.Fatal("unable to retrieve system:", err)
+	}
+	if response.HTTPResponse.StatusCode == http.StatusNotFound {
+		log.Fatal("failed to find system with requested id: ", projectID.String())
+	} else {
+		ValidateResponse(http.StatusOK, "unable to retrieve system", response.HTTPResponse, response.Body)
+	}
+	system = response.JSON200
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", " ")
+	enc.Encode(system)
+}
+
+func listSystems(cmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(systemProjectKey))
+
+	var pageToken *string = nil
+
+	var allSystems []api.System
+
+	for {
+		response, err := Client.ListSystemsWithResponse(
+			context.Background(), projectID, &api.ListSystemsParams{
+				PageSize:  Ptr(100),
+				PageToken: pageToken,
+			})
+		if err != nil {
+			log.Fatal("failed to list systems:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list systems", response.HTTPResponse, response.Body)
+
+		pageToken = response.JSON200.NextPageToken
+		if response.JSON200 == nil || response.JSON200.Systems == nil {
+			log.Fatal("no systemes")
+		}
+		allSystems = append(allSystems, *response.JSON200.Systems...)
+		if pageToken == nil || *pageToken == "" {
+			break
+		}
+	}
+	OutputJson(allSystems)
+}
+
+func createSystem(cmd *cobra.Command, args []string) {
+	if !viper.GetBool(systemGithubKey) {
+		fmt.Println("Creating a system...")
+	}
+	// Parse the various arguments from command line
+	projectID := getProjectID(Client, viper.GetString(systemProjectKey))
+
+	systemName := viper.GetString(systemNameKey)
+	if systemName == "" {
+		log.Fatal("empty system name")
+	}
+
+	systemDescription := viper.GetString(systemDescriptionKey)
+	if systemDescription == "" {
+		log.Fatal("empty system description")
+	}
+
+	body := api.System{
+		Name:                       &systemName,
+		Description:                &systemDescription,
+		BuildGpus:                  Ptr(viper.GetInt(systemBuildGPUsKey)),
+		BuildVcpus:                 Ptr(viper.GetInt(systemBuildVCPUsKey)),
+		BuildMemoryMib:             Ptr(viper.GetInt(systemBuildMemoryMiBKey)),
+		BuildSharedMemoryMb:        Ptr(viper.GetInt(systemBuildSharedMemoryMBKey)),
+		MetricsBuildGpus:           Ptr(viper.GetInt(systemMetricsBuildGPUsKey)),
+		MetricsBuildMemoryMib:      Ptr(viper.GetInt(systemMetricsBuildMemoryMibKey)),
+		MetricsBuildSharedMemoryMb: Ptr(viper.GetInt(systemMetricsBuildSharedMemoryMbKey)),
+	}
+
+	response, err := Client.CreateSystemWithResponse(context.Background(), projectID, body)
+	if err != nil {
+		log.Fatal("unable to create system: ", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create system", response.HTTPResponse, response.Body)
+	if response.JSON201 == nil {
+		log.Fatal("empty system returned")
+	}
+	system := *response.JSON201
+	if system.SystemID == nil {
+		log.Fatal("no system ID")
+	}
+
+	// Report the results back to the user
+	if viper.GetBool(systemGithubKey) {
+		fmt.Printf("system_id=%s\n", system.SystemID.String())
+	} else {
+		fmt.Println("Created system successfully!")
+		fmt.Printf("System ID: %s\n", system.SystemID.String())
+	}
+}
 
 // TODO(https://app.asana.com/0/1205228215063249/1205227572053894/f): we should have first class support in API for this
 func checkSystemID(client api.ClientWithResponsesInterface, projectID uuid.UUID, identifier string) uuid.UUID {

--- a/cmd/resim/commands/system.go
+++ b/cmd/resim/commands/system.go
@@ -46,13 +46,13 @@ const (
 	systemNameKey                       = "name"
 	systemDescriptionKey                = "description"
 	systemBuildVCPUsKey                 = "build-vcpus"
-	systemMetricsBuildVCPUsKey          = "metricsbuild-vcpus"
+	systemMetricsBuildVCPUsKey          = "metrics-build-vcpus"
 	systemBuildGPUsKey                  = "build-gpus"
 	systemMetricsBuildGPUsKey           = "metrics-build-gpus"
 	systemBuildMemoryMiBKey             = "build-memory-mib"
 	systemMetricsBuildMemoryMibKey      = "metrics-build-memory-mib"
 	systemBuildSharedMemoryMBKey        = "build-shared-memory-mb"
-	systemMetricsBuildSharedMemoryMbKey = "metrics-shared-build-memory-mb"
+	systemMetricsBuildSharedMemoryMbKey = "metrics-build-shared-memory-mb"
 	systemProjectKey                    = "project"
 	systemKey                           = "system"
 	systemGithubKey                     = "github"
@@ -171,6 +171,7 @@ func createSystem(cmd *cobra.Command, args []string) {
 		BuildVcpus:                 Ptr(viper.GetInt(systemBuildVCPUsKey)),
 		BuildMemoryMib:             Ptr(viper.GetInt(systemBuildMemoryMiBKey)),
 		BuildSharedMemoryMb:        Ptr(viper.GetInt(systemBuildSharedMemoryMBKey)),
+		MetricsBuildVcpus:          Ptr(viper.GetInt(systemMetricsBuildVCPUsKey)),
 		MetricsBuildGpus:           Ptr(viper.GetInt(systemMetricsBuildGPUsKey)),
 		MetricsBuildMemoryMib:      Ptr(viper.GetInt(systemMetricsBuildMemoryMibKey)),
 		MetricsBuildSharedMemoryMb: Ptr(viper.GetInt(systemMetricsBuildSharedMemoryMbKey)),


### PR DESCRIPTION
# Description of change

PR 2 of 4 to introduce systems to the ReSim CLI. The intent is to squash all four of these PRs into one before landing.

In this PR, add the most basic system creation commands and ensure that the end to end test passes for this and existing commands.

## Guide to reproduce test results

```
DEPLOYMENT=dev-env-pr-639  go test -v -tags end_to_end -count 1 ./testing
```

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.