### PR TITLE
Include trigger information in batches, sweeps, and reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,7 @@ resim reports create --name "my-report" --test-suite "Nightly Regression" --bran
 which will generate a report using the supplied metrics build (which must be capable of generating a report).
 - Other available report commands are similar to batches: `get`, `wait`, `logs`.
 - For full details of how reports work and how to generate a report, please read the main ReSim [docs](https://docs.resim.ai)
-
-### v0.3.3 - June 20 2024
-
-#### Changed
-
-- When creating a batch, sweep, or report, additional information will be included to describe
+- When creating a batch, sweep, or report additional environment information will be included to describe
   where it was created from (GitHub, Gitlab, local, etc.)
 
 ### v0.3.2 - June 13 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ which will generate a report using the supplied metrics build (which must be cap
 - Other available report commands are similar to batches: `get`, `wait`, `logs`.
 - For full details of how reports work and how to generate a report, please read the main ReSim [docs](https://docs.resim.ai)
 
+### v0.3.3 - June 20 2024
+
+#### Changed
+
+- When creating a batch, sweep, or report, additional information will be included to describe
+  where it was created from (GitHub, Gitlab, local, etc.)
+
 ### v0.3.2 - June 13 2024
 
 #### Added

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -260,14 +260,12 @@ func createBatch(ccmd *cobra.Command, args []string) {
 		associatedAccount = viper.GetString(batchAccountKey)
 	}
 
-	triggeredVia := DetermineTriggerMethod()
-
 	// Build the request body
 	body := api.BatchInput{
 		BuildID:           &buildID,
 		Parameters:        &parameters,
 		AssociatedAccount: &associatedAccount,
-		TriggeredVia:      triggeredVia,
+		TriggeredVia:      DetermineTriggerMethod(),
 	}
 
 	if allExperienceIDs != nil {

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -157,6 +157,23 @@ func GetCIEnvironmentVariableAccount() string {
 	return account
 }
 
+// Attempt to determine the environment we're in. i.e. are we running in Gitlab CI?
+// Github CI? or maybe just running locally on a customer's machine? This information
+// is useful downstream, for understanding where a batch was triggered from.
+func DetermineTriggerMethod() *api.TriggeredVia {
+	if _, ok := os.LookupEnv("CI"); ok {
+		if _, ok := os.LookupEnv("GITHUB_ACTOR"); ok {
+			return Ptr(api.GITHUB)
+		}
+		if _, ok := os.LookupEnv("GITLAB_USER_LOGIN"); ok {
+			return Ptr(api.GITLAB)
+		}
+		// Unfortunately, we're not sure what ENV we're being executed from
+		return nil
+	}
+	return Ptr(api.LOCAL)
+}
+
 func createBatch(ccmd *cobra.Command, args []string) {
 	projectID := getProjectID(Client, viper.GetString(batchProjectKey))
 	batchGithub := viper.GetBool(batchGithubKey)
@@ -243,11 +260,14 @@ func createBatch(ccmd *cobra.Command, args []string) {
 		associatedAccount = viper.GetString(batchAccountKey)
 	}
 
+	triggeredVia := DetermineTriggerMethod()
+
 	// Build the request body
 	body := api.BatchInput{
 		BuildID:           &buildID,
 		Parameters:        &parameters,
 		AssociatedAccount: &associatedAccount,
+		TriggeredVia:      triggeredVia,
 	}
 
 	if allExperienceIDs != nil {

--- a/cmd/resim/commands/report.go
+++ b/cmd/resim/commands/report.go
@@ -198,6 +198,7 @@ func createReport(ccmd *cobra.Command, args []string) {
 		StartTimestamp:          startTimestamp,
 		EndTimestamp:            Ptr(endTimestamp),
 		AssociatedAccount:       &associatedAccount,
+		TriggeredVia:            DetermineTriggerMethod(),
 	}
 
 	if viper.IsSet(reportNameKey) {

--- a/cmd/resim/commands/sweep.go
+++ b/cmd/resim/commands/sweep.go
@@ -191,6 +191,7 @@ func createSweep(ccmd *cobra.Command, args []string) {
 		BuildID:           &buildID,
 		Parameters:        &sweepParameters,
 		AssociatedAccount: &associatedAccount,
+		TriggeredVia:      DetermineTriggerMethod(),
 	}
 
 	if allExperienceIDs != nil {


### PR DESCRIPTION
# Description of change

When creating a batch, sweep, or report include information about where it was triggered from.

https://app.asana.com/0/1206827738654243/1207474151607273

## Guide to reproduce test results

Create a batch locally, then via Github. You should see it noted in the `batches.triggered_via column`

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.