### PR TITLE
Systems CLI support #3: Systems Listing Commands

### DIFF
--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -44,11 +44,26 @@ var (
 		Long:  ``,
 		Run:   untagExperience,
 	}
+
+	addSystemExperienceCmd = &cobra.Command{
+		Use:   "add-system",
+		Short: "add-system - Add a system as compatible with an experience",
+		Long:  ``,
+		Run:   addSystemToExperience,
+	}
+	removeSystemExperienceCmd = &cobra.Command{
+		Use:   "remove-system",
+		Short: "remove-system - Remove a system as compatible with an experience",
+		Long:  ``,
+		Run:   removeSystemFromExperience,
+	}
 )
 
 const (
 	experienceProjectKey       = "project"
+	experienceSystemKey        = "system"
 	experienceNameKey          = "name"
+	experienceKey              = "experience"
 	experienceIDKey            = "id"
 	experienceDescriptionKey   = "description"
 	experienceLocationKey      = "location"
@@ -70,9 +85,11 @@ func init() {
 	createExperienceCmd.Flags().MarkDeprecated(experienceLaunchProfileKey, "launch profiles are deprecated in favor of systems to define resource requirements")
 	createExperienceCmd.Flags().Bool(experienceGithubKey, false, "Whether to output format in github action friendly format")
 	experienceCmd.AddCommand(createExperienceCmd)
+
 	listExperiencesCmd.Flags().String(experienceProjectKey, "", "The name or ID of the project to list the experiences within")
 	listExperiencesCmd.MarkFlagRequired(experienceProjectKey)
 	experienceCmd.AddCommand(listExperiencesCmd)
+	// Experience tag sub-commands:
 	tagExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
 	tagExperienceCmd.MarkFlagRequired(experienceProjectKey)
 	tagExperienceCmd.Flags().String(experienceTagKey, "", "The name of the tag to add")
@@ -80,6 +97,7 @@ func init() {
 	tagExperienceCmd.Flags().String(experienceIDKey, "", "The ID of the experience to tag")
 	tagExperienceCmd.MarkFlagRequired(experienceNameKey)
 	experienceCmd.AddCommand(tagExperienceCmd)
+
 	untagExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
 	untagExperienceCmd.MarkFlagRequired(experienceProjectKey)
 	untagExperienceCmd.Flags().String(experienceTagKey, "", "The name of the tag to remove")
@@ -87,6 +105,22 @@ func init() {
 	untagExperienceCmd.Flags().String(experienceIDKey, "", "The ID of the experience to untag")
 	untagExperienceCmd.MarkFlagRequired(experienceNameKey)
 	experienceCmd.AddCommand(untagExperienceCmd)
+	// Systems-related sub-commands:
+	addSystemExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
+	addSystemExperienceCmd.MarkFlagRequired(experienceProjectKey)
+	addSystemExperienceCmd.Flags().String(experienceSystemKey, "", "The name or ID of the system to add")
+	addSystemExperienceCmd.MarkFlagRequired(experienceSystemKey)
+	addSystemExperienceCmd.Flags().String(experienceKey, "", "The name or ID of the experience register as compatible with the system")
+	addSystemExperienceCmd.MarkFlagRequired(experienceKey)
+	experienceCmd.AddCommand(addSystemExperienceCmd)
+	removeSystemExperienceCmd.Flags().String(experienceProjectKey, "", "The name or ID of the associated project")
+	removeSystemExperienceCmd.MarkFlagRequired(experienceProjectKey)
+	removeSystemExperienceCmd.Flags().String(experienceSystemKey, "", "The name or ID  of the system to remove")
+	removeSystemExperienceCmd.MarkFlagRequired(experienceSystemKey)
+	removeSystemExperienceCmd.Flags().String(experienceKey, "", "The name or ID of the experience to deregister as compatible with the system")
+	removeSystemExperienceCmd.MarkFlagRequired(experienceKey)
+	experienceCmd.AddCommand(removeSystemExperienceCmd)
+
 	rootCmd.AddCommand(experienceCmd)
 }
 
@@ -250,4 +284,122 @@ func untagExperience(ccmd *cobra.Command, args []string) {
 		log.Fatal("failed to untag experience, it may not be tagged ", experienceTagName)
 	}
 	ValidateResponse(http.StatusNoContent, "failed to untag experience", response.HTTPResponse, response.Body)
+}
+
+func addSystemToExperience(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(experienceProjectKey))
+
+	systemName := viper.GetString(experienceSystemKey)
+	if systemName == "" {
+		log.Fatal("empty system name")
+	}
+	systemID := getSystemID(Client, projectID, systemName, true)
+
+	if viper.GetString(experienceKey) == "" {
+		log.Fatal("empty experience name")
+	}
+	experienceID := getExperienceID(Client, projectID, viper.GetString(experienceKey), true)
+
+	response, err := Client.AddSystemToExperienceWithResponse(
+		context.Background(), projectID,
+		systemID,
+		experienceID,
+	)
+	if err != nil {
+		log.Fatal("failed to register experience with system", err)
+	}
+	if response.HTTPResponse.StatusCode == 409 {
+		log.Fatal("failed to register experience with system, it may already be registered ", systemName)
+	}
+	ValidateResponse(http.StatusCreated, "failed to register experience with system", response.HTTPResponse, response.Body)
+}
+
+func removeSystemFromExperience(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(experienceProjectKey))
+
+	systemName := viper.GetString(experienceSystemKey)
+	if systemName == "" {
+		log.Fatal("empty system name")
+	}
+	systemID := getSystemID(Client, projectID, systemName, true)
+	if viper.GetString(experienceKey) == "" {
+		log.Fatal("empty experience name")
+	}
+	experienceID := getExperienceID(Client, projectID, viper.GetString(experienceKey), true)
+
+	response, err := Client.RemoveSystemFromExperienceWithResponse(
+		context.Background(), projectID,
+		systemID,
+		experienceID,
+	)
+	if err != nil {
+		log.Fatal("failed to deregister experience with system", err)
+	}
+	if response.HTTPResponse.StatusCode == 409 {
+		log.Fatal("failed to deregister experience with system, it may not be registered ", systemName)
+	}
+	ValidateResponse(http.StatusNoContent, "failed to deregister experience with system", response.HTTPResponse, response.Body)
+}
+
+// TODO(https://app.asana.com/0/1205228215063249/1205227572053894/f): we should have first class support in API for this
+func checkExperienceID(client api.ClientWithResponsesInterface, projectID uuid.UUID, identifier string) uuid.UUID {
+	// Page through experiences until we find the one with either a name or an ID
+	// that matches the identifier string.
+	experienceID := uuid.Nil
+	// First try the assumption that identifier is a UUID.
+	err := uuid.Validate(identifier)
+	if err == nil {
+		// The identifier is a uuid - but does it refer to an existing experience?
+		potentialExperienceID := uuid.MustParse(identifier)
+		response, _ := client.GetExperienceWithResponse(context.Background(), projectID, potentialExperienceID)
+		if response.HTTPResponse.StatusCode == http.StatusOK {
+			// Experience found with ID
+			return potentialExperienceID
+		}
+	}
+	// If we're here then either the identifier is not a UUID or the UUID was not
+	// found. Users could choose to name experiences with UUIDs so regardless of how
+	// we got here we now search for identifier as a string name.
+	var pageToken *string = nil
+pageLoop:
+	for {
+		response, err := client.ListExperiencesWithResponse(
+			context.Background(), projectID, &api.ListExperiencesParams{
+				PageSize:  Ptr(100),
+				PageToken: pageToken,
+			})
+		if err != nil {
+			log.Fatal("failed to list experiences:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list experiences", response.HTTPResponse, response.Body)
+		if response.JSON200 == nil {
+			log.Fatal("empty response")
+		}
+		pageToken = response.JSON200.NextPageToken
+		experiences := *response.JSON200.Experiences
+		for _, experience := range experiences {
+			if experience.Name == nil {
+				log.Fatal("experience has no name")
+			}
+			if experience.ExperienceID == nil {
+				log.Fatal("experience ID is empty")
+			}
+			if *experience.Name == identifier {
+				experienceID = *experience.ExperienceID
+				break pageLoop
+			}
+		}
+		if pageToken == nil || *pageToken == "" {
+			break
+		}
+	}
+	return experienceID
+}
+
+func getExperienceID(client api.ClientWithResponsesInterface, projectID uuid.UUID, identifier string, failWhenNotFound bool) uuid.UUID {
+	experienceID := checkExperienceID(client, projectID, identifier)
+	if experienceID == uuid.Nil && failWhenNotFound {
+		log.Fatal("failed to find experience with name or ID: ", identifier)
+	}
+	return experienceID
 }

--- a/cmd/resim/commands/system.go
+++ b/cmd/resim/commands/system.go
@@ -312,6 +312,7 @@ func systemBuilds(ccmd *cobra.Command, args []string) {
 			context.Background(), projectID, systemID, &api.ListBuildsForSystemParams{
 				PageSize:  Ptr(100),
 				PageToken: pageToken,
+				OrderBy:   Ptr("timestamp"),
 			})
 		if err != nil {
 			log.Fatal("failed to list builds for system:", err)

--- a/cmd/resim/commands/system.go
+++ b/cmd/resim/commands/system.go
@@ -290,7 +290,7 @@ func systemMetricsBuilds(ccmd *cobra.Command, args []string) {
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || response.JSON200.MetricsBuilds == nil {
-			log.Fatal("no metrics builds")
+			log.Fatal("no experiences")
 		}
 		allMetricsBuilds = append(allMetricsBuilds, *response.JSON200.MetricsBuilds...)
 		if pageToken == nil || *pageToken == "" {

--- a/cmd/resim/commands/system.go
+++ b/cmd/resim/commands/system.go
@@ -40,6 +40,24 @@ var (
 		Long:  ``,
 		Run:   listSystems,
 	}
+	systemsBuildsCmd = &cobra.Command{
+		Use:   "builds",
+		Short: "builds - Lists builds of a system",
+		Long:  ``,
+		Run:   systemBuilds,
+	}
+	systemsExperiencesCmd = &cobra.Command{
+		Use:   "experiences",
+		Short: "experiences - Lists experiences compatible with a system",
+		Long:  ``,
+		Run:   systemExperiences,
+	}
+	systemsMetricsBuildsCmd = &cobra.Command{
+		Use:   "metrics-builds",
+		Short: "metrics-builds - Lists metrics builds compatible with a system",
+		Long:  ``,
+		Run:   systemMetricsBuilds,
+	}
 )
 
 const (
@@ -85,15 +103,38 @@ func init() {
 	getSystemCmd.MarkFlagRequired(systemProjectKey)
 	getSystemCmd.Flags().String(systemKey, "", "The name or ID of the system to get details for")
 	getSystemCmd.MarkFlagRequired(systemKey)
+	getSystemCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
 
 	listSystemsCmd.Flags().String(systemProjectKey, "", "List systems associated with this project")
 	listSystemsCmd.MarkFlagRequired(systemProjectKey)
 
 	listSystemsCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
 
+	systemsBuildsCmd.Flags().String(systemProjectKey, "", "The project the system is associated with")
+	systemsBuildsCmd.MarkFlagRequired(systemProjectKey)
+	systemsBuildsCmd.Flags().String(systemKey, "", "The system whose builds to list")
+	systemsBuildsCmd.MarkFlagRequired(systemKey)
+	systemsBuildsCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
+
+	systemsExperiencesCmd.Flags().String(systemProjectKey, "", "The project the system is associated with")
+	systemsExperiencesCmd.MarkFlagRequired(systemProjectKey)
+	systemsExperiencesCmd.Flags().String(systemKey, "", "The system whose compatible experiences to list")
+	systemsExperiencesCmd.MarkFlagRequired(systemKey)
+	systemsExperiencesCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
+
+	systemsMetricsBuildsCmd.Flags().String(systemProjectKey, "", "The project the system is associated with")
+	systemsMetricsBuildsCmd.MarkFlagRequired(systemProjectKey)
+	systemsMetricsBuildsCmd.Flags().String(systemKey, "", "The system whose compatible metrics builds to list")
+	systemsMetricsBuildsCmd.MarkFlagRequired(systemKey)
+	systemsMetricsBuildsCmd.Flags().SetNormalizeFunc(AliasNormalizeFunc)
+
 	systemCmd.AddCommand(createSystemCmd)
 	systemCmd.AddCommand(getSystemCmd)
 	systemCmd.AddCommand(listSystemsCmd)
+	systemCmd.AddCommand(systemsBuildsCmd)
+	systemCmd.AddCommand(systemsExperiencesCmd)
+	systemCmd.AddCommand(systemsMetricsBuildsCmd)
+
 	rootCmd.AddCommand(systemCmd)
 }
 
@@ -137,7 +178,7 @@ func listSystems(cmd *cobra.Command, args []string) {
 
 		pageToken = response.JSON200.NextPageToken
 		if response.JSON200 == nil || response.JSON200.Systems == nil {
-			log.Fatal("no systemes")
+			log.Fatal("no systems")
 		}
 		allSystems = append(allSystems, *response.JSON200.Systems...)
 		if pageToken == nil || *pageToken == "" {
@@ -197,6 +238,96 @@ func createSystem(cmd *cobra.Command, args []string) {
 		fmt.Println("Created system successfully!")
 		fmt.Printf("System ID: %s\n", system.SystemID.String())
 	}
+}
+
+func systemExperiences(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(systemProjectKey))
+	systemID := getSystemID(Client, projectID, viper.GetString(systemKey), true)
+	var pageToken *string = nil
+
+	var allExperiences []api.Experience
+
+	for {
+		response, err := Client.ListExperiencesForSystemWithResponse(
+			context.Background(), projectID, systemID, &api.ListExperiencesForSystemParams{
+				PageSize:  Ptr(100),
+				PageToken: pageToken,
+			})
+		if err != nil {
+			log.Fatal("failed to list experiences for system:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list experiences for system", response.HTTPResponse, response.Body)
+
+		pageToken = response.JSON200.NextPageToken
+		if response.JSON200 == nil || response.JSON200.Experiences == nil {
+			log.Fatal("no experiences")
+		}
+		allExperiences = append(allExperiences, *response.JSON200.Experiences...)
+		if pageToken == nil || *pageToken == "" {
+			break
+		}
+	}
+	OutputJson(allExperiences)
+}
+
+func systemMetricsBuilds(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(systemProjectKey))
+	systemID := getSystemID(Client, projectID, viper.GetString(systemKey), true)
+	var pageToken *string = nil
+
+	var allMetricsBuilds []api.MetricsBuild
+
+	for {
+		response, err := Client.ListMetricsBuildsForSystemWithResponse(
+			context.Background(), projectID, systemID, &api.ListMetricsBuildsForSystemParams{
+				PageSize:  Ptr(100),
+				PageToken: pageToken,
+			})
+		if err != nil {
+			log.Fatal("failed to list metrics builds for system:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list metrics builds for system", response.HTTPResponse, response.Body)
+
+		pageToken = response.JSON200.NextPageToken
+		if response.JSON200 == nil || response.JSON200.MetricsBuilds == nil {
+			log.Fatal("no metrics builds")
+		}
+		allMetricsBuilds = append(allMetricsBuilds, *response.JSON200.MetricsBuilds...)
+		if pageToken == nil || *pageToken == "" {
+			break
+		}
+	}
+	OutputJson(allMetricsBuilds)
+}
+
+func systemBuilds(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(systemProjectKey))
+	systemID := getSystemID(Client, projectID, viper.GetString(systemKey), true)
+	var pageToken *string = nil
+
+	var allBuilds []api.Build
+
+	for {
+		response, err := Client.ListBuildsForSystemWithResponse(
+			context.Background(), projectID, systemID, &api.ListBuildsForSystemParams{
+				PageSize:  Ptr(100),
+				PageToken: pageToken,
+			})
+		if err != nil {
+			log.Fatal("failed to list builds for system:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list builds for system", response.HTTPResponse, response.Body)
+
+		pageToken = response.JSON200.NextPageToken
+		if response.JSON200 == nil || response.JSON200.Builds == nil {
+			log.Fatal("no builds")
+		}
+		allBuilds = append(allBuilds, *response.JSON200.Builds...)
+		if pageToken == nil || *pageToken == "" {
+			break
+		}
+	}
+	OutputJson(allBuilds)
 }
 
 // TODO(https://app.asana.com/0/1205228215063249/1205227572053894/f): we should have first class support in API for this

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -126,10 +126,12 @@ const (
 	EmptyProjectID      string = "empty project ID"
 	InvalidBranchType   string = "invalid branch type"
 	// System Message
-	CreatedSystem          string = "Created system"
-	GithubCreatedSystem    string = "system_id="
-	EmptySystemName        string = "empty system name"
-	EmptySystemDescription string = "empty system description"
+	CreatedSystem             string = "Created system"
+	GithubCreatedSystem       string = "system_id="
+	EmptySystemName           string = "empty system name"
+	EmptySystemDescription    string = "empty system description"
+	SystemAlreadyRegistered   string = "it may already be registered"
+	SystemAlreadyDeregistered string = "it may not be registered"
 	// Build Messages
 	CreatedBuild          string = "Created build"
 	GithubCreatedBuild    string = "build_id="
@@ -520,6 +522,54 @@ func (s *EndToEndTestSuite) systemBuilds(project string, system string) []Comman
 	return []CommandBuilder{systemCommand, buildsCommand}
 }
 
+func (s *EndToEndTestSuite) addSystemToExperience(project string, system string, experience string) []CommandBuilder {
+	addExperienceCommand := CommandBuilder{
+		Command: "experience",
+	}
+	addCommand := CommandBuilder{
+		Command: "add-system",
+		Flags: []Flag{
+			{
+				Name:  "--project",
+				Value: project,
+			},
+			{
+				Name:  "--system",
+				Value: system,
+			},
+			{
+				Name:  "--experience",
+				Value: experience,
+			},
+		},
+	}
+	return []CommandBuilder{addExperienceCommand, addCommand}
+}
+
+func (s *EndToEndTestSuite) removeSystemFromExperience(project string, system string, experience string) []CommandBuilder {
+	removeExperienceCommand := CommandBuilder{
+		Command: "experience",
+	}
+	removeCommand := CommandBuilder{
+		Command: "remove-system",
+		Flags: []Flag{
+			{
+				Name:  "--project",
+				Value: project,
+			},
+			{
+				Name:  "--system",
+				Value: system,
+			},
+			{
+				Name:  "--experience",
+				Value: experience,
+			},
+		},
+	}
+	return []CommandBuilder{removeExperienceCommand, removeCommand}
+}
+
 func (s *EndToEndTestSuite) systemExperiences(project string, system string) []CommandBuilder {
 	systemCommand := CommandBuilder{
 		Command: "system", // Implicitly testing singular noun alias
@@ -538,6 +588,54 @@ func (s *EndToEndTestSuite) systemExperiences(project string, system string) []C
 		},
 	}
 	return []CommandBuilder{systemCommand, experiencesCommand}
+}
+
+func (s *EndToEndTestSuite) addSystemToMetricsBuild(project string, system string, metricsBuild string) []CommandBuilder {
+	addMetricsBuildCommand := CommandBuilder{
+		Command: "metrics-build",
+	}
+	addCommand := CommandBuilder{
+		Command: "add-system",
+		Flags: []Flag{
+			{
+				Name:  "--project",
+				Value: project,
+			},
+			{
+				Name:  "--system",
+				Value: system,
+			},
+			{
+				Name:  "--metrics-build",
+				Value: metricsBuild,
+			},
+		},
+	}
+	return []CommandBuilder{addMetricsBuildCommand, addCommand}
+}
+
+func (s *EndToEndTestSuite) removeSystemFromMetricsBuild(project string, system string, metricsBuild string) []CommandBuilder {
+	removeMetricsBuildCommand := CommandBuilder{
+		Command: "metrics-build",
+	}
+	removeCommand := CommandBuilder{
+		Command: "remove-system",
+		Flags: []Flag{
+			{
+				Name:  "--project",
+				Value: project,
+			},
+			{
+				Name:  "--system",
+				Value: system,
+			},
+			{
+				Name:  "--metrics-build",
+				Value: metricsBuild,
+			},
+		},
+	}
+	return []CommandBuilder{removeMetricsBuildCommand, removeCommand}
 }
 
 func (s *EndToEndTestSuite) systemMetricsBuilds(project string, system string) []CommandBuilder {
@@ -1500,6 +1598,130 @@ func (s *EndToEndTestSuite) TestSystems() {
 	output = s.runCommand(s.systemBuilds(projectIDString, systemID.String()), ExpectNoError)
 	s.Contains(output.StdOut, build1Version)
 	s.Contains(output.StdOut, build2Version)
+
+	// Create and tag a couple of experiences:
+	experience1Name := fmt.Sprintf("test-experience-%s", uuid.New().String())
+	output = s.runCommand(s.createExperience(projectID, experience1Name, "description", "location", GithubTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedExperience)
+	// We expect to be able to parse the experience ID as a UUID
+	experience1IDString := output.StdOut[len(GithubCreatedExperience) : len(output.StdOut)-1]
+	uuid.MustParse(experience1IDString)
+	experience2Name := fmt.Sprintf("test-experience-%s", uuid.New().String())
+	output = s.runCommand(s.createExperience(projectID, experience2Name, "description", "location", GithubTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedExperience)
+	// We expect to be able to parse the experience ID as a UUID
+	experience2IDString := output.StdOut[len(GithubCreatedExperience) : len(output.StdOut)-1]
+	uuid.MustParse(experience2IDString)
+	// Check we can list the experiences for the systems, and our new experiences are not in it:
+	output = s.runCommand(s.systemExperiences(projectIDString, systemName), ExpectNoError)
+	s.NotContains(output.StdOut, experience1Name)
+	s.NotContains(output.StdOut, experience2Name)
+	s.NotContains(output.StdOut, experience1IDString)
+	s.NotContains(output.StdOut, experience2IDString)
+
+	// Add the experiences to the system:
+	output = s.runCommand(s.addSystemToExperience(projectIDString, systemName, experience1IDString), ExpectNoError)
+	// Check duplicates should error:
+	output = s.runCommand(s.addSystemToExperience(projectIDString, systemName, experience1IDString), ExpectError)
+	s.Contains(output.StdErr, SystemAlreadyRegistered)
+	output = s.runCommand(s.addSystemToExperience(projectName, systemName, experience2IDString), ExpectNoError)
+	// Check we can list the experiences for the systems, and our new experiences are in it:
+	output = s.runCommand(s.systemExperiences(projectIDString, systemName), ExpectNoError)
+	s.Contains(output.StdOut, experience1Name)
+	s.Contains(output.StdOut, experience2Name)
+	s.Contains(output.StdOut, experience1IDString)
+	s.Contains(output.StdOut, experience2IDString)
+
+	// Remove one experience:
+	output = s.runCommand(s.removeSystemFromExperience(projectIDString, systemName, experience1IDString), ExpectNoError)
+	// Check duplicates should error:
+	output = s.runCommand(s.removeSystemFromExperience(projectIDString, systemName, experience1IDString), ExpectError)
+	// Check we can list the experiences for the systems, and only one experience is in it:
+	output = s.runCommand(s.systemExperiences(projectIDString, systemName), ExpectNoError)
+	s.NotContains(output.StdOut, experience1Name)
+	s.Contains(output.StdOut, experience2Name)
+	// Remove the second experience:
+	output = s.runCommand(s.removeSystemFromExperience(projectIDString, systemName, experience2IDString), ExpectNoError)
+	// Check we can list the experiences for the systems, and no experiences are in it:
+	output = s.runCommand(s.systemExperiences(projectIDString, systemName), ExpectNoError)
+	s.NotContains(output.StdOut, experience1Name)
+	s.NotContains(output.StdOut, experience2Name)
+
+	// Edge cases:
+	output = s.runCommand(s.addSystemToExperience("", systemName, experience1IDString), ExpectError)
+	s.Contains(output.StdErr, FailedToFindProject)
+	output = s.runCommand(s.addSystemToExperience(projectIDString, "", experience1IDString), ExpectError)
+	s.Contains(output.StdErr, EmptySystemName)
+	output = s.runCommand(s.addSystemToExperience(projectIDString, systemName, ""), ExpectError)
+	s.Contains(output.StdErr, EmptyExperienceName)
+	output = s.runCommand(s.removeSystemFromExperience("", systemName, experience1IDString), ExpectError)
+	s.Contains(output.StdErr, FailedToFindProject)
+	output = s.runCommand(s.removeSystemFromExperience(projectIDString, "", experience1IDString), ExpectError)
+	s.Contains(output.StdErr, EmptySystemName)
+	output = s.runCommand(s.removeSystemFromExperience(projectIDString, systemName, ""), ExpectError)
+	s.Contains(output.StdErr, EmptyExperienceName)
+
+	// Create and tag a couple of metrics builds:
+	metricsBuild1Name := fmt.Sprintf("test-metrics-build-%s", uuid.New().String())
+	output = s.runCommand(s.createMetricsBuild(projectID, metricsBuild1Name, "public.ecr.aws/docker/library/hello-world:latest", "0.0.1", GithubTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedMetricsBuild)
+	// We expect to be able to parse the metrics build ID as a UUID
+	metricsBuild1IDString := output.StdOut[len(GithubCreatedMetricsBuild) : len(output.StdOut)-1]
+	uuid.MustParse(metricsBuild1IDString)
+	metricsBuild2Name := fmt.Sprintf("test-metrics-build-%s", uuid.New().String())
+	output = s.runCommand(s.createMetricsBuild(projectID, metricsBuild2Name, "public.ecr.aws/docker/library/hello-world:latest", "0.0.2", GithubTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedMetricsBuild)
+	// We expect to be able to parse the metrics build ID as a UUID
+	metricsBuild2IDString := output.StdOut[len(GithubCreatedMetricsBuild) : len(output.StdOut)-1]
+	uuid.MustParse(metricsBuild2IDString)
+	// Check we can list the metrics builds for the systems, and our new metrics builds are not in it:
+	output = s.runCommand(s.systemMetricsBuilds(projectIDString, systemName), ExpectNoError)
+	s.NotContains(output.StdOut, metricsBuild1Name)
+	s.NotContains(output.StdOut, metricsBuild2Name)
+	s.NotContains(output.StdOut, metricsBuild1IDString)
+	s.NotContains(output.StdOut, metricsBuild2IDString)
+
+	// Add the metrics builds to the system:
+	output = s.runCommand(s.addSystemToMetricsBuild(projectIDString, systemName, metricsBuild1IDString), ExpectNoError)
+	// Check duplicates should error:
+	output = s.runCommand(s.addSystemToMetricsBuild(projectIDString, systemName, metricsBuild1IDString), ExpectError)
+	s.Contains(output.StdErr, SystemAlreadyRegistered)
+	output = s.runCommand(s.addSystemToMetricsBuild(projectName, systemName, metricsBuild2IDString), ExpectNoError)
+	// Check we can list the metrics builds for the systems, and our new metrics builds are in it:
+	output = s.runCommand(s.systemMetricsBuilds(projectIDString, systemName), ExpectNoError)
+	s.Contains(output.StdOut, metricsBuild1Name)
+	s.Contains(output.StdOut, metricsBuild2Name)
+	s.Contains(output.StdOut, metricsBuild1IDString)
+	s.Contains(output.StdOut, metricsBuild2IDString)
+
+	// Remove one metrics build:
+	output = s.runCommand(s.removeSystemFromMetricsBuild(projectIDString, systemName, metricsBuild1IDString), ExpectNoError)
+	// Check duplicates should error:
+	output = s.runCommand(s.removeSystemFromMetricsBuild(projectIDString, systemName, metricsBuild1IDString), ExpectError)
+	// Check we can list the metrics builds for the systems, and only one metrics build is in it:
+	output = s.runCommand(s.systemMetricsBuilds(projectIDString, systemName), ExpectNoError)
+	s.NotContains(output.StdOut, metricsBuild1Name)
+	s.Contains(output.StdOut, metricsBuild2Name)
+	// Remove the second metrics build:
+	output = s.runCommand(s.removeSystemFromMetricsBuild(projectIDString, systemName, metricsBuild2IDString), ExpectNoError)
+	// Check we can list the metrics builds for the systems, and no metrics builds are in it:
+	output = s.runCommand(s.systemMetricsBuilds(projectIDString, systemName), ExpectNoError)
+	s.NotContains(output.StdOut, metricsBuild1Name)
+	s.NotContains(output.StdOut, metricsBuild2Name)
+
+	// Edge cases:
+	output = s.runCommand(s.addSystemToMetricsBuild("", systemName, metricsBuild1IDString), ExpectError)
+	s.Contains(output.StdErr, FailedToFindProject)
+	output = s.runCommand(s.addSystemToMetricsBuild(projectIDString, "", metricsBuild1IDString), ExpectError)
+	s.Contains(output.StdErr, EmptySystemName)
+	output = s.runCommand(s.addSystemToMetricsBuild(projectIDString, systemName, ""), ExpectError)
+	s.Contains(output.StdErr, EmptyMetricsBuildName)
+	output = s.runCommand(s.removeSystemFromMetricsBuild("", systemName, metricsBuild1IDString), ExpectError)
+	s.Contains(output.StdErr, FailedToFindProject)
+	output = s.runCommand(s.removeSystemFromMetricsBuild(projectIDString, "", metricsBuild1IDString), ExpectError)
+	s.Contains(output.StdErr, EmptySystemName)
+	output = s.runCommand(s.removeSystemFromMetricsBuild(projectIDString, systemName, ""), ExpectError)
+	s.Contains(output.StdErr, EmptyMetricsBuildName)
 
 	// Delete the test project
 	output = s.runCommand(s.deleteProject(projectIDString), ExpectNoError)


### PR DESCRIPTION
# Description of change

PR 3 of 4 to introduce systems to the ReSim CLI. The intent is to squash all four of these PRs into one before landing.

In this PR, we add the listing commands to systems. The builds listing is completely tested, the other two will be tested in the final PR.

## Guide to reproduce test results

```
DEPLOYMENT=dev-env-pr-639  go test -v -tags end_to_end -count 1 ./testing
```

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.