### PR TITLE
Bulk Log Ingest

### DIFF
--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -66,7 +66,7 @@ func init() {
 	ingestLogCmd.Flags().String(ingestLogNameKey, "", "A project-unique name to use in processing this log, often a run id.")
 	// Log Location
 	ingestLogCmd.Flags().String(ingestExperienceLocationKey, "", "An S3 prefix, which ReSim has access to, where the log is stored.")
-	ingestLogCmd.Flags().StringArray(ingestLogKey, []string{}, "Log name and location pairs in the format 'name=s3://location'. Can be specified multiple times.")
+	ingestLogCmd.Flags().StringSlice(ingestLogKey, []string{}, "Log name and location pairs in the format 'name=s3://location'. Can be specified multiple times.")
 	ingestLogCmd.Flags().String(ingestConfigFileKey, "", "Path to YAML file containing log configurations")
 	// Support the old way, a config file, and the --log flag mutually exclusively:
 	ingestLogCmd.MarkFlagsRequiredTogether(ingestLogNameKey, ingestExperienceLocationKey)
@@ -272,7 +272,7 @@ func getOrCreateBuild(client api.ClientWithResponsesInterface, projectID uuid.UU
 }
 
 func parseLogPairs(pairs []string) ([]logPair, error) {
-	var results []logPair
+	results := []logPair{}
 	for _, pair := range pairs {
 		parts := strings.SplitN(pair, "=", 2)
 		if len(parts) != 2 {

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
 	. "github.com/resim-ai/api-client/ptr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -33,6 +36,9 @@ const (
 	ingestGithubKey             = "github"
 	ingestMetricsBuildKey       = "metrics-build-id"
 	ingestBuildKey              = "build-id"
+	ingestLogKey                = "log"
+	ingestConfigFileKey         = "config-file"
+	ingestBatchNameKey          = "ingestion-name"
 
 	LogIngestURI = "public.ecr.aws/resim/open-builds/log-ingest:latest"
 )
@@ -58,13 +64,187 @@ func init() {
 	ingestLogCmd.MarkFlagRequired(ingestMetricsBuildKey)
 	// Log Name
 	ingestLogCmd.Flags().String(ingestLogNameKey, "", "A project-unique name to use in processing this log, often a run id.")
-	ingestLogCmd.MarkFlagRequired(ingestLogNameKey)
 	// Log Location
 	ingestLogCmd.Flags().String(ingestExperienceLocationKey, "", "An S3 prefix, which ReSim has access to, where the log is stored.")
-	ingestLogCmd.MarkFlagRequired(ingestExperienceLocationKey)
+	ingestLogCmd.Flags().StringArray(ingestLogKey, []string{}, "Log name and location pairs in the format 'name=s3://location'. Can be specified multiple times.")
+	ingestLogCmd.Flags().String(ingestConfigFileKey, "", "Path to YAML file containing log configurations")
+	// Support the old way, a config file, and the --log flag mutually exclusively:
+	ingestLogCmd.MarkFlagsRequiredTogether(ingestLogNameKey, ingestExperienceLocationKey)
+	ingestLogCmd.MarkFlagsOneRequired(ingestLogNameKey, ingestConfigFileKey, ingestLogKey)
+	ingestLogCmd.MarkFlagsMutuallyExclusive(ingestLogNameKey, ingestConfigFileKey)
+	ingestLogCmd.MarkFlagsMutuallyExclusive(ingestLogNameKey, ingestLogKey)
+	ingestLogCmd.MarkFlagsMutuallyExclusive(ingestConfigFileKey, ingestLogKey)
 	// Tags
 	ingestLogCmd.Flags().StringSlice(ingestExperienceTagsKey, []string{}, "Comma-separated list of tags to apply. ReSim will automatically add the `ingested-via-resim` tag.")
+	// Batch Name
+	ingestLogCmd.Flags().String(ingestBatchNameKey, "", "A memorable name for this batch of logs to ingest. If not provided, a default name will be generated.")
 	rootCmd.AddCommand(ingestLogCmd)
+}
+
+type logPair struct {
+	name     string
+	location string
+}
+type LogConfig struct {
+	Name     string `yaml:"name"`
+	Location string `yaml:"location"`
+}
+
+type LogsFile struct {
+	Logs []LogConfig `yaml:"logs"`
+}
+
+func ingestLog(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(batchProjectKey))
+	logIngestGithub := viper.GetBool(ingestGithubKey)
+	if !logIngestGithub {
+		fmt.Println("Ingesting a log...")
+	}
+
+	var buildID uuid.UUID
+	var err error
+	if viper.IsSet(ingestBuildKey) {
+		buildID, err = uuid.Parse(viper.GetString(ingestBuildKey))
+		if err != nil {
+			log.Fatal("invalid build ID")
+		}
+	} else {
+		// Create a build using the ReSim standard log ingest build:
+		systemID := getSystemID(Client, projectID, viper.GetString(ingestSystemKey), true)
+		// Check the branch exists:
+		branchID := getOrCreateBranchID(Client, projectID, viper.GetString(ingestBranchKey), logIngestGithub)
+		buildID = getOrCreateBuild(Client, projectID, branchID, systemID, LogIngestURI, viper.GetString(ingestVersionKey))
+	}
+
+	var logsToProcess []LogConfig
+
+	// Get logs from config file if provided
+	if viper.IsSet(ingestConfigFileKey) {
+		configLogs, err := readLogsFromConfig(viper.GetString(ingestConfigFileKey))
+		if err != nil {
+			log.Fatal("Error reading config file:", err)
+		}
+		logsToProcess = configLogs
+	}
+
+	// Add logs from command line flags if provided
+	if viper.IsSet(ingestLogKey) {
+		logPairs, err := parseLogPairs(viper.GetStringSlice(ingestLogKey))
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, pair := range logPairs {
+			logsToProcess = append(logsToProcess, LogConfig{
+				Name:     pair.name,
+				Location: pair.location,
+			})
+		}
+	}
+
+	// Use the old way of `--log-name` and `--log-location`
+	if viper.IsSet(ingestLogNameKey) && viper.IsSet(ingestExperienceLocationKey) {
+		logsToProcess = append(logsToProcess, LogConfig{
+			Name:     viper.GetString(ingestLogNameKey),
+			Location: viper.GetString(ingestExperienceLocationKey),
+		})
+	}
+
+	// Validate we have at least one log to process
+	if len(logsToProcess) == 0 {
+		log.Fatal("No logs specified. Use --log flags or --config-file to specify logs to ingest")
+	}
+
+	// Check for duplicate names
+	nameSet := make(map[string]bool)
+	for _, l := range logsToProcess {
+		if nameSet[l.Name] {
+			log.Fatal("Duplicate log name found:", l.Name)
+		}
+		nameSet[l.Name] = true
+	}
+
+	// Process each log
+	experienceIDs := []uuid.UUID{}
+	for _, logConfig := range logsToProcess {
+		if !logIngestGithub {
+			fmt.Printf("Processing log: %s\n", logConfig.Name)
+		}
+
+		// Create the experience
+		experienceBody := api.CreateExperienceInput{
+			Name:        logConfig.Name,
+			Location:    logConfig.Location,
+			Description: "Ingested into ReSim via the CLI",
+		}
+		experienceResponse, err := Client.CreateExperienceWithResponse(context.Background(), projectID, experienceBody)
+		if err != nil {
+			log.Fatal("unable to create experience:", err)
+		}
+		ValidateResponse(http.StatusCreated, "unable to create experience", experienceResponse.HTTPResponse, experienceResponse.Body)
+		if experienceResponse.JSON201 == nil {
+			log.Fatal("empty response")
+		}
+		experience := *experienceResponse.JSON201
+		experienceID := experience.ExperienceID
+		experienceIDs = append(experienceIDs, experienceID)
+		// Merge global tags with log-specific tags
+		allTags := append([]string{}, viper.GetStringSlice(ingestExperienceTagsKey)...)
+		allTags = append(allTags, "ingested-via-resim")
+
+		// Create or get any associated experience tags:
+		for _, tag := range allTags {
+			getOrCreateExperienceTagID(Client, projectID, tag)
+			tagExperienceHelper(Client, projectID, experienceID, tag)
+		}
+	}
+
+	// Process the associated account: by default, we try to get from CI/CD environment variables
+	// Otherwise, we use the account flag. The default is "".
+	associatedAccount := GetCIEnvironmentVariableAccount()
+	if viper.IsSet(batchAccountKey) {
+		associatedAccount = viper.GetString(batchAccountKey)
+	}
+
+	// Validate the metrics build exists:
+	metricsBuildID, err := uuid.Parse(viper.GetString(ingestMetricsBuildKey))
+	if err != nil || metricsBuildID == uuid.Nil {
+		log.Fatal("Metrics build ID is required")
+	}
+
+	// Finally, create a batch to process the log(s)
+	batchBody := api.BatchInput{
+		ExperienceIDs:     Ptr(experienceIDs),
+		BuildID:           Ptr(buildID),
+		AssociatedAccount: &associatedAccount,
+		TriggeredVia:      DetermineTriggerMethod(),
+		MetricsBuildID:    Ptr(metricsBuildID),
+	}
+	if viper.IsSet(ingestBatchNameKey) {
+		batchBody.BatchName = Ptr(viper.GetString(ingestBatchNameKey))
+	}
+
+	batchResponse, err := Client.CreateBatchWithResponse(context.Background(), projectID, batchBody)
+	if err != nil {
+		log.Fatal("unable to create batch:", err)
+	}
+	ValidateResponse(http.StatusCreated, "unable to create batch", batchResponse.HTTPResponse, batchResponse.Body)
+	if batchResponse.JSON201 == nil {
+		log.Fatal("empty response")
+	}
+	batch := *batchResponse.JSON201
+	if batch.BatchID == nil {
+		log.Fatal("no batch ID")
+	}
+	// Report the results back to the user
+	if logIngestGithub {
+		fmt.Printf("batch_id=%s\n", batch.BatchID.String())
+	} else {
+		fmt.Println("Ingested logs successfully!")
+		fmt.Printf("Batch ID: %s\n", batch.BatchID.String())
+		if resimURL := maybeGenerateResimURL(projectID, *batch.BatchID); resimURL != "" {
+			fmt.Printf("View the results at %s\n", resimURL)
+		}
+	}
 }
 
 // Index over the imageURI and the version to determine whether or not we want to create a new build:
@@ -91,122 +271,58 @@ func getOrCreateBuild(client api.ClientWithResponsesInterface, projectID uuid.UU
 	return build.BuildID
 }
 
-func ingestLog(ccmd *cobra.Command, args []string) {
-	projectID := getProjectID(Client, viper.GetString(batchProjectKey))
-	logIngestGithub := viper.GetBool(ingestGithubKey)
-	if !logIngestGithub {
-		fmt.Println("Ingesting a log...")
-	}
-
-	var buildID uuid.UUID
-	var err error
-	if viper.IsSet(ingestBuildKey) {
-		buildID, err = uuid.Parse(viper.GetString(ingestBuildKey))
-		if err != nil {
-			log.Fatal("invalid build ID")
+func parseLogPairs(pairs []string) ([]logPair, error) {
+	var results []logPair
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid log pair format: %s (expected 'name=location')", pair)
 		}
-	} else {
-		// Create a build using the ReSim standard log ingest build:
-		systemID := getSystemID(Client, projectID, viper.GetString(ingestSystemKey), true)
-		// Check the branch exists:
-		branchID := getOrCreateBranchID(Client, projectID, viper.GetString(ingestBranchKey), logIngestGithub)
-		buildID = getOrCreateBuild(Client, projectID, branchID, systemID, LogIngestURI, viper.GetString(ingestVersionKey))
-	}
 
-	// Create the experience
-	experienceBody := api.CreateExperienceInput{
-		Name:        viper.GetString(ingestLogNameKey),
-		Location:    viper.GetString(ingestExperienceLocationKey),
-		Description: "Ingested into ReSim via the CLI",
-	}
-	experienceResponse, err := Client.CreateExperienceWithResponse(context.Background(), projectID, experienceBody)
-	if err != nil {
-		log.Fatal("unable to create experience:", err)
-	}
-	ValidateResponse(http.StatusCreated, "unable to create experience", experienceResponse.HTTPResponse, experienceResponse.Body)
-	if experienceResponse.JSON201 == nil {
-		log.Fatal("empty response")
-	}
-	experience := *experienceResponse.JSON201
-	experienceID := experience.ExperienceID
+		name := strings.TrimSpace(parts[0])
+		location := strings.TrimSpace(parts[1])
 
-	// Create or get any associated experience tags:
-	experienceTags := viper.GetStringSlice(ingestExperienceTagsKey)
-	experienceTags = append(experienceTags, "ingested-via-resim")
-	for _, tag := range experienceTags {
-		getOrCreateExperienceTagID(Client, projectID, tag)
-		tagExperienceHelper(Client, projectID, experienceID, tag)
-	}
-
-	// Process the associated account: by default, we try to get from CI/CD environment variables
-	// Otherwise, we use the account flag. The default is "".
-	associatedAccount := GetCIEnvironmentVariableAccount()
-	if viper.IsSet(batchAccountKey) {
-		associatedAccount = viper.GetString(batchAccountKey)
-	}
-
-	// Validate the metrics build exists:
-	metricsBuildID, err := uuid.Parse(viper.GetString(ingestMetricsBuildKey))
-	if err != nil || metricsBuildID == uuid.Nil {
-		log.Fatal("Metrics build ID is required")
-	}
-
-	// Finally, create a batch to process the log
-	ingestionBatchName := fmt.Sprintf("Ingested Log: %s", experience.Name)
-	batchBody := api.BatchInput{
-		BatchName:         Ptr(ingestionBatchName),
-		ExperienceIDs:     Ptr([]uuid.UUID{experienceID}),
-		BuildID:           Ptr(buildID),
-		AssociatedAccount: &associatedAccount,
-		TriggeredVia:      DetermineTriggerMethod(),
-		MetricsBuildID:    Ptr(metricsBuildID),
-	}
-
-	batchResponse, err := Client.CreateBatchWithResponse(context.Background(), projectID, batchBody)
-	if err != nil {
-		log.Fatal("unable to create batch:", err)
-	}
-	ValidateResponse(http.StatusCreated, "unable to create batch", batchResponse.HTTPResponse, batchResponse.Body)
-	if batchResponse.JSON201 == nil {
-		log.Fatal("empty response")
-	}
-	batch := *batchResponse.JSON201
-	if batch.BatchID == nil {
-		log.Fatal("no batch ID")
-	}
-
-	// Get the jobs for this batch:
-	jobsResponse, err := Client.ListJobsWithResponse(context.Background(), projectID, *batch.BatchID, &api.ListJobsParams{
-		PageSize:  Ptr(10),
-		PageToken: nil,
-	})
-	if err != nil {
-		log.Fatal("unable to get jobs for batch:", err)
-	}
-	ValidateResponse(http.StatusOK, "unable to get jobs for batch", jobsResponse.HTTPResponse, jobsResponse.Body)
-	if jobsResponse.JSON200 == nil {
-		log.Fatal("empty response")
-	}
-	jobs := *jobsResponse.JSON200.Jobs
-	if len(jobs) != 1 {
-		log.Fatal("expected 1 job, got", len(jobs))
-	}
-	theJob := jobs[0]
-	jobID := theJob.JobID
-
-	// Report the results back to the user
-	if logIngestGithub {
-		fmt.Printf("batch_id=%s\n", batch.BatchID.String())
-	} else {
-		fmt.Println("Ingested log successfully!")
-		fmt.Printf("Batch ID: %s\n", batch.BatchID.String())
-		if resimURL := maybeGenerateResimURL(projectID, *batch.BatchID, *jobID); resimURL != "" {
-			fmt.Printf("View the results at %s\n", resimURL)
+		if name == "" || location == "" {
+			return nil, fmt.Errorf("both name and location must be non-empty in pair: %s", pair)
 		}
+
+		results = append(results, logPair{
+			name:     name,
+			location: location,
+		})
 	}
+	return results, nil
 }
 
-func maybeGenerateResimURL(projectID uuid.UUID, batchID uuid.UUID, jobID uuid.UUID) string {
+func readLogsFromConfig(configPath string) ([]LogConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var config LogsFile
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if len(config.Logs) == 0 {
+		return nil, fmt.Errorf("no logs defined in config file")
+	}
+
+	// Validate the config
+	for i, log := range config.Logs {
+		if log.Name == "" {
+			return nil, fmt.Errorf("log at index %d missing name", i)
+		}
+		if log.Location == "" {
+			return nil, fmt.Errorf("log at index %d missing location", i)
+		}
+	}
+
+	return config.Logs, nil
+}
+
+func maybeGenerateResimURL(projectID uuid.UUID, batchID uuid.UUID) string {
 	// Generate resim url for the test:
 	apiURL := viper.GetString(urlKey)
 	baseURL := ""
@@ -216,7 +332,7 @@ func maybeGenerateResimURL(projectID uuid.UUID, batchID uuid.UUID, jobID uuid.UU
 		baseURL = "https://app.resim.ai/"
 	}
 	if baseURL != "" {
-		return fmt.Sprintf("%s/projects/%s/batches/%s/jobs/%s", baseURL, projectID.String(), batchID.String(), jobID.String())
+		return fmt.Sprintf("%s/projects/%s/batches/%s", baseURL, projectID.String(), batchID.String())
 	}
 	return ""
 }

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -37,7 +37,7 @@ const (
 	ingestMetricsBuildKey       = "metrics-build-id"
 	ingestBuildKey              = "build-id"
 	ingestLogKey                = "log"
-	ingestConfigFileKey         = "config-file"
+	ingestConfigFileKey         = "log-config"
 	ingestBatchNameKey          = "ingestion-name"
 
 	LogIngestURI = "public.ecr.aws/resim/open-builds/log-ingest:latest"


### PR DESCRIPTION
# Description of change

Extends the ReSim CLI's log ingestion functionality with a few variations in how to ingest logs that aim to support ingesting multiple logs at one time. 

First `--log "logname=s3path" --log "logname=s3path"` can be used. Alternatively, a YAML file:

```
logs:
  - name: "log1"
    location: "s3://bucket/path1"
  - name: "log2"
    location: "s3://bucket/path2"
```

## Guide to reproduce test results

Run t'end to end test

## Checklist

- [X] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.