### PR TITLE
Show help by default and fix project selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.4.1 - February 13 2025
+
+#### Added
+
+- The ReSim CLI now shows help when no subcommands are provided.
+
+#### Fixed
+
+- The CLI no longer fails to select a new project if the config file is present.
+
 ### v0.4.0 - January 24 2025
 
 #### Added

--- a/cmd/resim/commands/commands.go
+++ b/cmd/resim/commands/commands.go
@@ -31,6 +31,11 @@ var (
 )
 
 func rootCommand(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		cmd.Help()
+		os.Exit(0)
+	}
+
 	viper.SetConfigName("resim")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(os.ExpandEnv(ConfigPath))

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -148,7 +148,7 @@ func selectProject(ccmd *cobra.Command, args []string) {
 	// Therefore we can safely save it again without adding any additional flags.
 	v := viper.New()
 	v.SetConfigName("resim")
-	v.SetConfigType("json")
+	v.SetConfigType("yaml")
 	v.AddConfigPath(os.ExpandEnv(ConfigPath))
 	if err := v.ReadInConfig(); err != nil {
 		switch err.(type) {


### PR DESCRIPTION
# Description of change

- Show `resim --help` when just running `resim` ([Asana task](https://app.asana.com/0/1208904700846047/1209391154283074))
- Fix `resim project select <>` ([Asana task](https://app.asana.com/0/1208904700846047/1209402535640595))

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.