### PR TITLE
Log Ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.8.0 - March 12 2025
+
+#### Added
+
+- A new `ingest` command now supports ingesting existing logs -- from field testing, for example -- into the ReSim platform and running metrics on them. It works by importing a log with a given name and cloud storage location then running metrics on it. For more information see the [ReSim docs](https://docs.resim.ai/guides/log-ingest) for more details.
+
 ### v0.7.0 - February 26 2025
 
 #### Changed

--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -87,12 +87,14 @@ const (
 const (
 	ARCHIVELOG       LogType = "ARCHIVE_LOG"
 	CONTAINERLOG     LogType = "CONTAINER_LOG"
+	ERRORLOG         LogType = "ERROR_LOG"
 	EXECUTIONLOG     LogType = "EXECUTION_LOG"
 	FOXGLOVEMCAPLOG  LogType = "FOXGLOVE_MCAP_LOG"
 	MCAPLOG          LogType = "MCAP_LOG"
 	METRICSOUTPUTLOG LogType = "METRICS_OUTPUT_LOG"
 	MP4LOG           LogType = "MP4_LOG"
 	OTHERLOG         LogType = "OTHER_LOG"
+	RERUNIOLOG       LogType = "RERUN_IO_LOG"
 )
 
 // Defines values for MetricStatus.
@@ -138,10 +140,10 @@ const (
 
 // Defines values for ReportStatus.
 const (
-	ReportStatusERROR     ReportStatus = "ERROR"
-	ReportStatusRUNNING   ReportStatus = "RUNNING"
-	ReportStatusSUBMITTED ReportStatus = "SUBMITTED"
-	ReportStatusSUCCEEDED ReportStatus = "SUCCEEDED"
+	ERROR     ReportStatus = "ERROR"
+	RUNNING   ReportStatus = "RUNNING"
+	SUBMITTED ReportStatus = "SUBMITTED"
+	SUCCEEDED ReportStatus = "SUCCEEDED"
 )
 
 // Defines values for TriggeredVia.
@@ -192,6 +194,7 @@ type Batch struct {
 	CreationTimestamp      *Timestamp              `json:"creationTimestamp,omitempty"`
 	Description            *string                 `json:"description,omitempty"`
 	ExecutionError         *ExecutionError         `json:"executionError,omitempty"`
+	ExecutionErrors        *[]ExecutionError       `json:"executionErrors"`
 	FriendlyName           *FriendlyName           `json:"friendlyName,omitempty"`
 	JobMetricsStatusCounts *JobMetricsStatusCounts `json:"jobMetricsStatusCounts,omitempty"`
 	JobStatusCounts        *BatchJobStatusCounts   `json:"jobStatusCounts,omitempty"`
@@ -493,7 +496,11 @@ type DebugExperienceInput struct {
 
 // DebugExperienceOutput defines model for debugExperienceOutput.
 type DebugExperienceOutput struct {
-	BatchID *BatchID `json:"batchID,omitempty"`
+	BatchID         *BatchID `json:"batchID,omitempty"`
+	ClusterCAData   *string  `json:"clusterCAData,omitempty"`
+	ClusterEndpoint *string  `json:"clusterEndpoint,omitempty"`
+	ClusterToken    *string  `json:"clusterToken,omitempty"`
+	Namespace       *string  `json:"namespace,omitempty"`
 }
 
 // Event defines model for event.
@@ -620,6 +627,7 @@ type Job struct {
 	CreationTimestamp    *Timestamp          `json:"creationTimestamp,omitempty"`
 	Description          *string             `json:"description,omitempty"`
 	ExecutionError       *ExecutionError     `json:"executionError,omitempty"`
+	ExecutionErrors      *[]ExecutionError   `json:"executionErrors"`
 	ExperienceID         *ExperienceID       `json:"experienceID,omitempty"`
 	ExperienceName       *ExperienceName     `json:"experienceName,omitempty"`
 	JobID                *JobID              `json:"jobID,omitempty"`
@@ -1523,6 +1531,9 @@ type OrderBy = string
 // PageSize defines model for pageSize.
 type PageSize = int
 
+// PageSizeUnbounded defines model for pageSizeUnbounded.
+type PageSizeUnbounded = int
+
 // PageToken defines model for pageToken.
 type PageToken = string
 
@@ -1737,10 +1748,10 @@ type ListExperiencesParams struct {
 	Text *string `form:"text,omitempty" json:"text,omitempty"`
 
 	// Search A search query. Supports searching by tag_id, test_suite_id and system_id
-	Search    *string    `form:"search,omitempty" json:"search,omitempty"`
-	PageSize  *PageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty"`
-	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
-	OrderBy   *OrderBy   `form:"orderBy,omitempty" json:"orderBy,omitempty"`
+	Search    *string            `form:"search,omitempty" json:"search,omitempty"`
+	PageSize  *PageSizeUnbounded `form:"pageSize,omitempty" json:"pageSize,omitempty"`
+	PageToken *PageToken         `form:"pageToken,omitempty" json:"pageToken,omitempty"`
+	OrderBy   *OrderBy           `form:"orderBy,omitempty" json:"orderBy,omitempty"`
 }
 
 // ListExperienceTagsForExperienceParams defines parameters for ListExperienceTagsForExperience.

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -390,7 +390,7 @@ func getBuildIDFromImageURIAndVersion(client api.ClientWithResponsesInterface, p
 		response, err := client.ListBuildsWithResponse(context.Background(), projectID, &api.ListBuildsParams{
 			PageSize:  Ptr(100),
 			OrderBy:   Ptr("timestamp"),
-			Search:    Ptr(fmt.Sprintf("branch_id=%s", branchID)),
+			Search:    Ptr(fmt.Sprintf("branch_id=\"%v\"", branchID)),
 			PageToken: pageToken,
 		})
 		if err != nil {

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -382,3 +382,36 @@ func getBuildID(client api.ClientWithResponsesInterface, projectID uuid.UUID, uu
 	}
 	return potentialBuildID
 }
+
+// Attempt to find an existing build for that branch, imageURI, and version
+func getBuildIDFromImageURIAndVersion(client api.ClientWithResponsesInterface, projectID uuid.UUID, systemID uuid.UUID, branchID uuid.UUID, imageURI string, version string, shouldFail bool) uuid.UUID {
+	var pageToken *string = nil
+	for {
+		response, err := client.ListBuildsWithResponse(context.Background(), projectID, &api.ListBuildsParams{
+			PageSize:  Ptr(100),
+			OrderBy:   Ptr("timestamp"),
+			Search:    Ptr(fmt.Sprintf("branch_id=%s", branchID)),
+			PageToken: pageToken,
+		})
+		if err != nil {
+			log.Fatal("failed to list builds:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list builds", response.HTTPResponse, response.Body)
+		if response.JSON200 == nil || response.JSON200.Builds == nil {
+			log.Fatal("no builds")
+		}
+		pageToken = &response.JSON200.NextPageToken
+		for _, build := range response.JSON200.Builds {
+			if build.ImageUri == imageURI && build.Version == version {
+				return build.BuildID
+			}
+		}
+		if *pageToken == "" {
+			break
+		}
+	}
+	if shouldFail {
+		log.Fatal("failed to find build with image URI and version: ", imageURI, version)
+	}
+	return uuid.Nil
+}

--- a/cmd/resim/commands/client.go
+++ b/cmd/resim/commands/client.go
@@ -35,6 +35,7 @@ const (
 	prodNonInteractiveClientKey = "prod-non-interactive-client"
 	prodGovcloudURL             = "https://api-gov.resim.ai/v1/"
 	prodAPIURL                  = "https://api.resim.ai/v1/"
+	stagingAPIURL               = "https://api.resim.io/v1/"
 	prodAuthURL                 = "https://resim.us.auth0.com/"
 	devAuthURL                  = "https://resim-dev.us.auth0.com/"
 )

--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -351,8 +351,11 @@ func tagExperience(ccmd *cobra.Command, args []string) {
 		log.Fatal("failed to parse experience ID: ", err)
 	}
 
-	experienceTagID := getExperienceTagIDForName(Client, projectID, experienceTagName)
+	tagExperienceHelper(Client, projectID, experienceID, experienceTagName)
+}
 
+func tagExperienceHelper(client api.ClientWithResponsesInterface, projectID uuid.UUID, experienceID uuid.UUID, experienceTagName string) {
+	experienceTagID := getExperienceTagIDForName(Client, projectID, experienceTagName, true)
 	response, err := Client.AddExperienceTagToExperienceWithResponse(
 		context.Background(), projectID,
 		experienceTagID,
@@ -379,7 +382,7 @@ func untagExperience(ccmd *cobra.Command, args []string) {
 		log.Fatal("failed to parse experience ID: ", err)
 	}
 
-	experienceTagID := getExperienceTagIDForName(Client, projectID, experienceTagName)
+	experienceTagID := getExperienceTagIDForName(Client, projectID, experienceTagName, true)
 	response, err := Client.RemoveExperienceTagFromExperienceWithResponse(
 		context.Background(), projectID,
 		experienceTagID,

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -27,8 +27,8 @@ const (
 	ingestSystemKey             = "system"
 	ingestBranchKey             = "branch"
 	ingestVersionKey            = "version"
-	ingestExperienceNameKey     = "experience-name"
-	ingestExperienceLocationKey = "remote-log-location"
+	ingestLogNameKey            = "log-name"
+	ingestExperienceLocationKey = "log-location"
 	ingestExperienceTagsKey     = "tags"
 	ingestGithubKey             = "github"
 	ingestMetricsBuildKey       = "metrics-build-id"
@@ -52,8 +52,8 @@ func init() {
 	ingestLogCmd.Flags().String(ingestMetricsBuildKey, "", "The ID of the metrics build to use in processing this log.")
 	ingestLogCmd.MarkFlagRequired(ingestMetricsBuildKey)
 	// Log Name
-	ingestLogCmd.Flags().String(ingestExperienceNameKey, "", "A project-unique name to use in processing this log, often a run id.")
-	ingestLogCmd.MarkFlagRequired(ingestExperienceNameKey)
+	ingestLogCmd.Flags().String(ingestLogNameKey, "", "A project-unique name to use in processing this log, often a run id.")
+	ingestLogCmd.MarkFlagRequired(ingestLogNameKey)
 	// Log Location
 	ingestLogCmd.Flags().String(ingestExperienceLocationKey, "", "An S3 prefix, which ReSim has access to, where the log is stored.")
 	ingestLogCmd.MarkFlagRequired(ingestExperienceLocationKey)
@@ -103,7 +103,7 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 
 	// Create the experience
 	experienceBody := api.CreateExperienceInput{
-		Name:        viper.GetString(ingestExperienceNameKey),
+		Name:        viper.GetString(ingestLogNameKey),
 		Location:    viper.GetString(ingestExperienceLocationKey),
 		Description: "Ingested into ReSim via the CLI",
 	}

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -130,7 +130,9 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 	}
 
 	// Finally, create a batch to process the log
+	ingestionBatchName := fmt.Sprintf("Ingested Log: %s", experience.Name)
 	batchBody := api.BatchInput{
+		BatchName:         Ptr(ingestionBatchName),
 		ExperienceIDs:     Ptr([]uuid.UUID{experienceID}),
 		BuildID:           Ptr(build.BuildID),
 		AssociatedAccount: &associatedAccount,

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/resim-ai/api-client/api"
+	. "github.com/resim-ai/api-client/ptr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	ingestLogCmd = &cobra.Command{
+		Use:   "ingest",
+		Short: "ingest - Ingests a new log and generates metrics analysis",
+		Long:  ``,
+		Run:   ingestLog,
+	}
+)
+
+const (
+	ingestProjectKey            = "project"
+	ingestSystemKey             = "system"
+	ingestBranchKey             = "branch"
+	ingestVersionKey            = "version"
+	ingestExperienceNameKey     = "experience-name"
+	ingestExperienceLocationKey = "remote-log-location"
+	ingestExperienceTagsKey     = "tags"
+	ingestGithubKey             = "github"
+	ingestMetricsBuildKey       = "metrics-build-id"
+)
+
+func init() {
+	ingestLogCmd.Flags().Bool(ingestGithubKey, false, "Whether to output format in github action friendly format")
+	// Project
+	ingestLogCmd.Flags().String(ingestProjectKey, "", "The name or ID of the project to associate with the log")
+	ingestLogCmd.MarkFlagRequired(ingestProjectKey)
+	// System
+	ingestLogCmd.Flags().String(ingestSystemKey, "", "The name or ID of the system that generated the log")
+	ingestLogCmd.MarkFlagRequired(ingestSystemKey)
+	// Branch
+	ingestLogCmd.Flags().String(ingestBranchKey, "", "The name or ID of the branch of the software that generated the log")
+	ingestLogCmd.MarkFlagRequired(ingestBranchKey) // TODO: make optional
+	// Build
+	ingestLogCmd.Flags().String(ingestVersionKey, "", "The version (often commit sha) of the software that generated the log")
+	ingestLogCmd.MarkFlagRequired(ingestVersionKey) // TODO: make optional
+	// Metrics Build
+	ingestLogCmd.Flags().String(ingestMetricsBuildKey, "", "The ID of the metrics build to use in processing this log.")
+	ingestLogCmd.MarkFlagRequired(ingestMetricsBuildKey)
+	// Log Name
+	ingestLogCmd.Flags().String(ingestExperienceNameKey, "", "A project-unique name to use in processing this log, often a run id.")
+	ingestLogCmd.MarkFlagRequired(ingestExperienceNameKey)
+	// Log Location
+	ingestLogCmd.Flags().String(ingestExperienceLocationKey, "", "An S3 prefix, which ReSim has access to, where the log is stored.")
+	ingestLogCmd.MarkFlagRequired(ingestExperienceLocationKey)
+	// Tags
+	ingestLogCmd.Flags().String(ingestExperienceTagsKey, "", "Comma-separated list of tags to apply.") // TODO: implement
+	rootCmd.AddCommand(ingestLogCmd)
+}
+
+func ingestLog(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(batchProjectKey))
+	logGithub := viper.GetBool(ingestGithubKey)
+	if !logGithub {
+		fmt.Println("Ingesting a log...")
+	}
+
+	// Check the system exists:
+	systemID := getSystemID(Client, projectID, viper.GetString(ingestSystemKey), true)
+	// Check the branch exists:
+	branchID := getBranchID(Client, projectID, viper.GetString(ingestBranchKey), true)
+	// Create a build using the ReSim standard log ingest build:
+	logIngestURI := "hello world"
+
+	body := api.CreateBuildForBranchInput{
+		Description: Ptr("A ReSim Log Ingest Build"),
+		ImageUri:    logIngestURI,
+		Version:     viper.GetString(ingestVersionKey),
+		SystemID:    systemID,
+	}
+	response, err := Client.CreateBuildForBranchWithResponse(context.Background(), projectID, branchID, body)
+	if err != nil {
+		log.Fatal("unable to create build:", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create build", response.HTTPResponse, response.Body)
+	if response.JSON201 == nil {
+		log.Fatal("empty response")
+	}
+	build := *response.JSON201
+	if build.BuildID == nil {
+		log.Fatal("no build ID")
+	}
+
+	// Create the experience
+	experienceBody := api.CreateExperienceInput{
+		Name:        viper.GetString(ingestExperienceNameKey),
+		Location:    viper.GetString(ingestExperienceLocationKey),
+		Description: "A ReSim Log Ingest Experience",
+	}
+	experienceResponse, err := Client.CreateExperienceWithResponse(context.Background(), projectID, experienceBody)
+	if err != nil {
+		log.Fatal("unable to create experience:", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create experience", experienceResponse.HTTPResponse, experienceResponse.Body)
+	if experienceResponse.JSON201 == nil {
+		log.Fatal("empty response")
+	}
+	experience := *experienceResponse.JSON201
+	experienceID := experience.ExperienceID
+
+	// Process the associated account: by default, we try to get from CI/CD environment variables
+	// Otherwise, we use the account flag. The default is "".
+	associatedAccount := GetCIEnvironmentVariableAccount()
+	if viper.IsSet(batchAccountKey) {
+		associatedAccount = viper.GetString(batchAccountKey)
+	}
+
+	// Validate the metrics build exists:
+	metricsBuildID, err := uuid.Parse(viper.GetString(ingestMetricsBuildKey))
+	if err != nil || metricsBuildID == uuid.Nil {
+		log.Fatal("Metrics build ID is required")
+	}
+
+	// Finally, create a batch to process the log
+	batchBody := api.BatchInput{
+		ExperienceIDs:     Ptr([]uuid.UUID{experienceID}),
+		BuildID:           build.BuildID,
+		AssociatedAccount: &associatedAccount,
+		TriggeredVia:      DetermineTriggerMethod(),
+		MetricsBuildID:    Ptr(metricsBuildID),
+	}
+
+	batchResponse, err := Client.CreateBatchWithResponse(context.Background(), projectID, batchBody)
+	if err != nil {
+		log.Fatal("unable to create batch:", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create batch", batchResponse.HTTPResponse, batchResponse.Body)
+	if batchResponse.JSON201 == nil {
+		log.Fatal("empty response")
+	}
+	batch := *batchResponse.JSON201
+	if batch.BatchID == nil {
+		log.Fatal("no batch ID")
+	}
+
+	// Report the results back to the user
+	if logGithub {
+		fmt.Printf("batch_id=%s\n", batch.BatchID.String())
+	} else {
+		fmt.Println("Ingested log successfully!")
+		fmt.Printf("Batch ID: %s\n", batch.BatchID.String())
+	}
+}

--- a/cmd/resim/commands/report.go
+++ b/cmd/resim/commands/report.go
@@ -296,13 +296,13 @@ func getReport(ccmd *cobra.Command, args []string) {
 
 	if viper.GetBool(reportExitStatusKey) {
 		switch report.Status {
-		case api.ReportStatusSUCCEEDED:
+		case api.SUCCEEDED:
 			os.Exit(0)
-		case api.ReportStatusERROR:
+		case api.ERROR:
 			os.Exit(2)
-		case api.ReportStatusSUBMITTED:
+		case api.SUBMITTED:
 			os.Exit(3)
-		case api.ReportStatusRUNNING:
+		case api.RUNNING:
 			os.Exit(4)
 		default:
 			log.Fatal("unknown report status: ", report.Status)
@@ -322,11 +322,11 @@ func waitReport(ccmd *cobra.Command, args []string) {
 		report = actualGetReport(projectID, viper.GetString(reportIDKey), viper.GetString(reportNameKey))
 		viper.Set(reportIDKey, report.ReportID.String())
 		switch report.Status {
-		case api.ReportStatusSUCCEEDED:
+		case api.SUCCEEDED:
 			os.Exit(0)
-		case api.ReportStatusERROR:
+		case api.ERROR:
 			os.Exit(2)
-		case api.ReportStatusSUBMITTED, api.ReportStatusRUNNING:
+		case api.SUBMITTED, api.RUNNING:
 		default:
 			log.Fatal("unknown report status: ", report.Status)
 		}


### PR DESCRIPTION
# Description of change

Introduces a CLI command designed to support customers who want to ingest logs from IRL (or HiL) robot testing and run a ReSim metrics build on it to generate results.

This is achieved by running a test batch with a single test containing that log.

## To Do

 - [x] Support tagging the log as desired
 - [x] Support optional branch and find the main branch
 - [x] Support optional version and use a "latest" commit
 - [ ] End to end test

## Notes:

This is a proof of concept, reusing the existing infrastructure that we have, which may or may not be the right thing to do.

## Guide to reproduce test results

```
```

## Checklist

- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.