### PR TITLE
Map main to MAIN

### DIFF
--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -225,10 +225,14 @@ func createBuild(ccmd *cobra.Command, args []string) {
 			if !buildGithub {
 				fmt.Printf("Branch with name %v doesn't currently exist. Creating... \n", branchName)
 			}
+			branchType := api.CHANGEREQUEST
+			if branchName == "main" {
+				branchType = api.MAIN
+			}
 			// Create the branch
 			body := api.CreateBranchInput{
 				Name:       branchName,
-				BranchType: api.CHANGEREQUEST,
+				BranchType: branchType,
 			}
 
 			response, err := Client.CreateBranchForProjectWithResponse(context.Background(), projectID, body)

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -226,7 +226,7 @@ func createBuild(ccmd *cobra.Command, args []string) {
 				fmt.Printf("Branch with name %v doesn't currently exist. Creating... \n", branchName)
 			}
 			branchType := api.CHANGEREQUEST
-			if branchName == "main" {
+			if branchName == "main" || branchName == "master" {
 				branchType = api.MAIN
 			}
 			// Create the branch


### PR DESCRIPTION
# Description of change

The CLI supports an `--auto-create-batch` flag that is used frequently in CI. This makes a decision about what type a main branch should be if it is ever triggered.

## Guide to reproduce test results

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.