### PR TITLE
ReRun Batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Unreleased
 
+### v0.19.0 - June 17, 2025
+
+- Add support for rerunning a subset of tests within a batch via `resim batches rerun --batch-id <> --test-ids <>...`
 - Add support for populating environment variables in docker compose files (builds) via .env files and/or current environment
 
 ### v0.18.0 - June 3, 2025

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -98,7 +98,7 @@ const (
 	batchWaitPollKey                = "poll-every"
 	batchSlackOutputKey             = "slack"
 	batchAllowableFailurePercentKey = "allowable-failure-percent"
-	batchJobIDsKey                  = "job-ids"
+	batchTestIDsKey                 = "test-ids"
 )
 
 func init() {
@@ -168,8 +168,8 @@ func init() {
 	rerunBatchCmd.Flags().String(batchIDKey, "", "The ID of the batch to rerun tests for.")
 	rerunBatchCmd.Flags().String(batchNameKey, "", "The name of the batch to rerun tests for (e.g. rejoicing-aquamarine-starfish). If the name is not unique, this reruns the most recent batch with that name.")
 	rerunBatchCmd.MarkFlagsMutuallyExclusive(batchIDKey, batchNameKey)
-	rerunBatchCmd.Flags().StringSlice(batchJobIDsKey, []string{}, "Comma-separated list of job IDs to rerun.")
-	rerunBatchCmd.MarkFlagRequired(batchJobIDsKey)
+	rerunBatchCmd.Flags().StringSlice(batchTestIDsKey, []string{}, "Comma-separated list of test IDs to rerun.")
+	rerunBatchCmd.MarkFlagRequired(batchTestIDsKey)
 	batchCmd.AddCommand(rerunBatchCmd)
 
 	rootCmd.AddCommand(batchCmd)
@@ -667,7 +667,7 @@ func rerunBatch(ccmd *cobra.Command, args []string) {
 	batch := actualGetBatch(projectID, viper.GetString(batchIDKey), viper.GetString(batchNameKey))
 
 	jobIDs := []uuid.UUID{}
-	for _, jobID := range viper.GetStringSlice(batchJobIDsKey) {
+	for _, jobID := range viper.GetStringSlice(batchTestIDsKey) {
 		jobID, err := uuid.Parse(jobID)
 		if err != nil {
 			log.Fatal("unable to parse job ID: ", err)

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -2424,7 +2424,7 @@ func rerunBatch(projectID uuid.UUID, batchID string, jobIDs []string) []CommandB
 				Value: batchID,
 			},
 			{
-				Name:  "--job-ids",
+				Name:  "--test-ids",
 				Value: strings.Join(jobIDs, ","),
 			},
 		},

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -3870,7 +3870,7 @@ func (s *EndToEndTestSuite) TestRerunBatch() {
 	s.NoError(err)
 	s.Len(tests, 2)
 	// Now rerun the batch:
-	// Sleep for 60 seconds to ensure the batch is cleaned up::
+	// Sleep for 60 seconds to ensure the batch is cleaned up:
 	time.Sleep(60 * time.Second)
 	output = s.runCommand(rerunBatch(projectID, batchIDString, []string{tests[0].JobID.String()}), ExpectNoError)
 	fmt.Println("Output: ", output.StdOut)


### PR DESCRIPTION
# Description of change

Introduces the ability to "rerun" a subset of the tests within a batch, via the `batches rerun` command. This will rerun any flaky or failing tests and then recompute any batch-level metrics.

## Guide to reproduce test results

Run the end to end test.

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.