### PR TITLE
Metrics Build Override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes in this section will be included in the next release.
 #### Added
 
 - A new `ingest` command now supports ingesting existing logs -- from field testing, for example -- into the ReSim platform and running metrics on them. It works by importing a log with a given name and cloud storage location then running metrics on it. For more information see the [ReSim docs](https://docs.resim.ai/guides/log-ingest) for more details.
+- The test suite run command now supports a `--metrics-build-override` flag to allow you to take advantage of the test suite grouping, but test out a new metrics build.
 
 ### v0.7.0 - February 26 2025
 

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -83,6 +83,7 @@ const (
 	testSuiteShowOnSummaryKey           = "show-on-summary"
 	testSuiteBatchNameKey               = "batch-name"
 	testSuiteAllowableFailurePercentKey = "allowable-failure-percent"
+	testSuiteMetricsBuildOverrideKey    = "metrics-build-override"
 )
 
 func init() {
@@ -171,6 +172,8 @@ func init() {
 	// Optional: Friendly name
 	runTestSuiteCmd.Flags().String(testSuiteBatchNameKey, "", "An optional name for the batch. If not supplied, ReSim generates a pseudo-unique name e.g rejoicing-aquamarine-starfish. This name need not be unique, but uniqueness is recommended to make it easier to identify batches.")
 	runTestSuiteCmd.Flags().Int(testSuiteAllowableFailurePercentKey, 0, "An optional percentage (0-100) that determines the maximum percentage of tests that can have an execution error and have aggregate metrics be computed and consider the batch successfully completed. If not supplied, ReSim defaults to 0, which means that the batch will only be considered successful if all tests complete successfully.")
+	// Optional: Metrics build override:
+	runTestSuiteCmd.Flags().String(testSuiteMetricsBuildOverrideKey, "", "An optional ID of a metrics build to override the standard metrics build in this test suite run (which will be run as an adhoc batch).")
 	testSuiteCmd.AddCommand(runTestSuiteCmd)
 
 	// Test Suite Batches
@@ -491,7 +494,6 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 		revision = Ptr(viper.GetInt32(testSuiteRevisionKey))
 	}
 	testSuite := actualGetTestSuite(projectID, viper.GetString(testSuiteKey), revision)
-
 	buildID, err := uuid.Parse(viper.GetString(testSuiteBuildIDKey))
 	if err != nil {
 		log.Fatal("failed to parse build ID: ", err)
@@ -529,43 +531,90 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 		associatedAccount = viper.GetString(testSuiteAccountKey)
 	}
 
-	// Build the request body
-	body := api.TestSuiteBatchInput{
-		BuildID:           buildID,
-		Parameters:        &parameters,
-		AssociatedAccount: &associatedAccount,
-	}
-
-	// Add the pool labels if any
-	if len(poolLabels) > 0 {
-		body.PoolLabels = &poolLabels
-	}
-
-	// Add the batch name if any
-	if viper.IsSet(testSuiteBatchNameKey) {
-		body.BatchName = Ptr(viper.GetString(testSuiteBatchNameKey))
-	}
-
-	// Parse --allowable-failure-percent (if any provided)
-	if viper.IsSet(testSuiteAllowableFailurePercentKey) {
-		allowableFailurePercent := viper.GetInt(testSuiteAllowableFailurePercentKey)
-		if allowableFailurePercent < 0 || allowableFailurePercent > 100 {
-			log.Fatal("allowable failure percent must be between 0 and 100")
+	var batch api.Batch
+	// If the user supplies a metrics build override, we run an adhoc batch:
+	if viper.IsSet(testSuiteMetricsBuildOverrideKey) {
+		metricsBuildID, err := uuid.Parse(viper.GetString(testSuiteMetricsBuildOverrideKey))
+		if err != nil {
+			log.Fatal("failed to parse metrics-build ID: ", err)
 		}
-		body.AllowableFailurePercent = &allowableFailurePercent
-	}
+		// Build the request body
+		body := api.BatchInput{
+			BuildID:           &buildID,
+			MetricsBuildID:    &metricsBuildID,
+			ExperienceIDs:     &testSuite.Experiences,
+			Parameters:        &parameters,
+			AssociatedAccount: &associatedAccount,
+		}
 
-	// Make the request
-	response, err := Client.CreateBatchForTestSuiteRevisionWithResponse(context.Background(), projectID, testSuite.TestSuiteID, testSuite.TestSuiteRevision, body)
-	if err != nil {
-		log.Fatal("failed to run test suite:", err)
-	}
-	ValidateResponse(http.StatusCreated, "failed to run test suite", response.HTTPResponse, response.Body)
+		// Add the pool labels if any
+		if len(poolLabels) > 0 {
+			body.PoolLabels = &poolLabels
+		}
 
-	if response.JSON201 == nil {
-		log.Fatal("empty response")
+		// Add the batch name if any
+		if viper.IsSet(testSuiteBatchNameKey) {
+			body.BatchName = Ptr(viper.GetString(testSuiteBatchNameKey))
+		}
+
+		// Parse --allowable-failure-percent (if any provided)
+		if viper.IsSet(testSuiteAllowableFailurePercentKey) {
+			allowableFailurePercent := viper.GetInt(testSuiteAllowableFailurePercentKey)
+			if allowableFailurePercent < 0 || allowableFailurePercent > 100 {
+				log.Fatal("allowable failure percent must be between 0 and 100")
+			}
+			body.AllowableFailurePercent = &allowableFailurePercent
+		}
+
+		response, err := Client.CreateBatchWithResponse(context.Background(), projectID, body)
+		if err != nil {
+			log.Fatal("failed to run test suite override:", err)
+		}
+		ValidateResponse(http.StatusCreated, "failed to run test suite override", response.HTTPResponse, response.Body)
+
+		if response.JSON201 == nil {
+			log.Fatal("empty response")
+		}
+		batch = *response.JSON201
+	} else {
+		// Build the request body
+		body := api.TestSuiteBatchInput{
+			BuildID:           buildID,
+			Parameters:        &parameters,
+			AssociatedAccount: &associatedAccount,
+		}
+
+		// Add the pool labels if any
+		if len(poolLabels) > 0 {
+			body.PoolLabels = &poolLabels
+		}
+
+		// Add the batch name if any
+		if viper.IsSet(testSuiteBatchNameKey) {
+			body.BatchName = Ptr(viper.GetString(testSuiteBatchNameKey))
+		}
+
+		// Parse --allowable-failure-percent (if any provided)
+		if viper.IsSet(testSuiteAllowableFailurePercentKey) {
+			allowableFailurePercent := viper.GetInt(testSuiteAllowableFailurePercentKey)
+			if allowableFailurePercent < 0 || allowableFailurePercent > 100 {
+				log.Fatal("allowable failure percent must be between 0 and 100")
+			}
+			body.AllowableFailurePercent = &allowableFailurePercent
+		}
+
+		// Make the request
+		response, err := Client.CreateBatchForTestSuiteRevisionWithResponse(context.Background(), projectID, testSuite.TestSuiteID, testSuite.TestSuiteRevision, body)
+		if err != nil {
+			log.Fatal("failed to run test suite:", err)
+		}
+		ValidateResponse(http.StatusCreated, "failed to run test suite", response.HTTPResponse, response.Body)
+
+		if response.JSON201 == nil {
+			log.Fatal("empty response")
+		}
+		batch = *response.JSON201
 	}
-	batch := *response.JSON201
 
 	if !testSuiteGithub {
 		// Report the results back to the user


### PR DESCRIPTION
# Description of change

Extends the CLI to allow the user to pass a `metrics-build-override` when running a test suite. This has the advantage of allowing you to test out a new metrics build in a test suite without having to pass through a large list of experiences like one would normally need to do for an ad hoc batch.

## Guide to reproduce test results

```
CONFIG=staging RESIM_CLIENT_ID=<> RESIM_CLIENT_SECRET=<> go test -v -tags end_to_end -count 1 ./testing -testify.m TestTestSuites
```

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.