### PR TITLE
WOB-3105 | allow for updating of build names

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+RESIM_CLIENT_ID="key found in .resim/cache.json"
+RESIM_CLIENT_SECRET="token value found in .resim/cache.json"
+CONFIG="staging"
+DEPLOYMENT=""

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,4 @@
+GRAPHQL_API_ENDPOINT="https://bff.resim.io/graphql"
 RESIM_CLIENT_ID="key found in .resim/cache.json"
 RESIM_CLIENT_SECRET="token value found in .resim/cache.json"
 CONFIG="staging"

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+dotenv .env.local

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Test
-        run: go test ./... -race 
+        run: go test ./... -race
 
   e2e:
-    name: Run end-to-end test    
+    name: Run end-to-end test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,4 +43,4 @@ jobs:
           CONFIG: staging
           RESIM_CLIENT_ID: ${{ secrets.RESIM_CLIENT_ID }}
           RESIM_CLIENT_SECRET: ${{ secrets.RESIM_CLIENT_SECRET }}
-        run: go test -v -timeout 30m -tags end_to_end -count 1 ./testing
+        run: go test -v -timeout 45m -tags end_to_end -count 1 ./testing

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -43,4 +43,6 @@ jobs:
           CONFIG: staging
           RESIM_CLIENT_ID: ${{ secrets.RESIM_CLIENT_ID }}
           RESIM_CLIENT_SECRET: ${{ secrets.RESIM_CLIENT_SECRET }}
+
+        # FIXME: This is so long. Please make them run in parallel.
         run: go test -v -timeout 45m -tags end_to_end -count 1 ./testing

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 go.work
 
 cmd/resim/resim
+
+.env.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Changelog
 
-See also <https://docs.resim.ai/changelog/> for all ReSim changes
-
 ## ReSim CLI
 
 ### Unreleased
 
 Changes in this section will be included in the next release.
 
-### v0.13.0
+### v0.13.0 - April 8, 2025
 
-- Build create/update now allows for a `--name` flag to set the build's name. `--description` had been used for this purpose previously. If `--name` is not provided, `--description` will be used to set the build's name, otherwise it will be used to set the build's description.
+- Build create/update now allows for a `--name` flag to set the build's name. If `--name` is not provided, `--description` will be used to set the build's name, otherwise it will be used to set the build's description.
 
 ### v0.12.0 - March 25 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changes in this section will be included in the next release.
 
 ### v0.13.0
 
-- Build creation now requires a `--name` flag instead of `--description`. `--description` is still accepted when creating or updating a build, and will still set the build's name. `--long-description` may be used to set the build's description.
+- Build create/update now allows for a `--name` flag to set the build's name. `--description` had been used for this purpose previously. If `--name` is not provided, `--description` will be used to set the build's name, otherwise it will be used to set the build's description.
 
 ### v0.12.0 - March 25 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@
 
 Changes in this section will be included in the next release.
 
-### v0.15.0 - April 8, 2025
+### v0.15.0 - April 10, 2025
 
-- Build create/update now allows for a `--name` flag to set the build's name. If `--name` is not provided, `--description` will be used to set the build's name, otherwise it will be used to set the build's description.
+- Build create/update now accepts a `--name` flag to set the build's name. If `--name` is not provided but `--description` is, the description value will be used for the build's name (matching current behavior). The `--description` flag is used to set the build's description when provided alongside `--name`. In a future release, `--name` will become a required parameter and `--description` will no longer be used to set the build's name, but will instead only be used to set its description.
 
 ### v0.14.0 - April 8 2025
 
 #### Changed
 
 - It is now possible to pass `pool-labels` to the `resim ingest` command to support log ingestion via the ReSim agent.
-
 
 ### v0.13.0 - April 7 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-See also https://docs.resim.ai/changelog/ for all ReSim changes
+See also <https://docs.resim.ai/changelog/> for all ReSim changes
 
 ## ReSim CLI
 
 ### Unreleased
 
 Changes in this section will be included in the next release.
+
+### v0.13.0
+
+- Build creation now requires a `--name` flag instead of `--description`. `--description` is still accepted when creating or updating a build, and will still set the build's name. `--long-description` may be used to set the build's description.
 
 ### v0.12.0 - March 25 2025
 
@@ -46,7 +50,7 @@ Changes in this section will be included in the next release.
 
 #### Changed
 
-- The `suites run` and `batches create`  commands now support using a separate delimiter for parameters: e.g. "key=value" to support cases where a colon is a natural part of the key e.g. `namespace::param=value`
+- The `suites run` and `batches create` commands now support using a separate delimiter for parameters: e.g. "key=value" to support cases where a colon is a natural part of the key e.g. `namespace::param=value`
 
 ### v0.6.0 - February 19 2025
 
@@ -60,7 +64,6 @@ Changes in this section will be included in the next release.
 
 - The ReSim Platform now supports container timeouts, which can be set when creating or updating an experience. The intention is to allow users to specify a timeout for the container that is running the experience. If the container runs longer than this, it will be terminated.
 - The ReSim CLI now supports updating experiences via `experiences update`. An experience can be updated with a new name, description, location, and container timeout.
-
 
 ### v0.4.1 - February 13 2025
 

--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -93,6 +93,7 @@ const (
 const (
 	ARCHIVELOG       LogType = "ARCHIVE_LOG"
 	CONTAINERLOG     LogType = "CONTAINER_LOG"
+	EMISSIONSLOG     LogType = "EMISSIONS_LOG"
 	ERRORLOG         LogType = "ERROR_LOG"
 	EXECUTIONLOG     LogType = "EXECUTION_LOG"
 	FOXGLOVEMCAPLOG  LogType = "FOXGLOVE_MCAP_LOG"
@@ -148,10 +149,10 @@ const (
 
 // Defines values for ReportStatus.
 const (
-	ReportStatusERROR     ReportStatus = "ERROR"
-	ReportStatusRUNNING   ReportStatus = "RUNNING"
-	ReportStatusSUBMITTED ReportStatus = "SUBMITTED"
-	ReportStatusSUCCEEDED ReportStatus = "SUCCEEDED"
+	ERROR     ReportStatus = "ERROR"
+	RUNNING   ReportStatus = "RUNNING"
+	SUBMITTED ReportStatus = "SUBMITTED"
+	SUCCEEDED ReportStatus = "SUCCEEDED"
 )
 
 // Defines values for TriggeredVia.
@@ -360,17 +361,30 @@ type Build struct {
 	AssociatedAccount AssociatedAccount `json:"associatedAccount"`
 	BranchID          BranchID          `json:"branchID"`
 	BuildID           BuildID           `json:"buildID"`
-	CreationTimestamp Timestamp         `json:"creationTimestamp"`
-	Description       BuildDescription  `json:"description"`
-	ImageUri          BuildImageUri     `json:"imageUri"`
-	OrgID             OrgID             `json:"orgID"`
-	ProjectID         ProjectID         `json:"projectID"`
-	SystemID          SystemID          `json:"systemID"`
-	UserID            UserID            `json:"userID"`
-	Version           BuildVersion      `json:"version"`
+
+	// BuildSpecification Build spec in YAML format.
+	BuildSpecification BuildSpecificationOutput `json:"buildSpecification"`
+	CreationTimestamp  Timestamp                `json:"creationTimestamp"`
+
+	// Description [DEPRECATED] This field was previously used to set the build's name. If both 'description' and 'name' are provided, 'name' will take precedence. In a future version, this field will be repurposed to store the build's description.
+	// Deprecated:
+	Description BuildDescription `json:"description"`
+	ImageUri    BuildImageUri    `json:"imageUri"`
+
+	// LongDescription [DEPRECATED] This field is temporarily being used to set the build's description. In a future version, the `description` field will be used instead.
+	// Deprecated:
+	LongDescription BuildLongDescription `json:"longDescription"`
+
+	// Name The name of the build. This replaces the previous usage of 'description'.
+	Name      BuildName    `json:"name"`
+	OrgID     OrgID        `json:"orgID"`
+	ProjectID ProjectID    `json:"projectID"`
+	SystemID  SystemID     `json:"systemID"`
+	UserID    UserID       `json:"userID"`
+	Version   BuildVersion `json:"version"`
 }
 
-// BuildDescription defines model for buildDescription.
+// BuildDescription [DEPRECATED] This field was previously used to set the build's name. If both 'description' and 'name' are provided, 'name' will take precedence. In a future version, this field will be repurposed to store the build's description.
 type BuildDescription = string
 
 // BuildID defines model for buildID.
@@ -378,6 +392,18 @@ type BuildID = openapi_types.UUID
 
 // BuildImageUri defines model for buildImageUri.
 type BuildImageUri = string
+
+// BuildLongDescription [DEPRECATED] This field is temporarily being used to set the build's description. In a future version, the `description` field will be used instead.
+type BuildLongDescription = string
+
+// BuildName The name of the build. This replaces the previous usage of 'description'.
+type BuildName = string
+
+// BuildSpecificationInput defines model for buildSpecificationInput.
+type BuildSpecificationInput = []byte
+
+// BuildSpecificationOutput Build spec in YAML format.
+type BuildSpecificationOutput = string
 
 // BuildVersion defines model for buildVersion.
 type BuildVersion = string
@@ -423,22 +449,58 @@ type CreateBranchInput struct {
 
 // CreateBuildForBranchInput defines model for createBuildForBranchInput.
 type CreateBuildForBranchInput struct {
-	AssociatedAccount *AssociatedAccount `json:"associatedAccount,omitempty"`
-	Description       *BuildDescription  `json:"description,omitempty"`
-	ImageUri          BuildImageUri      `json:"imageUri"`
-	SystemID          SystemID           `json:"systemID"`
-	Version           BuildVersion       `json:"version"`
+	AssociatedAccount  *AssociatedAccount       `json:"associatedAccount,omitempty"`
+	BuildSpecification *BuildSpecificationInput `json:"buildSpecification,omitempty"`
+
+	// Description [DEPRECATED] This field was previously used to set the build's name. If both 'description' and 'name' are provided, 'name' will take precedence. In a future version, this field will be repurposed to store the build's description.
+	// Deprecated:
+	Description *BuildDescription `json:"description,omitempty"`
+	ImageUri    *BuildImageUri    `json:"imageUri,omitempty"`
+
+	// LongDescription [DEPRECATED] This field is temporarily being used to set the build's description. In a future version, the `description` field will be used instead.
+	// Deprecated:
+	LongDescription *BuildLongDescription `json:"longDescription,omitempty"`
+
+	// Name The name of the build. This replaces the previous usage of 'description'.
+	Name     *BuildName   `json:"name,omitempty"`
+	SystemID SystemID     `json:"systemID"`
+	Version  BuildVersion `json:"version"`
+	union    json.RawMessage
 }
+
+// CreateBuildForBranchInput0 defines model for .
+type CreateBuildForBranchInput0 = interface{}
+
+// CreateBuildForBranchInput1 defines model for .
+type CreateBuildForBranchInput1 = interface{}
 
 // CreateBuildForSystemInput defines model for createBuildForSystemInput.
 type CreateBuildForSystemInput struct {
-	AssociatedAccount *AssociatedAccount `json:"associatedAccount,omitempty"`
-	BranchID          BranchID           `json:"branchID"`
-	Description       *BuildDescription  `json:"description,omitempty"`
-	ImageUri          BuildImageUri      `json:"imageUri"`
-	TriggeredVia      *TriggeredVia      `json:"triggeredVia,omitempty"`
-	Version           BuildVersion       `json:"version"`
+	AssociatedAccount  *AssociatedAccount       `json:"associatedAccount,omitempty"`
+	BranchID           BranchID                 `json:"branchID"`
+	BuildSpecification *BuildSpecificationInput `json:"buildSpecification,omitempty"`
+
+	// Description [DEPRECATED] This field was previously used to set the build's name. If both 'description' and 'name' are provided, 'name' will take precedence. In a future version, this field will be repurposed to store the build's description.
+	// Deprecated:
+	Description *BuildDescription `json:"description,omitempty"`
+	ImageUri    *BuildImageUri    `json:"imageUri,omitempty"`
+
+	// LongDescription [DEPRECATED] This field is temporarily being used to set the build's description. In a future version, the `description` field will be used instead.
+	// Deprecated:
+	LongDescription *BuildLongDescription `json:"longDescription,omitempty"`
+
+	// Name The name of the build. This replaces the previous usage of 'description'.
+	Name         *BuildName    `json:"name,omitempty"`
+	TriggeredVia *TriggeredVia `json:"triggeredVia,omitempty"`
+	Version      BuildVersion  `json:"version"`
+	union        json.RawMessage
 }
+
+// CreateBuildForSystemInput0 defines model for .
+type CreateBuildForSystemInput0 = interface{}
+
+// CreateBuildForSystemInput1 defines model for .
+type CreateBuildForSystemInput1 = interface{}
 
 // CreateExperienceInput defines model for createExperienceInput.
 type CreateExperienceInput struct {
@@ -1434,8 +1496,18 @@ type UpdateBatchInput struct {
 
 // UpdateBuildFields defines model for updateBuildFields.
 type UpdateBuildFields struct {
-	BranchID    *openapi_types.UUID `json:"branchID,omitempty"`
-	Description *string             `json:"description,omitempty"`
+	BranchID *openapi_types.UUID `json:"branchID,omitempty"`
+
+	// Description [DEPRECATED] This field was previously used to set the build's name. If both 'description' and 'name' are provided, 'name' will take precedence. In a future version, this field will be repurposed to store the build's description.
+	// Deprecated:
+	Description *BuildDescription `json:"description,omitempty"`
+
+	// LongDescription [DEPRECATED] This field is temporarily being used to set the build's description. In a future version, the `description` field will be used instead.
+	// Deprecated:
+	LongDescription *BuildLongDescription `json:"longDescription,omitempty"`
+
+	// Name The name of the build. This replaces the previous usage of 'description'.
+	Name *BuildName `json:"name,omitempty"`
 }
 
 // UpdateBuildInput defines model for updateBuildInput.
@@ -1588,6 +1660,12 @@ type ListAllJobsParams struct {
 	PageSize  *PageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty"`
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 	OrderBy   *OrderBy   `form:"orderBy,omitempty" json:"orderBy,omitempty"`
+}
+
+// ListBatchAccountsParams defines parameters for ListBatchAccounts.
+type ListBatchAccountsParams struct {
+	// Name Filter by the account name
+	Name *string `form:"name,omitempty" json:"name,omitempty"`
 }
 
 // CompareBatchesParams defines parameters for CompareBatches.
@@ -1812,7 +1890,10 @@ type GetSystemsForMetricsBuildParams struct {
 // ListReportsParams defines parameters for ListReports.
 type ListReportsParams struct {
 	// Search Filter based on branch_id, test_suite_id, created_at, status, associated_account
-	Search    *string    `form:"search,omitempty" json:"search,omitempty"`
+	Search *string `form:"search,omitempty" json:"search,omitempty"`
+
+	// Text Filter reports by a text string (only supports batch id as of 3/21/2025)
+	Text      *string    `form:"text,omitempty" json:"text,omitempty"`
 	PageSize  *PageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty"`
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 	OrderBy   *OrderBy   `form:"orderBy,omitempty" json:"orderBy,omitempty"`
@@ -2033,6 +2114,402 @@ type CreateBuildForSystemJSONRequestBody = CreateBuildForSystemInput
 // ValidateExperienceLocationJSONRequestBody defines body for ValidateExperienceLocation for application/json ContentType.
 type ValidateExperienceLocationJSONRequestBody = ExperienceLocation
 
+// AsCreateBuildForBranchInput0 returns the union data inside the CreateBuildForBranchInput as a CreateBuildForBranchInput0
+func (t CreateBuildForBranchInput) AsCreateBuildForBranchInput0() (CreateBuildForBranchInput0, error) {
+	var body CreateBuildForBranchInput0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateBuildForBranchInput0 overwrites any union data inside the CreateBuildForBranchInput as the provided CreateBuildForBranchInput0
+func (t *CreateBuildForBranchInput) FromCreateBuildForBranchInput0(v CreateBuildForBranchInput0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateBuildForBranchInput0 performs a merge with any union data inside the CreateBuildForBranchInput, using the provided CreateBuildForBranchInput0
+func (t *CreateBuildForBranchInput) MergeCreateBuildForBranchInput0(v CreateBuildForBranchInput0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateBuildForBranchInput1 returns the union data inside the CreateBuildForBranchInput as a CreateBuildForBranchInput1
+func (t CreateBuildForBranchInput) AsCreateBuildForBranchInput1() (CreateBuildForBranchInput1, error) {
+	var body CreateBuildForBranchInput1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateBuildForBranchInput1 overwrites any union data inside the CreateBuildForBranchInput as the provided CreateBuildForBranchInput1
+func (t *CreateBuildForBranchInput) FromCreateBuildForBranchInput1(v CreateBuildForBranchInput1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateBuildForBranchInput1 performs a merge with any union data inside the CreateBuildForBranchInput, using the provided CreateBuildForBranchInput1
+func (t *CreateBuildForBranchInput) MergeCreateBuildForBranchInput1(v CreateBuildForBranchInput1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateBuildForBranchInput) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	object := make(map[string]json.RawMessage)
+	if t.union != nil {
+		err = json.Unmarshal(b, &object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if t.AssociatedAccount != nil {
+		object["associatedAccount"], err = json.Marshal(t.AssociatedAccount)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'associatedAccount': %w", err)
+		}
+	}
+
+	if t.BuildSpecification != nil {
+		object["buildSpecification"], err = json.Marshal(t.BuildSpecification)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'buildSpecification': %w", err)
+		}
+	}
+
+	if t.Description != nil {
+		object["description"], err = json.Marshal(t.Description)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'description': %w", err)
+		}
+	}
+
+	if t.ImageUri != nil {
+		object["imageUri"], err = json.Marshal(t.ImageUri)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'imageUri': %w", err)
+		}
+	}
+
+	if t.LongDescription != nil {
+		object["longDescription"], err = json.Marshal(t.LongDescription)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'longDescription': %w", err)
+		}
+	}
+
+	if t.Name != nil {
+		object["name"], err = json.Marshal(t.Name)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'name': %w", err)
+		}
+	}
+
+	object["systemID"], err = json.Marshal(t.SystemID)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'systemID': %w", err)
+	}
+
+	object["version"], err = json.Marshal(t.Version)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'version': %w", err)
+	}
+
+	b, err = json.Marshal(object)
+	return b, err
+}
+
+func (t *CreateBuildForBranchInput) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	object := make(map[string]json.RawMessage)
+	err = json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["associatedAccount"]; found {
+		err = json.Unmarshal(raw, &t.AssociatedAccount)
+		if err != nil {
+			return fmt.Errorf("error reading 'associatedAccount': %w", err)
+		}
+	}
+
+	if raw, found := object["buildSpecification"]; found {
+		err = json.Unmarshal(raw, &t.BuildSpecification)
+		if err != nil {
+			return fmt.Errorf("error reading 'buildSpecification': %w", err)
+		}
+	}
+
+	if raw, found := object["description"]; found {
+		err = json.Unmarshal(raw, &t.Description)
+		if err != nil {
+			return fmt.Errorf("error reading 'description': %w", err)
+		}
+	}
+
+	if raw, found := object["imageUri"]; found {
+		err = json.Unmarshal(raw, &t.ImageUri)
+		if err != nil {
+			return fmt.Errorf("error reading 'imageUri': %w", err)
+		}
+	}
+
+	if raw, found := object["longDescription"]; found {
+		err = json.Unmarshal(raw, &t.LongDescription)
+		if err != nil {
+			return fmt.Errorf("error reading 'longDescription': %w", err)
+		}
+	}
+
+	if raw, found := object["name"]; found {
+		err = json.Unmarshal(raw, &t.Name)
+		if err != nil {
+			return fmt.Errorf("error reading 'name': %w", err)
+		}
+	}
+
+	if raw, found := object["systemID"]; found {
+		err = json.Unmarshal(raw, &t.SystemID)
+		if err != nil {
+			return fmt.Errorf("error reading 'systemID': %w", err)
+		}
+	}
+
+	if raw, found := object["version"]; found {
+		err = json.Unmarshal(raw, &t.Version)
+		if err != nil {
+			return fmt.Errorf("error reading 'version': %w", err)
+		}
+	}
+
+	return err
+}
+
+// AsCreateBuildForSystemInput0 returns the union data inside the CreateBuildForSystemInput as a CreateBuildForSystemInput0
+func (t CreateBuildForSystemInput) AsCreateBuildForSystemInput0() (CreateBuildForSystemInput0, error) {
+	var body CreateBuildForSystemInput0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateBuildForSystemInput0 overwrites any union data inside the CreateBuildForSystemInput as the provided CreateBuildForSystemInput0
+func (t *CreateBuildForSystemInput) FromCreateBuildForSystemInput0(v CreateBuildForSystemInput0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateBuildForSystemInput0 performs a merge with any union data inside the CreateBuildForSystemInput, using the provided CreateBuildForSystemInput0
+func (t *CreateBuildForSystemInput) MergeCreateBuildForSystemInput0(v CreateBuildForSystemInput0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateBuildForSystemInput1 returns the union data inside the CreateBuildForSystemInput as a CreateBuildForSystemInput1
+func (t CreateBuildForSystemInput) AsCreateBuildForSystemInput1() (CreateBuildForSystemInput1, error) {
+	var body CreateBuildForSystemInput1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateBuildForSystemInput1 overwrites any union data inside the CreateBuildForSystemInput as the provided CreateBuildForSystemInput1
+func (t *CreateBuildForSystemInput) FromCreateBuildForSystemInput1(v CreateBuildForSystemInput1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateBuildForSystemInput1 performs a merge with any union data inside the CreateBuildForSystemInput, using the provided CreateBuildForSystemInput1
+func (t *CreateBuildForSystemInput) MergeCreateBuildForSystemInput1(v CreateBuildForSystemInput1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateBuildForSystemInput) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	object := make(map[string]json.RawMessage)
+	if t.union != nil {
+		err = json.Unmarshal(b, &object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if t.AssociatedAccount != nil {
+		object["associatedAccount"], err = json.Marshal(t.AssociatedAccount)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'associatedAccount': %w", err)
+		}
+	}
+
+	object["branchID"], err = json.Marshal(t.BranchID)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'branchID': %w", err)
+	}
+
+	if t.BuildSpecification != nil {
+		object["buildSpecification"], err = json.Marshal(t.BuildSpecification)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'buildSpecification': %w", err)
+		}
+	}
+
+	if t.Description != nil {
+		object["description"], err = json.Marshal(t.Description)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'description': %w", err)
+		}
+	}
+
+	if t.ImageUri != nil {
+		object["imageUri"], err = json.Marshal(t.ImageUri)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'imageUri': %w", err)
+		}
+	}
+
+	if t.LongDescription != nil {
+		object["longDescription"], err = json.Marshal(t.LongDescription)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'longDescription': %w", err)
+		}
+	}
+
+	if t.Name != nil {
+		object["name"], err = json.Marshal(t.Name)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'name': %w", err)
+		}
+	}
+
+	if t.TriggeredVia != nil {
+		object["triggeredVia"], err = json.Marshal(t.TriggeredVia)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'triggeredVia': %w", err)
+		}
+	}
+
+	object["version"], err = json.Marshal(t.Version)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'version': %w", err)
+	}
+
+	b, err = json.Marshal(object)
+	return b, err
+}
+
+func (t *CreateBuildForSystemInput) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	object := make(map[string]json.RawMessage)
+	err = json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["associatedAccount"]; found {
+		err = json.Unmarshal(raw, &t.AssociatedAccount)
+		if err != nil {
+			return fmt.Errorf("error reading 'associatedAccount': %w", err)
+		}
+	}
+
+	if raw, found := object["branchID"]; found {
+		err = json.Unmarshal(raw, &t.BranchID)
+		if err != nil {
+			return fmt.Errorf("error reading 'branchID': %w", err)
+		}
+	}
+
+	if raw, found := object["buildSpecification"]; found {
+		err = json.Unmarshal(raw, &t.BuildSpecification)
+		if err != nil {
+			return fmt.Errorf("error reading 'buildSpecification': %w", err)
+		}
+	}
+
+	if raw, found := object["description"]; found {
+		err = json.Unmarshal(raw, &t.Description)
+		if err != nil {
+			return fmt.Errorf("error reading 'description': %w", err)
+		}
+	}
+
+	if raw, found := object["imageUri"]; found {
+		err = json.Unmarshal(raw, &t.ImageUri)
+		if err != nil {
+			return fmt.Errorf("error reading 'imageUri': %w", err)
+		}
+	}
+
+	if raw, found := object["longDescription"]; found {
+		err = json.Unmarshal(raw, &t.LongDescription)
+		if err != nil {
+			return fmt.Errorf("error reading 'longDescription': %w", err)
+		}
+	}
+
+	if raw, found := object["name"]; found {
+		err = json.Unmarshal(raw, &t.Name)
+		if err != nil {
+			return fmt.Errorf("error reading 'name': %w", err)
+		}
+	}
+
+	if raw, found := object["triggeredVia"]; found {
+		err = json.Unmarshal(raw, &t.TriggeredVia)
+		if err != nil {
+			return fmt.Errorf("error reading 'triggeredVia': %w", err)
+		}
+	}
+
+	if raw, found := object["version"]; found {
+		err = json.Unmarshal(raw, &t.Version)
+		if err != nil {
+			return fmt.Errorf("error reading 'version': %w", err)
+		}
+	}
+
+	return err
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
@@ -2140,7 +2617,7 @@ type ClientInterface interface {
 	ListAllJobs(ctx context.Context, projectID ProjectID, params *ListAllJobsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListBatchAccounts request
-	ListBatchAccounts(ctx context.Context, projectID ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListBatchAccounts(ctx context.Context, projectID ProjectID, params *ListBatchAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetBatch request
 	GetBatch(ctx context.Context, projectID ProjectID, batchID BatchID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2685,8 +3162,8 @@ func (c *Client) ListAllJobs(ctx context.Context, projectID ProjectID, params *L
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListBatchAccounts(ctx context.Context, projectID ProjectID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListBatchAccountsRequest(c.Server, projectID)
+func (c *Client) ListBatchAccounts(ctx context.Context, projectID ProjectID, params *ListBatchAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListBatchAccountsRequest(c.Server, projectID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -4920,7 +5397,7 @@ func NewListAllJobsRequest(server string, projectID ProjectID, params *ListAllJo
 }
 
 // NewListBatchAccountsRequest generates requests for ListBatchAccounts
-func NewListBatchAccountsRequest(server string, projectID ProjectID) (*http.Request, error) {
+func NewListBatchAccountsRequest(server string, projectID ProjectID, params *ListBatchAccountsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4943,6 +5420,28 @@ func NewListBatchAccountsRequest(server string, projectID ProjectID) (*http.Requ
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Name != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -9334,6 +9833,22 @@ func NewListReportsRequest(server string, projectID ProjectID, params *ListRepor
 
 		}
 
+		if params.Text != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "text", runtime.ParamLocationQuery, *params.Text); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.PageSize != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pageSize", runtime.ParamLocationQuery, *params.PageSize); err != nil {
@@ -12533,7 +13048,7 @@ type ClientWithResponsesInterface interface {
 	ListAllJobsWithResponse(ctx context.Context, projectID ProjectID, params *ListAllJobsParams, reqEditors ...RequestEditorFn) (*ListAllJobsResponse, error)
 
 	// ListBatchAccountsWithResponse request
-	ListBatchAccountsWithResponse(ctx context.Context, projectID ProjectID, reqEditors ...RequestEditorFn) (*ListBatchAccountsResponse, error)
+	ListBatchAccountsWithResponse(ctx context.Context, projectID ProjectID, params *ListBatchAccountsParams, reqEditors ...RequestEditorFn) (*ListBatchAccountsResponse, error)
 
 	// GetBatchWithResponse request
 	GetBatchWithResponse(ctx context.Context, projectID ProjectID, batchID BatchID, reqEditors ...RequestEditorFn) (*GetBatchResponse, error)
@@ -15747,8 +16262,8 @@ func (c *ClientWithResponses) ListAllJobsWithResponse(ctx context.Context, proje
 }
 
 // ListBatchAccountsWithResponse request returning *ListBatchAccountsResponse
-func (c *ClientWithResponses) ListBatchAccountsWithResponse(ctx context.Context, projectID ProjectID, reqEditors ...RequestEditorFn) (*ListBatchAccountsResponse, error) {
-	rsp, err := c.ListBatchAccounts(ctx, projectID, reqEditors...)
+func (c *ClientWithResponses) ListBatchAccountsWithResponse(ctx context.Context, projectID ProjectID, params *ListBatchAccountsParams, reqEditors ...RequestEditorFn) (*ListBatchAccountsResponse, error) {
+	rsp, err := c.ListBatchAccounts(ctx, projectID, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/bff/cmd/generate.go
+++ b/bff/cmd/generate.go
@@ -9,11 +9,18 @@ import (
 	"github.com/suessflorian/gqlfetch"
 )
 
-const GRAPHQL_API = "https://bff.resim.ai/graphql"
+var GRAPHQL_API_ENDPOINT string
+
+func init() {
+	GRAPHQL_API_ENDPOINT, _ = os.LookupEnv("GRAPHQL_API_ENDPOINT")
+	if GRAPHQL_API_ENDPOINT == "" {
+		GRAPHQL_API_ENDPOINT = "https://bff.resim.ai/graphql"
+	}
+}
 
 func main() {
-	log.Printf("Downloading GraphQL schema from %s", GRAPHQL_API)
-	schema, err := gqlfetch.BuildClientSchema(context.Background(), GRAPHQL_API, false)
+	log.Printf("Downloading GraphQL schema from %s", GRAPHQL_API_ENDPOINT)
+	schema, err := gqlfetch.BuildClientSchema(context.Background(), GRAPHQL_API_ENDPOINT, false)
 	if err != nil {
 		log.Fatalf("Failed to fetch schema: %s", err)
 	}

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -69,7 +69,7 @@ const (
 
 func init() {
 	createBuildCmd.Flags().String(buildNameKey, "", "The name of the build")
-	createBuildCmd.Flags().String(buildDescriptionKey, "", "The name of the build (deprecated)")
+	createBuildCmd.Flags().String(buildDescriptionKey, "", "The description of the build, often a commit message (can include markdown). For backwards compatibility reasons, if name is omitted, the description will be used")
 	createBuildCmd.Flags().String(buildImageURIKey, "", "The URI of the docker image")
 	createBuildCmd.MarkFlagRequired(buildImageURIKey)
 	createBuildCmd.Flags().String(buildVersionKey, "", "The version of the build image, usually a commit ID")

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -403,7 +403,7 @@ func getBuildID(client api.ClientWithResponsesInterface, projectID uuid.UUID, uu
 }
 
 // Attempt to find an existing build for that branch, imageURI, and version
-func getBuildIDFromImageURIAndVersion(client api.ClientWithResponsesInterface, projectID uuid.UUID, _ uuid.UUID, branchID uuid.UUID, imageURI string, version string, shouldFail bool) uuid.UUID {
+func getBuildIDFromImageURIAndVersion(client api.ClientWithResponsesInterface, projectID uuid.UUID, branchID uuid.UUID, imageURI string, version string, shouldFail bool) uuid.UUID {
 	var pageToken *string = nil
 	for {
 		response, err := client.ListBuildsWithResponse(context.Background(), projectID, &api.ListBuildsParams{

--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -70,6 +70,7 @@ const (
 func init() {
 	createBuildCmd.Flags().String(buildNameKey, "", "The name of the build")
 	createBuildCmd.Flags().String(buildDescriptionKey, "", "The description of the build, often a commit message (can include markdown). For backwards compatibility reasons, if name is omitted, the description will be used")
+	createBuildCmd.MarkFlagRequired(buildDescriptionKey)
 	createBuildCmd.Flags().String(buildImageURIKey, "", "The URI of the docker image")
 	createBuildCmd.MarkFlagRequired(buildImageURIKey)
 	createBuildCmd.Flags().String(buildVersionKey, "", "The version of the build image, usually a commit ID")

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -259,7 +259,7 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 
 // Index over the imageURI and the version to determine whether or not we want to create a new build:
 func getOrCreateBuild(client api.ClientWithResponsesInterface, projectID uuid.UUID, branchID uuid.UUID, systemID uuid.UUID, imageURI string, version string) uuid.UUID {
-	buildID := getBuildIDFromImageURIAndVersion(client, projectID, systemID, branchID, imageURI, version, false)
+	buildID := getBuildIDFromImageURIAndVersion(client, projectID, branchID, imageURI, version, false)
 	if buildID != uuid.Nil {
 		return buildID
 	}

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -255,7 +255,7 @@ func getOrCreateBuild(client api.ClientWithResponsesInterface, projectID uuid.UU
 	}
 	body := api.CreateBuildForBranchInput{
 		Description: Ptr("A ReSim Log Ingest Build"),
-		ImageUri:    LogIngestURI,
+		ImageUri:    Ptr(LogIngestURI),
 		Version:     viper.GetString(ingestVersionKey),
 		SystemID:    systemID,
 	}

--- a/cmd/resim/commands/report.go
+++ b/cmd/resim/commands/report.go
@@ -296,13 +296,13 @@ func getReport(ccmd *cobra.Command, args []string) {
 
 	if viper.GetBool(reportExitStatusKey) {
 		switch report.Status {
-		case api.ReportStatusSUCCEEDED:
+		case api.SUCCEEDED:
 			os.Exit(0)
-		case api.ReportStatusERROR:
+		case api.ERROR:
 			os.Exit(2)
-		case api.ReportStatusSUBMITTED:
+		case api.SUBMITTED:
 			os.Exit(3)
-		case api.ReportStatusRUNNING:
+		case api.RUNNING:
 			os.Exit(4)
 		default:
 			log.Fatal("unknown report status: ", report.Status)
@@ -322,11 +322,11 @@ func waitReport(ccmd *cobra.Command, args []string) {
 		report = actualGetReport(projectID, viper.GetString(reportIDKey), viper.GetString(reportNameKey))
 		viper.Set(reportIDKey, report.ReportID.String())
 		switch report.Status {
-		case api.ReportStatusSUCCEEDED:
+		case api.SUCCEEDED:
 			os.Exit(0)
-		case api.ReportStatusERROR:
+		case api.ERROR:
 			os.Exit(2)
-		case api.ReportStatusSUBMITTED, api.ReportStatusRUNNING:
+		case api.SUBMITTED, api.RUNNING:
 		default:
 			log.Fatal("unknown report status: ", report.Status)
 		}

--- a/cmd/resim/commands/system.go
+++ b/cmd/resim/commands/system.go
@@ -114,6 +114,7 @@ func init() {
 	updateSystemCmd.Flags().String(systemProjectKey, "", "The name or ID of the project the system belongs to")
 	updateSystemCmd.MarkFlagRequired(systemProjectKey)
 	updateSystemCmd.Flags().String(systemKey, "", "The name or ID of the system to update")
+	updateSystemCmd.MarkFlagRequired(systemKey)
 	updateSystemCmd.Flags().String(systemNameKey, "", "New value for the system name")
 	updateSystemCmd.Flags().String(systemDescriptionKey, "", "New value for the description of the system")
 	updateSystemCmd.Flags().Int(systemBuildVCPUsKey, DefaultCPUs, "New value for the number of vCPUs required to execute the build")

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -141,6 +141,7 @@ const (
 	// Build Messages
 	CreatedBuild          string = "Created build"
 	GithubCreatedBuild    string = "build_id="
+	EmptyBuildName        string = "empty build name"
 	EmptyBuildDescription string = "empty build description"
 	EmptyBuildImage       string = "empty build image URI"
 	InvalidBuildImage     string = "failed to parse the image URI"
@@ -2763,7 +2764,7 @@ func (s *EndToEndTestSuite) TestBuildCreateUpdate() {
 
 	// Verify that each of the required flags are required:
 	output = s.runCommand(createBuild(projectName, branchName, systemName, "", "public.ecr.aws/docker/library/hello-world:latest", "1.0.0", GithubFalse, AutoCreateBranchFalse), ExpectError)
-	s.Contains(output.StdErr, EmptyBuildDescription)
+	s.Contains(output.StdErr, EmptyBuildName)
 	output = s.runCommand(createBuild(projectName, branchName, systemName, "description", "", "1.0.0", GithubFalse, AutoCreateBranchFalse), ExpectError)
 	s.Contains(output.StdErr, EmptyBuildImage)
 	output = s.runCommand(createBuild(projectName, branchName, systemName, "description", "public.ecr.aws/docker/library/hello-world:latest", "", GithubFalse, AutoCreateBranchFalse), ExpectError)

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -4046,7 +4046,7 @@ func (s *EndToEndTestSuite) TestAliases() {
 	buildCommand := CommandBuilder{
 		Command: "builds",
 	}
-	createBuildWithNamesCommand := CommandBuilder{
+	createBuildWithNamesFromDescriptionCommand := CommandBuilder{
 		Command: "create",
 		Flags: []Flag{
 			{
@@ -4091,8 +4091,8 @@ func (s *EndToEndTestSuite) TestAliases() {
 				Value: systemName,
 			},
 			{
-				Name:  "--description",
-				Value: "description",
+				Name:  "--name",
+				Value: "build-name",
 			},
 			{
 				Name:  "--image",
@@ -4104,9 +4104,11 @@ func (s *EndToEndTestSuite) TestAliases() {
 			},
 		},
 	}
-	output = s.runCommand([]CommandBuilder{buildCommand, createBuildWithNamesCommand}, ExpectNoError)
-	s.Empty(output.StdErr)
+
+	output = s.runCommand([]CommandBuilder{buildCommand, createBuildWithNamesFromDescriptionCommand}, ExpectNoError)
+	s.Contains(output.StdErr, "Warning: Using 'description' to set the build name is deprecated. In the future, 'description' will only set the build's description. Please use --name instead.")
 	s.Contains(output.StdOut, CreatedBuild)
+
 	// Now try to create using the id for projects:
 	output = s.runCommand([]CommandBuilder{buildCommand, createBuildWithIDCommand}, ExpectNoError)
 	s.Empty(output.StdErr)

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -4047,7 +4047,7 @@ func (s *EndToEndTestSuite) TestAliases() {
 	buildCommand := CommandBuilder{
 		Command: "builds",
 	}
-	createBuildWithNamesFromDescriptionCommand := CommandBuilder{
+	createBuildWithNamesCommand := CommandBuilder{
 		Command: "create",
 		Flags: []Flag{
 			{
@@ -4096,6 +4096,10 @@ func (s *EndToEndTestSuite) TestAliases() {
 				Value: "build-name",
 			},
 			{
+				Name:  "--description",
+				Value: "description",
+			},
+			{
 				Name:  "--image",
 				Value: "public.ecr.aws/docker/library/hello-world:latest",
 			},
@@ -4106,7 +4110,7 @@ func (s *EndToEndTestSuite) TestAliases() {
 		},
 	}
 
-	output = s.runCommand([]CommandBuilder{buildCommand, createBuildWithNamesFromDescriptionCommand}, ExpectNoError)
+	output = s.runCommand([]CommandBuilder{buildCommand, createBuildWithNamesCommand}, ExpectNoError)
 	s.Contains(output.StdErr, "Warning: Using 'description' to set the build name is deprecated. In the future, 'description' will only set the build's description. Please use --name instead.")
 	s.Contains(output.StdOut, CreatedBuild)
 


### PR DESCRIPTION
# Description of change

Updates the build model and CLI to transition from using `description` as the build's name to a new explicit `name` field, which is now required. `description` now sets the build's description, as one might expect it to.

Updates GraphQL schema handling to support dynamic endpoint configuration via environment variable.

Also adds client updates to support the new `buildSpecification` field for build specs in YAML format. 

## Guide to reproduce test results

Run `resim create-build` and `resim update-build` with `--name` and `--description` flags. Validate behavior through API client methods and verify deprecated fields still work for backward compatibility.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.