### PR TITLE
Allow Existing Builds to Be Used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.9.0 - March 12 2025
+
+#### Changed
+
+- The `resim ingest` command now supports using a custom log ingestion build ID, to allow you to preprocess a log. It can be run with `--build-id`. This is mutually exclusive with the `--branch` and `--version` flags.
+
 ### v0.8.0 - March 12 2025
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
-### v0.9.0 - March 12 2025
+### v0.9.0 - March 13 2025
 
 #### Changed
 

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -4675,12 +4675,14 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 
 	// Check the MuTex parameters:
 	output = s.runCommand(createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, fourthLogName, logLocation, secondLogTags, Ptr(existingBuildID), GithubTrue), ExpectError)
-	const flagGroupTemplate = "if any flags in the group [%[1]v %[2]v] are set none of the others can be; [%[1]v %[2]v] were all set"
-	s.Contains(output.StdErr, fmt.Sprintf(flagGroupTemplate, "build-id", "system"))
+	s.Contains(output.StdErr, "build-id")
+	s.Contains(output.StdErr, "system")
 	output = s.runCommand(createIngestedLog(projectID, nil, &firstBranchName, nil, metricsBuildID, fourthLogName, logLocation, secondLogTags, Ptr(existingBuildID), GithubTrue), ExpectError)
-	s.Contains(output.StdErr, fmt.Sprintf(flagGroupTemplate, "build-id", "branch"))
+	s.Contains(output.StdErr, "build-id")
+	s.Contains(output.StdErr, "branch")
 	output = s.runCommand(createIngestedLog(projectID, nil, nil, &firstVersion, metricsBuildID, fourthLogName, logLocation, secondLogTags, Ptr(existingBuildID), GithubTrue), ExpectError)
-	s.Contains(output.StdErr, fmt.Sprintf(flagGroupTemplate, "build-id", "version"))
+	s.Contains(output.StdErr, "build-id")
+	s.Contains(output.StdErr, "version")
 }
 
 func checkBatchComplete(s *EndToEndTestSuite, projectID uuid.UUID, batchID uuid.UUID) (bool, int) {


### PR DESCRIPTION
# Description of change

Extends the ReSim CLI to support using a custom, existing build to ingest a log.

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.