### PR TITLE
PRO-126: Add resim logs download subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.10.0 - March 14 2025
+
+#### Added
+
+- A new `download` subcommand has been added to the `logs` command. This allows you to download logs for a given job from the ReSim platform to your local machine.
+
 ### v0.9.0 - March 13 2025
 
 #### Changed

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -237,7 +237,7 @@ func downloadLogToFile(jobLog api.JobLog, file *os.File) error {
 		return errors.New("unable to download log: " + err.Error())
 	}
 	defer resp.Body.Close()
-	
+
 	bytesWritten, err := io.Copy(file, resp.Body)
 	if err != nil {
 		return errors.New("unable to write log file: " + err.Error())
@@ -295,7 +295,7 @@ func downloadLogs(ccmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal("unable to create log file: ", err)
 		}
-		
+
 		err = downloadLogToFile(jobLog, out)
 		if err != nil {
 			log.Fatal("unable to download log: ", err)
@@ -306,7 +306,7 @@ func downloadLogs(ccmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatal("unable to determine if log file is zipped: ", err)
 			}
-			
+
 			if isZipped {
 				s.Update(fmt.Sprintf("Unzipping %s...", *jobLog.FileName))
 				err = unzipFile(*out)

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -1,9 +1,16 @@
 package commands
 
 import (
+	"archive/zip"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
@@ -15,7 +22,7 @@ import (
 var (
 	logsCmd = &cobra.Command{
 		Use:     "logs",
-		Short:   "logs contains commands for creating and listing test logs. This is not expected to be used directly by users, but via CI/CD systems.",
+		Short:   "logs contains commands for listing and downloading test logs.",
 		Long:    ``,
 		Aliases: []string{"log"},
 	}
@@ -26,12 +33,22 @@ var (
 		Long:  ``,
 		Run:   listLogs,
 	}
+
+	downloadLogsCmd = &cobra.Command{
+		Use:     "download",
+		Short:   "download - Downloads the logs for a batch",
+		Long:    ``,
+		Run:     downloadLogs,
+		Aliases: []string{"fetch"},
+	}
 )
 
 const (
 	logProjectKey = "project"
 	logBatchIDKey = "batch-id"
 	logTestIDKey  = "test-id" // User-facing is test ID, internal is job id
+	logOutputKey  = "output"
+	logGithubKey  = "github"
 )
 
 func init() {
@@ -44,7 +61,46 @@ func init() {
 	listLogsCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
 	logsCmd.AddCommand(listLogsCmd)
 
+	downloadLogsCmd.Flags().String(logProjectKey, "", "The name or ID of the project to list logs with")
+	downloadLogsCmd.MarkFlagRequired(logProjectKey)
+	downloadLogsCmd.Flags().String(logBatchIDKey, "", "The UUID of the batch the logs are associated with")
+	downloadLogsCmd.MarkFlagRequired(logBatchIDKey)
+	downloadLogsCmd.Flags().String(logTestIDKey, "", "The UUID of the test in the batch to list logs for")
+	downloadLogsCmd.MarkFlagRequired(logTestIDKey)
+	downloadLogsCmd.Flags().String(logOutputKey, "", "The directory to download the logs to, must be empty if it already exists")
+	downloadLogsCmd.MarkFlagRequired(logOutputKey)
+	downloadLogsCmd.Flags().Bool(logGithubKey, false, "Whether to output log messages in GitHub Actions friendly format")
+	downloadLogsCmd.Flags().SetNormalizeFunc(aliasProjectNameFunc)
+	logsCmd.AddCommand(downloadLogsCmd)
+
 	rootCmd.AddCommand(logsCmd)
+}
+
+func listJobLogsForJob(projectID uuid.UUID, batchID uuid.UUID, testID uuid.UUID) ([]api.JobLog, error) {
+	logs := []api.JobLog{}
+	var pageToken *string = nil
+	for {
+		response, err := Client.ListJobLogsForJobWithResponse(context.Background(), projectID, batchID, testID, &api.ListJobLogsForJobParams{
+			PageToken: pageToken,
+			PageSize:  Ptr(100),
+		})
+		if err != nil {
+			return nil, err
+		}
+		ValidateResponse(http.StatusOK, "unable to list logs", response.HTTPResponse, response.Body)
+		if response.JSON200.Logs == nil {
+			return nil, errors.New("log list in response is nil")
+		}
+		responseLogs := *response.JSON200.Logs
+		logs = append(logs, responseLogs...)
+
+		if response.JSON200.NextPageToken != nil && *response.JSON200.NextPageToken != "" {
+			pageToken = response.JSON200.NextPageToken
+		} else {
+			break
+		}
+	}
+	return logs, nil
 }
 
 func listLogs(ccmd *cobra.Command, args []string) {
@@ -59,28 +115,195 @@ func listLogs(ccmd *cobra.Command, args []string) {
 		log.Fatal("unable to parse test ID: ", err)
 	}
 
-	logs := []api.JobLog{}
-	var pageToken *string = nil
-	for {
-		response, err := Client.ListJobLogsForJobWithResponse(context.Background(), projectID, batchID, testID, &api.ListJobLogsForJobParams{
-			PageToken: pageToken,
-			PageSize:  Ptr(100),
-		})
-		if err != nil {
-			log.Fatal("unable to list logs: ", err)
-		}
-		ValidateResponse(http.StatusOK, "unable to list logs", response.HTTPResponse, response.Body)
-		if response.JSON200.Logs == nil {
-			log.Fatal("unable to list logs")
-		}
-		responseLogs := *response.JSON200.Logs
-		logs = append(logs, responseLogs...)
-
-		if response.JSON200.NextPageToken != nil && *response.JSON200.NextPageToken != "" {
-			pageToken = response.JSON200.NextPageToken
-		} else {
-			break
-		}
+	logs, err := listJobLogsForJob(projectID, batchID, testID)
+	if err != nil {
+		log.Fatal("unable to fetch logs: ", err)
 	}
 	OutputJson(logs)
+}
+
+func isFileZipped(f os.File) (bool, error) {
+	info, err := os.Stat(f.Name())
+	if err != nil {
+		return false, errors.New("could not 'stat' file")
+	}
+
+	fileHead := make([]byte, 512)
+	if info.Size() < 512 {
+		fileHead = make([]byte, info.Size())
+	}
+
+	_, err = f.Read(fileHead)
+	if err != nil {
+		return false, errors.Join(errors.New("failed to read file to determine content type"), err)
+	}
+
+	thisFileType := http.DetectContentType(fileHead)
+	return thisFileType == "application/zip", nil
+}
+
+func unzipFile(zippedFile os.File) error {
+	zippedFilePath, err := filepath.Abs(zippedFile.Name())
+	if err != nil {
+		return errors.New("failed to read zip file")
+	}
+
+	r, err := zip.OpenReader(zippedFilePath)
+	if err != nil {
+		return errors.New("failed to read zip file")
+	}
+	var deferredErr error
+	defer func() {
+		if err := r.Close(); err != nil {
+			deferredErr = errors.New("failed to close zip file")
+		}
+	}()
+
+	dest := filepath.Dir(zippedFilePath)
+	err = os.MkdirAll(dest, 0o777)
+	if err != nil {
+		return errors.New("unable to make destination directory for zip file")
+	}
+	err = os.Chmod(dest, 0o777)
+	if err != nil {
+		return errors.New("could not chmod destination directory")
+	}
+
+	// Closure to address file descriptors issue with all the deferred .Close() methods
+	extractAndWriteFile := func(f *zip.File) error {
+		var deferredErr error
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := rc.Close(); err != nil {
+				if deferredErr == nil {
+					// this is the second deferred function (written first) so don't overwrite the error
+					deferredErr = errors.New("failed to close unzipped file")
+				}
+			}
+		}()
+
+		path := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip (Directory traversal)
+		if !strings.HasPrefix(path, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", path)
+		}
+
+		if f.FileInfo().IsDir() {
+			err := os.MkdirAll(path, f.Mode())
+			if err != nil {
+				return err
+			}
+		} else {
+			err := os.MkdirAll(filepath.Dir(path), 0o777)
+			if err != nil {
+				return err
+			}
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					deferredErr = errors.New("failed to close unzipped file")
+				}
+			}()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		}
+		return deferredErr
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return errors.New("could not unzip file")
+		}
+	}
+	return deferredErr
+}
+
+func downloadLogs(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(logProjectKey))
+	batchID, err := uuid.Parse(viper.GetString(logBatchIDKey))
+	if err != nil || batchID == uuid.Nil {
+		log.Fatal("unable to parse batch ID: ", err)
+	}
+
+	testID, err := uuid.Parse(viper.GetString(logTestIDKey))
+	if err != nil || testID == uuid.Nil {
+		log.Fatal("unable to parse test ID: ", err)
+	}
+
+	outputDir := viper.GetString(logOutputKey)
+	// if the directory exists, we need to check if it is empty
+	// otherwise, we need to create it
+	if files, err := os.ReadDir(outputDir); !os.IsNotExist(err) {
+		if err != nil {
+			log.Fatal("unable to read output directory: ", err)
+		}
+		if len(files) > 0 {
+			log.Fatal("output directory is not empty: ", outputDir)
+		}	
+	} else {
+		os.MkdirAll(outputDir, 0755)
+	}
+
+	outputDir, err = filepath.Abs(outputDir)
+	if err != nil {
+		log.Fatal("unable to get absolute path for output directory: ", err)
+	}
+
+	s := NewSpinner(ccmd)
+	s.Start("Getting list of logs...")
+
+	logs, err := listJobLogsForJob(projectID, batchID, testID)
+	if err != nil {
+		log.Fatal("unable to fetch logs: ", err)
+	}
+
+	for _, jobLog := range logs {
+		filePath := filepath.Join(outputDir, *jobLog.FileName)
+		resp, err := http.Get(*jobLog.LogOutputLocation)
+
+		s.Update(fmt.Sprintf("Downloading %s...", *jobLog.FileName))
+		
+		if err != nil {
+			log.Fatal("unable to download log: ", err)
+		}
+		defer resp.Body.Close()
+		out, err := os.Create(filePath)
+		if err != nil {
+			log.Fatal("unable to create log file: ", err)
+		}
+		defer out.Close()
+		bytesWritten, err := io.Copy(out, resp.Body)
+		if err != nil {
+			log.Fatal("unable to write log file: ", err)
+		}
+		if bytesWritten != *jobLog.FileSize {
+			log.Fatal("wrote ", bytesWritten, " bytes to ", filePath, " but expected ", *jobLog.FileSize)
+		}
+		out.Seek(0, io.SeekStart)
+		isZipped, err := isFileZipped(*out)
+		if err != nil {
+			log.Fatal("unable to determine if log file is zipped: ", err)
+		}
+		if *jobLog.LogType == api.ARCHIVELOG && isZipped {
+			s.Update(fmt.Sprintf("Unzipping %s...", *jobLog.FileName))
+			// unzip the file
+			err = unzipFile(*out)
+			if err != nil {
+				log.Fatal("unable to unzip log file: ", err)
+			}
+		}
+	}
+
+	s.Stop(fmt.Sprintf("Downloaded %d logs to %s\n", len(logs), outputDir))
 }

--- a/cmd/resim/commands/spinner.go
+++ b/cmd/resim/commands/spinner.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"io"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+)
+
+type Spinner struct {
+	spinner *spinner.Spinner
+	ccmd *cobra.Command
+}
+
+func NewSpinner(ccmd *cobra.Command) *Spinner {
+	return &Spinner{
+		spinner: spinner.New(spinner.CharSets[14], 100 * time.Millisecond),
+		ccmd: ccmd,
+	}
+}
+
+func (s *Spinner) Start(msg string) {
+	s.spinner.HideCursor = false
+	s.spinner.Suffix = " " + msg
+	if s.ccmd.Flag(logGithubKey) != nil && s.ccmd.Flag(logGithubKey).Value.String() == "true" {
+		s.spinner.Writer = io.Discard
+	}
+	s.spinner.Start()
+}
+
+func (s *Spinner) Stop(finalMsg string) {
+	s.spinner.FinalMSG = finalMsg
+	s.spinner.Stop()
+}
+
+func (s *Spinner) Update(msg string) {
+	s.spinner.Suffix = " " + msg
+}

--- a/cmd/resim/commands/spinner.go
+++ b/cmd/resim/commands/spinner.go
@@ -10,13 +10,13 @@ import (
 
 type Spinner struct {
 	spinner *spinner.Spinner
-	ccmd *cobra.Command
+	ccmd    *cobra.Command
 }
 
 func NewSpinner(ccmd *cobra.Command) *Spinner {
 	return &Spinner{
-		spinner: spinner.New(spinner.CharSets[14], 100 * time.Millisecond),
-		ccmd: ccmd,
+		spinner: spinner.New(spinner.CharSets[14], 100*time.Millisecond),
+		ccmd:    ccmd,
 	}
 }
 
@@ -29,8 +29,10 @@ func (s *Spinner) Start(msg string) {
 	s.spinner.Start()
 }
 
-func (s *Spinner) Stop(finalMsg string) {
-	s.spinner.FinalMSG = finalMsg
+func (s *Spinner) Stop(finalMsg *string) {
+	if finalMsg != nil {
+		s.spinner.FinalMSG = *finalMsg
+	}
 	s.spinner.Stop()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ retract (
 )
 
 require (
+	github.com/briandowns/spinner v1.23.2
 	github.com/cli/browser v1.3.0
 	github.com/deepmap/oapi-codegen v1.13.4
 	github.com/fatih/color v1.14.1
@@ -20,7 +21,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -30,6 +30,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
+	golang.org/x/term v0.22.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
+github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.10.0-rc/go.mod h1:ElCzW+ufi8qKqNW0FY314xriJhyJhuoJ3gFZdAHF7NM=
 github.com/bytedance/sonic v1.10.0-rc3 h1:uNSnscRapXTwUgTyOF0GVljYD08p9X/Lbr9MweSV3V0=
@@ -21,8 +23,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deepmap/oapi-codegen v1.13.4 h1:lRRQ8JAXaz5/4oidKFyk3fFZFQsbv0BzRtvDKDnvIfM=
 github.com/deepmap/oapi-codegen v1.13.4/go.mod h1:/h5nFQbTAMz4S/WtBz8sBfamlGByYKDr21O2uoNgCYI=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -209,6 +209,8 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
+golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=


### PR DESCRIPTION
# Description of change
Adds a subcommand to `resim logs` which downloads the logs for a given job.

Needs https://github.com/resim-ai/rerun/pull/1682 for test data.

## Guide to reproduce test results

Try it out!

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.