### PR TITLE
Add check for trailing slash when supplying authURL

### DIFF
--- a/cmd/resim/commands/client.go
+++ b/cmd/resim/commands/client.go
@@ -64,7 +64,14 @@ func GetClient(ctx context.Context) (*api.ClientWithResponses, *CredentialCache,
 	if err != nil {
 		log.Fatal("unable to create token URL: ", err)
 	}
-	authURL, err := url.JoinPath(viper.GetString(authURLKey), "/oauth/device/code")
+
+	// Check if the URL has a trailing slash and add it if not
+	// This prevents an ambiguous error when authenticating against Auth0
+	checkURL := viper.GetString(authURLKey)
+	if !strings.HasSuffix(checkURL, "/") {
+		checkURL += "/"
+	}
+	authURL, err := url.JoinPath(checkURL, "/oauth/device/code")
 	if err != nil {
 		log.Fatal("unable to create authURL: ", err)
 	}


### PR DESCRIPTION
# Description of change

This checks that the `auth-url` supplied has a trailing slash. Without one, the CLI returns an ambiguous error:

```
› resim projects list
2024/07/15 15:37:35 Initializing credential cache
2024/07/15 15:37:35 couldn't find CLI client ID for auth-url
```

We'd always expect it to have a trailing slash, so this will simply check for one, then add it if not.

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.