### PR TITLE
PRO-178: Update logs commands to support batch logs and downloading a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ See also https://docs.resim.ai/changelog/ for all ReSim changes
 
 Changes in this section will be included in the next release.
 
+### v0.13.0 - April 7 2025
+
+#### Added
+
+- The `logs download` command now supports downloading a single log by providing the log name.
+
+#### Changed
+
+- The `logs` commands now support batch logs.
+
 ### v0.12.0 - March 25 2025
 
 - A new `metrics sync` command has been added, for syncing your metrics configuration with ReSim. This command is for

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -266,20 +266,20 @@ func unzipFile(zippedFile os.File) error {
 }
 
 type DownloadableLog struct {
-	FileName string
+	FileName          string
 	LogOutputLocation string
-	FileSize int64
-	LogType api.LogType
+	FileSize          int64
+	LogType           api.LogType
 }
 
 func DownloadableLogsFromJobLogs(jobLogs []api.JobLog) []DownloadableLog {
 	downloadableLogs := []DownloadableLog{}
 	for _, jobLog := range jobLogs {
 		downloadableLogs = append(downloadableLogs, DownloadableLog{
-			FileName: *jobLog.FileName,
+			FileName:          *jobLog.FileName,
 			LogOutputLocation: *jobLog.LogOutputLocation,
-			FileSize: *jobLog.FileSize,
-			LogType: *jobLog.LogType,
+			FileSize:          *jobLog.FileSize,
+			LogType:           *jobLog.LogType,
 		})
 	}
 	return downloadableLogs
@@ -289,10 +289,10 @@ func DownloadableLogsFromBatchLogs(batchLogs []api.BatchLog) []DownloadableLog {
 	downloadableLogs := []DownloadableLog{}
 	for _, batchLog := range batchLogs {
 		downloadableLogs = append(downloadableLogs, DownloadableLog{
-			FileName: *batchLog.FileName,
+			FileName:          *batchLog.FileName,
 			LogOutputLocation: *batchLog.LogOutputLocation,
-			FileSize: *batchLog.FileSize,
-			LogType: *batchLog.LogType,
+			FileSize:          *batchLog.FileSize,
+			LogType:           *batchLog.LogType,
 		})
 	}
 	return downloadableLogs

--- a/cmd/resim/commands/logs.go
+++ b/cmd/resim/commands/logs.go
@@ -23,7 +23,7 @@ import (
 var (
 	logsCmd = &cobra.Command{
 		Use:     "logs",
-		Short:   "logs contains commands for listing and downloading test logs.",
+		Short:   "logs contains commands for listing and downloading logs.",
 		Long:    ``,
 		Aliases: []string{"log"},
 	}
@@ -67,7 +67,7 @@ func init() {
 	downloadLogsCmd.Flags().String(logBatchIDKey, "", "The UUID of the batch the logs are associated with")
 	downloadLogsCmd.MarkFlagRequired(logBatchIDKey)
 	downloadLogsCmd.Flags().String(logTestIDKey, "", "The UUID of the test in the batch to list logs for")
-	downloadLogsCmd.Flags().String(logOutputKey, "", "The directory to download the logs to, must be empty if it already exists")
+	downloadLogsCmd.Flags().String(logOutputKey, "", "The directory to download the logs to")
 	downloadLogsCmd.MarkFlagRequired(logOutputKey)
 	downloadLogsCmd.Flags().Bool(logGithubKey, false, "Whether to output log messages in GitHub Actions friendly format")
 	downloadLogsCmd.Flags().StringSlice(logFilesKey, []string{}, "The files to download from the logs, separated by commas. If not provided, all logs will be downloaded. If files are not all found, the command will exit with an error.")
@@ -335,8 +335,8 @@ func downloadLogs(ccmd *cobra.Command, args []string) {
 	projectID := getProjectID(Client, viper.GetString(logProjectKey))
 
 	outputDir := viper.GetString(logOutputKey)
-	// if the directory exists and we're downloading everything, we need to check if it is empty
-	// otherwise, we need to create it
+
+	// we need to create the directory if it doesn't exist
 	if _, err := os.ReadDir(outputDir); os.IsNotExist(err) {
 		os.MkdirAll(outputDir, 0755)
 	}

--- a/cmd/resim/commands/spinner.go
+++ b/cmd/resim/commands/spinner.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"io"
+	"log"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -38,4 +39,9 @@ func (s *Spinner) Stop(finalMsg *string) {
 
 func (s *Spinner) Update(msg string) {
 	s.spinner.Suffix = " " + msg
+}
+
+func (s *Spinner) Fatal(v ...any) {
+	s.Stop(nil)
+	log.Fatal(v...)
 }

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -3359,36 +3359,36 @@ func (s *EndToEndTestSuite) TestBatchAndLogs() {
 
 	// Pass unknown name / id to batches tests:
 	output = s.runCommand(getBatchJobsByName(projectID, "does not exist"), ExpectError)
-	s.Contains(output.StdErr, InvalidBatchName)
+	s.Contains(output.StdErr, InvalidBatchName)	
 
-	// List logs:
+	// List test logs:
 	output = s.runCommand(listLogs(projectID, batchIDString, testID2.String()), ExpectNoError)
 	// Marshal into a struct:
 	var logs []api.JobLog
 	err = json.Unmarshal([]byte(output.StdOut), &logs)
 	s.NoError(err)
-	s.Len(logs, 8)
+	s.Len(logs, 7)
 	for _, log := range logs {
 		s.Equal(testID2, *log.JobID)
-		s.Contains([]string{"experience-worker.log", "metrics-worker.log", "experience-container.log", "metrics-container.log", "metrics.binproto", "logs.zip", "file.name", "parameters.json"}, *log.FileName)
+		s.Contains([]string{"experience-worker.log", "metrics-worker.log", "experience-container.log", "metrics-container.log", "metrics.binproto", "logs.zip", "file.name"}, *log.FileName)
 	}
 
-	// Download a single log
+	// Download a single test log
 	tempDir, err := os.MkdirTemp("", "test-logs")
 	s.NoError(err)
 	output = s.runCommand(downloadLogs(projectID, batchIDString, testID2.String(), tempDir, []string{"file.name"}), ExpectNoError)
 	s.Contains(output.StdOut, fmt.Sprintf("Downloaded 1 log(s) to %s", tempDir))
 
-	// Download all logs:
+	// Download all test logs:
 	output = s.runCommand(downloadLogs(projectID, batchIDString, testID2.String(), tempDir, []string{}), ExpectNoError)
-	s.Contains(output.StdOut, fmt.Sprintf("Downloaded 8 log(s) to %s", tempDir))
+	s.Contains(output.StdOut, fmt.Sprintf("Downloaded 7 log(s) to %s", tempDir))
 
 	// Check that the logs were downloaded and unzipped:
 	files, err := os.ReadDir(tempDir)
 	s.NoError(err)
-	s.Len(files, 8)
+	s.Len(files, 7)
 	for _, file := range files {
-		s.Contains([]string{"experience-worker.log", "metrics-worker.log", "experience-container.log", "metrics-container.log", "metrics.binproto", "logs", "file.name", "parameters.json"}, file.Name())
+		s.Contains([]string{"experience-worker.log", "metrics-worker.log", "experience-container.log", "metrics-container.log", "metrics.binproto", "logs", "file.name"}, file.Name())
 	}
 
 	// Pass blank name / id to logs:


### PR DESCRIPTION
# Description of change

- update `resim logs` commands to support batch logs
- update `resim logs download` to allow downloading a subset of files
- fix broken e2e test

## Guide to reproduce test results

Try it out!

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.