### PR TITLE
RSC-331: Log Ingest ReIngestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 Changes in this section will be included in the next release.
 
+### v0.17.0 - May 14, 2025
+
+- Add support for re-ingesting existing logs with the `--reingest` flag.
 - Add support for defining an experience build as [compose files](https://docs.docker.com/reference/compose-file/) instead of by image URI. This feature is currently highly experimental.
 
 ### v0.16.1 - April 23, 2025

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -41,7 +41,7 @@ const (
 	ingestBatchNameKey          = "ingestion-name"
 	ingestPoolLabelsKey         = "pool-labels"
 	ingestReingestKey           = "reingest"
-	
+
 	LogIngestURI = "public.ecr.aws/resim/open-builds/log-ingest:latest"
 )
 
@@ -181,7 +181,7 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 		if reIngest {
 			// List experiences by name
 			resp, err := Client.ListExperiencesWithResponse(context.Background(), projectID, &api.ListExperiencesParams{
-				Name: &logConfig.Name,
+				Name:     &logConfig.Name,
 				PageSize: Ptr(100),
 			})
 			if err != nil {

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -40,7 +40,8 @@ const (
 	ingestConfigFileKey         = "log-config"
 	ingestBatchNameKey          = "ingestion-name"
 	ingestPoolLabelsKey         = "pool-labels"
-
+	ingestReingestKey           = "reingest"
+	
 	LogIngestURI = "public.ecr.aws/resim/open-builds/log-ingest:latest"
 )
 
@@ -81,6 +82,8 @@ func init() {
 	// Pool Labels
 	ingestLogCmd.Flags().StringSlice(ingestPoolLabelsKey, []string{}, "Comma-separated list of pool labels to apply to the log ingestion. If not provided, a default pool label will be generated.")
 	rootCmd.AddCommand(ingestLogCmd)
+	// Re-ingestion
+	ingestLogCmd.Flags().Bool(ingestReingestKey, false, "Whether to re-ingest the logs if its experiences already exist. If not provided, the log will not be ingested again.")
 }
 
 type logPair struct {
@@ -170,6 +173,37 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 	for _, logConfig := range logsToProcess {
 		if !logIngestGithub {
 			fmt.Printf("Processing log: %s\n", logConfig.Name)
+		}
+
+		// Re-ingest logic: check for existing experience with same name and location
+		reIngest := viper.GetBool(ingestReingestKey)
+		existingExperienceID := uuid.Nil
+		if reIngest {
+			// List experiences by name
+			resp, err := Client.ListExperiencesWithResponse(context.Background(), projectID, &api.ListExperiencesParams{
+				Name: &logConfig.Name,
+				PageSize: Ptr(100),
+			})
+			if err != nil {
+				log.Fatalf("failed to list experiences for re-ingest check: %v", err)
+			}
+			if resp.JSON200 != nil && resp.JSON200.Experiences != nil {
+				experiences := *resp.JSON200.Experiences
+				for _, exp := range experiences {
+					if exp.Name == logConfig.Name && exp.Location == logConfig.Location {
+						existingExperienceID = exp.ExperienceID
+						break
+					}
+				}
+			}
+		}
+
+		if existingExperienceID != uuid.Nil {
+			if !logIngestGithub {
+				fmt.Printf("Skipping log '%s' at '%s' (already ingested)\n", logConfig.Name, logConfig.Location)
+			}
+			experienceIDs = append(experienceIDs, existingExperienceID)
+			continue
 		}
 
 		// Create the experience

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -1362,7 +1362,7 @@ func createBatch(projectID uuid.UUID, buildID string, experienceIDs []string, ex
 	return []CommandBuilder{batchCommand, createCommand}
 }
 
-func createIngestedLog(projectID uuid.UUID, system *string, branchname *string, version *string, metricsBuildID uuid.UUID, logName *string, logLocation *string, logsList []string, configFileLocation *string, experienceTags []string, buildID *uuid.UUID, batchName *string, github bool) []CommandBuilder {
+func createIngestedLog(projectID uuid.UUID, system *string, branchname *string, version *string, metricsBuildID uuid.UUID, logName *string, logLocation *string, logsList []string, configFileLocation *string, experienceTags []string, buildID *uuid.UUID, batchName *string, github bool, reingest bool) []CommandBuilder {
 	ingestCommand := CommandBuilder{
 		Command: "ingest",
 		Flags: []Flag{
@@ -1443,6 +1443,12 @@ func createIngestedLog(projectID uuid.UUID, system *string, branchname *string, 
 	if github {
 		ingestCommand.Flags = append(ingestCommand.Flags, Flag{
 			Name:  "--github",
+			Value: "",
+		})
+	}
+	if reingest {
+		ingestCommand.Flags = append(ingestCommand.Flags, Flag{
+			Name:  "--reingest",
 			Value: "",
 		})
 	}
@@ -4810,6 +4816,9 @@ func (s *EndToEndTestSuite) TestBatchWithZeroTimeout() {
 }
 
 func (s *EndToEndTestSuite) TestLogIngest() {
+	const ReIngestTrue = true
+	const ReIngestFalse = false
+
 	// First create a project
 	projectName := fmt.Sprintf("test-project-%s", uuid.New().String())
 	output := s.runCommand(createProject(projectName, "description", GithubTrue), ExpectNoError)
@@ -4836,7 +4845,7 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	logLocation := fmt.Sprintf("s3://%v/test-object/", s.Config.E2EBucket)
 
 	experienceTags := []string{"test-tag"}
-	ingestCommand := createIngestedLog(projectID, &systemIDString, &firstBranchName, &firstVersion, metricsBuildID, Ptr(logName), Ptr(logLocation), []string{}, nil, experienceTags, nil, nil, GithubTrue)
+	ingestCommand := createIngestedLog(projectID, &systemIDString, &firstBranchName, &firstVersion, metricsBuildID, Ptr(logName), Ptr(logLocation), []string{}, nil, experienceTags, nil, nil, GithubTrue, ReIngestFalse)
 	output = s.runCommand(ingestCommand, ExpectNoError)
 	s.Contains(output.StdOut, GithubCreatedBatch)
 	batchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
@@ -4921,7 +4930,7 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	secondLogTags := []string{"test-tag-2"}
 	defaultBranchName := "log-ingest-branch"
 	defaultVersion := "latest"
-	secondLogCommand := createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, Ptr(secondLogName), Ptr(logLocation), []string{}, nil, secondLogTags, nil, nil, GithubTrue)
+	secondLogCommand := createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, Ptr(secondLogName), Ptr(logLocation), []string{}, nil, secondLogTags, nil, nil, GithubTrue, ReIngestFalse)
 	output = s.runCommand(secondLogCommand, ExpectNoError)
 	s.Contains(output.StdOut, GithubCreatedBatch)
 	secondBatchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
@@ -5009,7 +5018,7 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	// Validate that things are not recreated:
 	thirdLogName := fmt.Sprintf("test-log-%v", uuid.New())
 	specialBatchName := "my-batch-name"
-	output = s.runCommand(createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, Ptr(thirdLogName), Ptr(logLocation), []string{}, nil, secondLogTags, nil, &specialBatchName, GithubTrue), ExpectNoError)
+	output = s.runCommand(createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, Ptr(thirdLogName), Ptr(logLocation), []string{}, nil, secondLogTags, nil, &specialBatchName, GithubTrue, ReIngestFalse), ExpectNoError)
 	s.Contains(output.StdOut, GithubCreatedBatch)
 	thirdBatchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
 	// Grab the batch and validate the status, first by name then by ID:
@@ -5041,7 +5050,7 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	existingBuildID := uuid.MustParse(buildIDString)
 	// Finally, use the existing build ID:
 	fourthLogName := fmt.Sprintf("test-log-%v", uuid.New())
-	output = s.runCommand(createIngestedLog(projectID, nil, nil, nil, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue), ExpectNoError)
+	output = s.runCommand(createIngestedLog(projectID, nil, nil, nil, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue, ReIngestFalse), ExpectNoError)
 	s.Contains(output.StdOut, GithubCreatedBatch)
 	fourthBatchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
 	// Grab the batch and validate the status, first by name then by ID:
@@ -5051,13 +5060,13 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	s.NoError(err)
 
 	// Check the MuTex parameters:
-	output = s.runCommand(createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue), ExpectError)
+	output = s.runCommand(createIngestedLog(projectID, &systemIDString, nil, nil, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue, ReIngestFalse), ExpectError)
 	s.Contains(output.StdErr, "build-id")
 	s.Contains(output.StdErr, "system")
-	output = s.runCommand(createIngestedLog(projectID, nil, &firstBranchName, nil, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue), ExpectError)
+	output = s.runCommand(createIngestedLog(projectID, nil, &firstBranchName, nil, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue, ReIngestFalse), ExpectError)
 	s.Contains(output.StdErr, "build-id")
 	s.Contains(output.StdErr, "branch")
-	output = s.runCommand(createIngestedLog(projectID, nil, nil, &firstVersion, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue), ExpectError)
+	output = s.runCommand(createIngestedLog(projectID, nil, nil, &firstVersion, metricsBuildID, Ptr(fourthLogName), Ptr(logLocation), []string{}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue, ReIngestFalse), ExpectError)
 	s.Contains(output.StdErr, "build-id")
 	s.Contains(output.StdErr, "version")
 
@@ -5066,7 +5075,7 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	log1 := fmt.Sprintf("%s=%s", log1Name, logLocation)
 	log2Name := fmt.Sprintf("test-log-%v", uuid.New())
 	log2 := fmt.Sprintf("%s=%s", log2Name, logLocation)
-	output = s.runCommand(createIngestedLog(projectID, nil, nil, nil, metricsBuildID, nil, nil, []string{log1, log2}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue), ExpectNoError)
+	output = s.runCommand(createIngestedLog(projectID, nil, nil, nil, metricsBuildID, nil, nil, []string{log1, log2}, nil, secondLogTags, Ptr(existingBuildID), nil, GithubTrue, ReIngestFalse), ExpectNoError)
 	fmt.Println("Output: ", output.StdOut)
 	fmt.Println("Output: ", output.StdErr)
 	s.Contains(output.StdOut, GithubCreatedBatch)
@@ -5118,7 +5127,7 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	s.NoError(err)
 
 	// Run the ingest command with the config file:
-	output = s.runCommand(createIngestedLog(projectID, &systemIDString, &firstBranchName, &firstVersion, metricsBuildID, nil, nil, []string{}, Ptr(configFileLocation), nil, nil, nil, GithubTrue), ExpectNoError)
+	output = s.runCommand(createIngestedLog(projectID, &systemIDString, &firstBranchName, &firstVersion, metricsBuildID, nil, nil, []string{}, Ptr(configFileLocation), nil, nil, nil, GithubTrue, ReIngestFalse), ExpectNoError)
 	fmt.Println("Output: ", output.StdOut)
 	fmt.Println("Output: ", output.StdErr)
 	s.Contains(output.StdOut, GithubCreatedBatch)
@@ -5145,6 +5154,16 @@ func (s *EndToEndTestSuite) TestLogIngest() {
 	err = json.Unmarshal([]byte(output.StdOut), &jobs)
 	s.NoError(err)
 	s.Equal(2, len(jobs))
+
+	// Re-ingest the config file with the --reingest flag; should not create duplicate experiences
+	output = s.runCommand(createIngestedLog(projectID, &systemIDString, &firstBranchName, &firstVersion, metricsBuildID, nil, nil, []string{}, Ptr(configFileLocation), nil, nil, nil, GithubTrue, ReIngestTrue), ExpectNoError)
+	s.Contains(output.StdOut, GithubCreatedBatch)
+	
+	reIngestBatchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
+	// Do not wait for batch to complete; just cancel it
+	output = s.runCommand(cancelBatchByID(projectID, reIngestBatchIDString), ExpectNoError)
+	// Check that the cancel command succeeded
+	s.Contains(output.StdOut, "CANCELLED")
 }
 
 func (s *EndToEndTestSuite) TestMetricsSync() {


### PR DESCRIPTION
# Description of change

- Allow rerunning a log ingestion with the addition of the `--reingest` flag.

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [x] I have self-reviewed this change.
- [ ] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.