### PR TITLE
Rename jobs to test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ which will generate a report using the supplied metrics build (which must be cap
 - When creating a batch, sweep, or report additional environment information will be included to describe
   where it was created from (GitHub, Gitlab, local, etc.)
 
+#### Changed
+
+- Any historic use of 'job' has been replaced with 'test', which is the more accurate external-facing term for the elements of a test batch.
+
 ### v0.3.2 - June 13 2024
 
 #### Added

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -44,10 +44,11 @@ var (
 	}
 
 	jobsBatchCmd = &cobra.Command{
-		Use:   "jobs",
-		Short: "jobs - Lists the jobs in a batch",
+		Use:   "tests",
+		Short: "tests - Lists the tests in a batch",
 		Long:  ``,
 		Run:   jobsBatch,
+		Aliases: []string{"jobs"},
 	}
 
 	waitBatchCmd = &cobra.Command{

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -43,11 +43,11 @@ var (
 		Run:   cancelBatch,
 	}
 
-	jobsBatchCmd = &cobra.Command{
-		Use:   "tests",
-		Short: "tests - Lists the tests in a batch",
-		Long:  ``,
-		Run:   jobsBatch,
+	testsBatchCmd = &cobra.Command{
+		Use:     "tests",
+		Short:   "tests - Lists the tests in a batch",
+		Long:    ``,
+		Run:     testsBatch,
 		Aliases: []string{"jobs"},
 	}
 
@@ -118,12 +118,13 @@ func init() {
 	cancelBatchCmd.MarkFlagsMutuallyExclusive(batchIDKey, batchNameKey)
 	batchCmd.AddCommand(cancelBatchCmd)
 
-	jobsBatchCmd.Flags().String(batchProjectKey, "", "The name or ID of the project the batch is associated with")
-	jobsBatchCmd.MarkFlagRequired(batchProjectKey)
-	jobsBatchCmd.Flags().String(batchIDKey, "", "The ID of the batch to retrieve jobs for.")
-	jobsBatchCmd.Flags().String(batchNameKey, "", "The name of the batch to retrieve (e.g. rejoicing-aquamarine-starfish).")
-	jobsBatchCmd.MarkFlagsMutuallyExclusive(batchIDKey, batchNameKey)
-	batchCmd.AddCommand(jobsBatchCmd)
+	testsBatchCmd.Flags().String(batchProjectKey, "", "The name or ID of the project the batch is associated with")
+	testsBatchCmd.MarkFlagRequired(batchProjectKey)
+	testsBatchCmd.Flags().String(batchIDKey, "", "The ID of the batch to retrieve tests for.")
+	testsBatchCmd.Flags().String(batchNameKey, "", "The name of the batch to retrieve (e.g. rejoicing-aquamarine-starfish).")
+	testsBatchCmd.MarkFlagsMutuallyExclusive(batchIDKey, batchNameKey)
+	testsBatchCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
+	batchCmd.AddCommand(testsBatchCmd)
 
 	waitBatchCmd.Flags().String(batchProjectKey, "", "The name or ID of the project the batch is associated with")
 	waitBatchCmd.MarkFlagRequired(batchProjectKey)
@@ -435,7 +436,7 @@ func waitBatch(ccmd *cobra.Command, args []string) {
 	}
 }
 
-func jobsBatch(ccmd *cobra.Command, args []string) {
+func testsBatch(ccmd *cobra.Command, args []string) {
 	projectID := getProjectID(Client, viper.GetString(batchProjectKey))
 	var batchID uuid.UUID
 	var err error
@@ -451,8 +452,8 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 		log.Fatal("must specify either the batch ID or the batch name")
 	}
 
-	// Now list the jobs
-	jobs := []api.Job{}
+	// Now list the tests
+	tests := []api.Job{}
 	var pageToken *string = nil
 	for {
 		response, err := Client.ListJobsWithResponse(context.Background(), projectID, batchID, &api.ListJobsParams{
@@ -460,14 +461,14 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 			PageToken: pageToken,
 		})
 		if err != nil {
-			log.Fatal("unable to list jobs:", err)
+			log.Fatal("unable to list tests:", err)
 		}
-		ValidateResponse(http.StatusOK, "unable to list jobs", response.HTTPResponse, response.Body)
+		ValidateResponse(http.StatusOK, "unable to list tests", response.HTTPResponse, response.Body)
 		if response.JSON200.Jobs == nil {
-			log.Fatal("unable to list jobs")
+			log.Fatal("unable to list tests")
 		}
 		responseJobs := *response.JSON200.Jobs
-		jobs = append(jobs, responseJobs...)
+		tests = append(tests, responseJobs...)
 
 		if response.JSON200.NextPageToken != nil && *response.JSON200.NextPageToken != "" {
 			pageToken = response.JSON200.NextPageToken
@@ -475,7 +476,7 @@ func jobsBatch(ccmd *cobra.Command, args []string) {
 			break
 		}
 	}
-	OutputJson(jobs)
+	OutputJson(tests)
 }
 
 func listBatchLogs(ccmd *cobra.Command, args []string) {

--- a/cmd/resim/commands/commands.go
+++ b/cmd/resim/commands/commands.go
@@ -123,6 +123,8 @@ func AliasNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "project"
 	case "branch-name":
 		name = "branch"
+	case "job-id":
+		name = "test-id"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -31,7 +31,7 @@ var (
 const (
 	logProjectKey = "project"
 	logBatchIDKey = "batch-id"
-	logJobIDKey   = "test-id" // User-facing is test ID, internal is job id
+	logTestIDKey  = "test-id" // User-facing is test ID, internal is job id
 )
 
 func init() {
@@ -39,8 +39,8 @@ func init() {
 	listLogsCmd.MarkFlagRequired(logProjectKey)
 	listLogsCmd.Flags().String(logBatchIDKey, "", "The UUID of the batch the logs are associated with")
 	listLogsCmd.MarkFlagRequired(logBatchIDKey)
-	listLogsCmd.Flags().String(logJobIDKey, "", "The UUID of the test in the batch to list logs for")
-	listLogsCmd.MarkFlagRequired(logJobIDKey)
+	listLogsCmd.Flags().String(logTestIDKey, "", "The UUID of the test in the batch to list logs for")
+	listLogsCmd.MarkFlagRequired(logTestIDKey)
 	listLogsCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
 	logsCmd.AddCommand(listLogsCmd)
 
@@ -54,7 +54,7 @@ func listLogs(ccmd *cobra.Command, args []string) {
 		log.Fatal("unable to parse batch ID: ", err)
 	}
 
-	testID, err := uuid.Parse(viper.GetString(logJobIDKey))
+	testID, err := uuid.Parse(viper.GetString(logTestIDKey))
 	if err != nil || testID == uuid.Nil {
 		log.Fatal("unable to parse test ID: ", err)
 	}

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -20,12 +19,7 @@ var (
 		Long:    ``,
 		Aliases: []string{"log"},
 	}
-	createLogCmd = &cobra.Command{
-		Use:   "create",
-		Short: "create - Creates a new log entry",
-		Long:  ``,
-		Run:   createLog,
-	}
+
 	listLogsCmd = &cobra.Command{
 		Use:   "list",
 		Short: "list - Lists the logs for a batch",
@@ -35,141 +29,22 @@ var (
 )
 
 const (
-	logProjectKey       = "project"
-	logNameKey          = "name"
-	logBatchIDKey       = "batch-id"
-	logJobIDKey         = "job-id"
-	logFileSizeKey      = "file-size"
-	logChecksumKey      = "checksum"
-	logExecutionStepKey = "execution-step"
-	logTypeKey          = "type"
-	logGithubKey        = "github"
+	logProjectKey = "project"
+	logBatchIDKey = "batch-id"
+	logJobIDKey   = "test-id" // User-facing is test ID, internal is job id
 )
 
 func init() {
-	createLogCmd.Flags().String(logProjectKey, "", "The name or ID of the project to associate the log with")
-	createLogCmd.MarkFlagRequired(logProjectKey)
-	createLogCmd.Flags().String(logNameKey, "", "The simple name of the log file to register (not a directory)")
-	createLogCmd.MarkFlagRequired(logNameKey)
-	createLogCmd.Flags().String(logBatchIDKey, "", "The UUID of the batch this log file is associated with")
-	createLogCmd.MarkFlagRequired(logBatchIDKey)
-	createLogCmd.Flags().String(logJobIDKey, "", "The UUID of the job in the batch this log file was created by and will be associated with")
-	createLogCmd.MarkFlagRequired(logJobIDKey)
-	createLogCmd.Flags().Int64(logFileSizeKey, -1, "The size of the file in bytes")
-	createLogCmd.MarkFlagRequired(logFileSizeKey)
-	createLogCmd.Flags().String(logChecksumKey, "", "A checksum for the file, to enable integrity checking when downloading")
-	createLogCmd.Flags().String(logExecutionStepKey, "EXPERIENCE", "The execution step to register the log: EXPERIENCE, METRICS. BATCH_METRICS is not currently supported.")
-	createLogCmd.MarkFlagRequired(logExecutionStepKey)
-	createLogCmd.Flags().String(logTypeKey, "", "The type of the log: ARCHIVE_LOG, CONTAINER_LOG, EXECUTION_LOG, MCAP_LOG, METRICS_OUTPUT_LOG, MP4_LOG, OTHER_LOG")
-	createLogCmd.MarkFlagRequired(logTypeKey)
-	createLogCmd.Flags().Bool(logGithubKey, false, "Whether to output format in github action friendly format")
-	logsCmd.AddCommand(createLogCmd)
-
 	listLogsCmd.Flags().String(logProjectKey, "", "The name or ID of the project to list logs with")
 	listLogsCmd.MarkFlagRequired(logProjectKey)
 	listLogsCmd.Flags().String(logBatchIDKey, "", "The UUID of the batch the logs are associated with")
 	listLogsCmd.MarkFlagRequired(logBatchIDKey)
-	listLogsCmd.Flags().String(logJobIDKey, "", "The UUID of the job in the batch to list logs for")
+	listLogsCmd.Flags().String(logJobIDKey, "", "The UUID of the test in the batch to list logs for")
 	listLogsCmd.MarkFlagRequired(logJobIDKey)
+	listLogsCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
 	logsCmd.AddCommand(listLogsCmd)
 
 	rootCmd.AddCommand(logsCmd)
-}
-
-func createLog(ccmd *cobra.Command, args []string) {
-	projectID := getProjectID(Client, viper.GetString(logProjectKey))
-	logGithub := viper.GetBool(logGithubKey)
-	if !logGithub {
-		fmt.Println("Creating a log entry...")
-	}
-
-	// Parse the various arguments from command line
-	logName := viper.GetString(logNameKey)
-	if logName == "" {
-		log.Fatal("empty log file name")
-	}
-
-	logBatchID, err := uuid.Parse(viper.GetString(logBatchIDKey))
-	if err != nil || logBatchID == uuid.Nil {
-		log.Fatal("empty batch ID")
-	}
-
-	logJobID, err := uuid.Parse(viper.GetString(logJobIDKey))
-	if err != nil || logJobID == uuid.Nil {
-		log.Fatal("empty job ID")
-	}
-
-	logFileSize := viper.GetInt64(logFileSizeKey)
-	if logFileSize == -1 {
-		log.Fatal("empty file size")
-	}
-
-	logChecksum := viper.GetString(logChecksumKey)
-	if logChecksum == "" {
-		if !logGithub {
-			fmt.Println("No checksum was provided, integrity checking will not be possible")
-		}
-	}
-
-	logType := api.LogType(viper.GetString(logTypeKey))
-	if logType != api.MP4LOG && logType != api.ARCHIVELOG && logType != api.CONTAINERLOG && logType != api.EXECUTIONLOG && logType != api.MCAPLOG && logType != api.METRICSOUTPUTLOG && logType != api.OTHERLOG {
-		log.Fatal("invalid log type")
-	}
-
-	logExecutionStep := api.ExecutionStep(viper.GetString(logExecutionStepKey))
-	if logExecutionStep != api.EXPERIENCE && logExecutionStep != api.METRICS {
-		log.Fatal("invalid execution step")
-	}
-
-	body := api.JobLog{
-		FileName:      &logName,
-		FileSize:      &logFileSize,
-		Checksum:      &logChecksum,
-		LogType:       &logType,
-		ExecutionStep: &logExecutionStep,
-	}
-
-	// Verify that the batch and job exist:
-	batchResponse, err := Client.GetBatchWithResponse(context.Background(), projectID, logBatchID)
-	if err != nil {
-		log.Fatal("unable to get batch: ", err)
-	}
-	ValidateResponse(http.StatusOK, fmt.Sprintf("unable to find batch with ID %v", logBatchID),
-		batchResponse.HTTPResponse, batchResponse.Body)
-
-	jobResponse, err := Client.GetJobWithResponse(context.Background(), projectID, logBatchID, logJobID)
-	if err != nil {
-		log.Fatal("unable to get job: ", err)
-	}
-	ValidateResponse(http.StatusOK, fmt.Sprintf("unable to find job with ID %v", logJobID),
-		jobResponse.HTTPResponse, jobResponse.Body)
-
-	// Create the log entry
-	logResponse, err := Client.CreateJobLogWithResponse(context.Background(), projectID, logBatchID, logJobID, body)
-	if err != nil {
-		log.Fatal("unable to create log: ", err)
-	}
-	ValidateResponse(http.StatusCreated, "unable to create log", logResponse.HTTPResponse, logResponse.Body)
-	if logResponse.JSON201 == nil {
-		log.Fatal("empty response")
-	}
-	myLog := logResponse.JSON201
-	if myLog.Location == nil || *myLog.Location == "" {
-		log.Fatal("empty location")
-	}
-	if myLog.LogID == nil {
-		log.Fatal("empty log ID")
-	}
-
-	// Report the results back to the user
-	if logGithub {
-		fmt.Printf("log_location=%s\n", *myLog.Location)
-	} else {
-		fmt.Println("Created log successfully!")
-		fmt.Printf("Log ID: %s\n", myLog.LogID.String())
-		fmt.Printf("Output Location: %s\n", *myLog.Location)
-		fmt.Println("Please upload the log file to this location")
-	}
 }
 
 func listLogs(ccmd *cobra.Command, args []string) {
@@ -179,15 +54,15 @@ func listLogs(ccmd *cobra.Command, args []string) {
 		log.Fatal("unable to parse batch ID: ", err)
 	}
 
-	jobID, err := uuid.Parse(viper.GetString(logJobIDKey))
-	if err != nil || jobID == uuid.Nil {
-		log.Fatal("unable to parse job ID: ", err)
+	testID, err := uuid.Parse(viper.GetString(logJobIDKey))
+	if err != nil || testID == uuid.Nil {
+		log.Fatal("unable to parse test ID: ", err)
 	}
 
 	logs := []api.JobLog{}
 	var pageToken *string = nil
 	for {
-		response, err := Client.ListJobLogsForJobWithResponse(context.Background(), projectID, batchID, jobID, &api.ListJobLogsForJobParams{
+		response, err := Client.ListJobLogsForJobWithResponse(context.Background(), projectID, batchID, testID, &api.ListJobLogsForJobParams{
 			PageToken: pageToken,
 			PageSize:  Ptr(100),
 		})

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -2031,7 +2031,7 @@ func (s *EndToEndTestSuite) TestSystems() {
 	s.Contains(output.StdErr, EmptySystemName)
 	output = s.runCommand(createSystem(projectIDString, systemName, "", nil, nil, nil, nil, nil, nil, nil, nil, GithubFalse), ExpectError)
 	s.Contains(output.StdErr, EmptySystemDescription)
-	output = s.runCommand(createSystem(uuid.Nil.String(), systemName, systemDescription, nil, nil, nil, nil, nil, nil, nil, nil, GithubFalse), ExpectError)
+	output = s.runCommand(createSystem(uuid.New().String(), systemName, systemDescription, nil, nil, nil, nil, nil, nil, nil, nil, GithubFalse), ExpectError)
 	s.Contains(output.StdErr, FailedToFindProject)
 
 	// Check we can list the systems, and our new system is in it:

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -1861,7 +1861,7 @@ func (s *EndToEndTestSuite) TestProjectCommands() {
 	output = s.runCommand(getProject(""), ExpectError)
 	s.Contains(output.StdErr, FailedToFindProject)
 	// Non-existent project:
-	output = s.runCommand(getProject(uuid.Nil.String()), ExpectError)
+	output = s.runCommand(getProject(uuid.New().String()), ExpectError)
 	s.Contains(output.StdErr, FailedToFindProject)
 	// Blank name:
 	output = s.runCommand(getProject(""), ExpectError)

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -1861,7 +1861,7 @@ func (s *EndToEndTestSuite) TestProjectCommands() {
 	output = s.runCommand(getProject(""), ExpectError)
 	s.Contains(output.StdErr, FailedToFindProject)
 	// Non-existent project:
-	output = s.runCommand(getProject(uuid.New().String()), ExpectError)
+	output = s.runCommand(getProject(uuid.Nil.String()), ExpectError)
 	s.Contains(output.StdErr, FailedToFindProject)
 	// Blank name:
 	output = s.runCommand(getProject(""), ExpectError)
@@ -2031,7 +2031,7 @@ func (s *EndToEndTestSuite) TestSystems() {
 	s.Contains(output.StdErr, EmptySystemName)
 	output = s.runCommand(createSystem(projectIDString, systemName, "", nil, nil, nil, nil, nil, nil, nil, nil, GithubFalse), ExpectError)
 	s.Contains(output.StdErr, EmptySystemDescription)
-	output = s.runCommand(createSystem(uuid.New().String(), systemName, systemDescription, nil, nil, nil, nil, nil, nil, nil, nil, GithubFalse), ExpectError)
+	output = s.runCommand(createSystem(uuid.Nil.String(), systemName, systemDescription, nil, nil, nil, nil, nil, nil, nil, nil, GithubFalse), ExpectError)
 	s.Contains(output.StdErr, FailedToFindProject)
 
 	// Check we can list the systems, and our new system is in it:


### PR DESCRIPTION
# Description of change

Small refactoring to the CLI to deprecate the use of the term jobs (still allowed via aliases). Test is now used.

In addition, we remove the ability to create a log via the CLI as this is not part of the non-customer facing API.

## Guide to reproduce test results

```
go test -v -tags end_to_end -count 1 ./testing
```

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.