### PR TITLE
Revise Show On Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.6.0 - February 19 2025
+
+#### Added
+
+- The test suite `revise` command now supports the `--show-on-summary` flag, which can be used to specify whether the latest results of a test suite should be displayed on the overview dashboard.
+
 ### v0.5.0 - February 18 2025
 
 #### Added

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -135,12 +135,14 @@ func init() {
 	reviseTestSuiteCmd.Flags().String(testSuiteSystemKey, "", "A new name or ID of the system that the new test suite is designed for.")
 	// Description [optional]
 	reviseTestSuiteCmd.Flags().String(testSuiteDescriptionKey, "", "A new description for the test suite revision.")
+	// Show on Summary [optional]
+	reviseTestSuiteCmd.Flags().Bool(testSuiteShowOnSummaryKey, false, "Should latest results of this test suite be displayed on the overview dashboard?")
 	// Metrics build
 	reviseTestSuiteCmd.Flags().String(testSuiteMetricsBuildKey, "", "A new ID of the metrics build to use in this test suite revision. To unset an existing metrics build, pass a nil uuid (00000000-0000-0000-0000-000000000000).")
 	// Experiences
 	reviseTestSuiteCmd.Flags().String(testSuiteExperiencesKey, "", "A list of updated experience names or list of experience IDs to have in the test suite revision.")
 	// We need something to revise!
-	reviseTestSuiteCmd.MarkFlagsOneRequired(testSuiteNameKey, testSuiteSystemKey, testSuiteDescriptionKey, testSuiteMetricsBuildKey, testSuiteExperiencesKey)
+	reviseTestSuiteCmd.MarkFlagsOneRequired(testSuiteNameKey, testSuiteSystemKey, testSuiteDescriptionKey, testSuiteMetricsBuildKey, testSuiteExperiencesKey, testSuiteShowOnSummaryKey)
 	testSuiteCmd.AddCommand(reviseTestSuiteCmd)
 
 	// List Test Suite
@@ -299,6 +301,10 @@ func reviseTestSuite(ccmd *cobra.Command, args []string) {
 
 	if viper.IsSet(testSuiteDescriptionKey) {
 		reviseRequest.Description = Ptr(viper.GetString(testSuiteDescriptionKey))
+	}
+
+	if viper.IsSet(testSuiteShowOnSummaryKey) {
+		reviseRequest.ShowOnSummary = Ptr(viper.GetBool(testSuiteShowOnSummaryKey))
 	}
 
 	if viper.IsSet(testSuiteSystemKey) {


### PR DESCRIPTION
# Description of change

The ReSim App supports displaying the latest summary of a test suite's execution on the 'Overview' page. This change allows users of the CLI to revise existing test suites to either set or unset this flag.

## Guide to reproduce test results

Run the E2E test.

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.