### PR TITLE
WOB-3501 | Require project id when syncing metrics config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Unreleased
 
+### v0.23.0 - August 7, 2025
+
+- The `resim metrics sync` command now requires the `--project` flag.
+
 ### v0.22.0 - July 31, 2025
 
 - Creating builds via build spec now uploads services for all profiles by default. Previously only services without a profile were selected. A limited selection of profiles can be uploaded with `resim builds create ... --build-spec <path> --compose-profiles profile1,...` if desired.

--- a/bff/queries.gen.go
+++ b/bff/queries.gen.go
@@ -30,9 +30,13 @@ func (v *UpdateMetricsConfigResponse) GetUpdateMetricsConfig() string { return v
 
 // __UpdateMetricsConfigInput is used internally by genqlient
 type __UpdateMetricsConfigInput struct {
+	ProjectId     string            `json:"projectId"`
 	Config        string            `json:"config"`
 	TemplateFiles []MetricsTemplate `json:"templateFiles"`
 }
+
+// GetProjectId returns __UpdateMetricsConfigInput.ProjectId, and is useful for accessing the field via an interface.
+func (v *__UpdateMetricsConfigInput) GetProjectId() string { return v.ProjectId }
 
 // GetConfig returns __UpdateMetricsConfigInput.Config, and is useful for accessing the field via an interface.
 func (v *__UpdateMetricsConfigInput) GetConfig() string { return v.Config }
@@ -42,14 +46,15 @@ func (v *__UpdateMetricsConfigInput) GetTemplateFiles() []MetricsTemplate { retu
 
 // The mutation executed by UpdateMetricsConfig.
 const UpdateMetricsConfig_Operation = `
-mutation UpdateMetricsConfig ($config: String!, $templateFiles: [MetricsTemplate!]!) {
-	updateMetricsConfig(config: $config, templateFiles: $templateFiles)
+mutation UpdateMetricsConfig ($projectId: String!, $config: String!, $templateFiles: [MetricsTemplate!]!) {
+	updateMetricsConfig(projectId: $projectId, config: $config, templateFiles: $templateFiles)
 }
 `
 
 func UpdateMetricsConfig(
 	ctx_ context.Context,
 	client_ graphql.Client,
+	projectId string,
 	config string,
 	templateFiles []MetricsTemplate,
 ) (data_ *UpdateMetricsConfigResponse, err_ error) {
@@ -57,6 +62,7 @@ func UpdateMetricsConfig(
 		OpName: "UpdateMetricsConfig",
 		Query:  UpdateMetricsConfig_Operation,
 		Variables: &__UpdateMetricsConfigInput{
+			ProjectId:     projectId,
 			Config:        config,
 			TemplateFiles: templateFiles,
 		},

--- a/bff/queries/update_metrics_config.graphql
+++ b/bff/queries/update_metrics_config.graphql
@@ -1,3 +1,3 @@
-mutation UpdateMetricsConfig($config: String!, $templateFiles: [MetricsTemplate!]!) {
-    updateMetricsConfig(config: $config, templateFiles: $templateFiles)
+mutation UpdateMetricsConfig($projectId: String!, $config: String!, $templateFiles: [MetricsTemplate!]!) {
+    updateMetricsConfig(projectId: $projectId, config: $config, templateFiles: $templateFiles)
 }

--- a/cmd/resim/commands/metrics.go
+++ b/cmd/resim/commands/metrics.go
@@ -100,7 +100,7 @@ func syncMetrics(cmd *cobra.Command, args []string) {
 			continue
 		}
 		if verboseMode {
-			fmt.Printf("Found template %s", file.Name())
+			fmt.Printf("Found template %s\n", file.Name())
 		}
 		contents := readFile(path.Join(workDir, ".resim/metrics/templates/", file.Name()))
 		if len(contents) == 0 {

--- a/cmd/resim/commands/metrics.go
+++ b/cmd/resim/commands/metrics.go
@@ -28,7 +28,13 @@ var (
 	}
 )
 
+const (
+	metricsProjectKey = "project"
+)
+
 func init() {
+	syncMetricsCmd.Flags().String(metricsProjectKey, "", "The name or ID of the project to sync metrics to")
+	syncMetricsCmd.MarkFlagRequired(metricsProjectKey)
 	metricsCmd.AddCommand(syncMetricsCmd)
 	rootCmd.AddCommand(metricsCmd)
 }
@@ -47,6 +53,8 @@ func readFile(path string) string {
 func syncMetrics(cmd *cobra.Command, args []string) {
 
 	verboseMode := viper.GetBool(verboseKey)
+
+	projectID := getProjectID(Client, viper.GetString(metricsProjectKey))
 
 	workDir, err := os.Getwd()
 	if err != nil {
@@ -104,7 +112,7 @@ func syncMetrics(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	_, err = bff.UpdateMetricsConfig(context.Background(), BffClient, configFile, templates)
+	_, err = bff.UpdateMetricsConfig(context.Background(), BffClient, projectID, configFile, templates)
 	if err != nil {
 		log.Fatalf("Failed to sync metrics config: %s", err)
 	}

--- a/cmd/resim/commands/metrics.go
+++ b/cmd/resim/commands/metrics.go
@@ -93,9 +93,9 @@ func syncMetrics(cmd *cobra.Command, args []string) {
 			}
 			continue
 		}
-		if !strings.HasSuffix(strings.ToLower(file.Name()), ".heex") {
+		if !strings.HasSuffix(strings.ToLower(file.Name()), ".liquid") {
 			if verboseMode {
-				fmt.Printf("Skipping non .heex file %s\n", file.Name())
+				fmt.Printf("Skipping non .liquid file %s\n", file.Name())
 			}
 			continue
 		}
@@ -112,7 +112,7 @@ func syncMetrics(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	_, err = bff.UpdateMetricsConfig(context.Background(), BffClient, projectID, configFile, templates)
+	_, err = bff.UpdateMetricsConfig(context.Background(), BffClient, projectID.String(), configFile, templates)
 	if err != nil {
 		log.Fatalf("Failed to sync metrics config: %s", err)
 	}

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -321,7 +321,7 @@ func syncMetrics(projectName string, verbose bool) []CommandBuilder {
 	metricsCommand := CommandBuilder{Command: "metrics"}
 
 	flags := []Flag{
-		{Name: "project", Value: projectName},
+		{Name: "--project", Value: projectName},
 	}
 	if verbose {
 		flags = append(flags, Flag{Name: "--verbose"})

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -5703,7 +5703,7 @@ func TestMetricsSync(t *testing.T) {
 		}, "\n")
 		err = os.WriteFile(".resim/metrics/config.yml", []byte(metricsFile), 0644)
 		ts.NoError(err)
-		err = os.WriteFile(".resim/metrics/templates/bar.json.heex", []byte("{}"), 0644)
+		err = os.WriteFile(".resim/metrics/templates/bar.liquid", []byte("{}"), 0644)
 		ts.NoError(err)
 
 		// Standard behavior is exit 0 with no output
@@ -5715,7 +5715,7 @@ func TestMetricsSync(t *testing.T) {
 		output = s.runCommand(ts, syncMetrics(projectIDString, true), false)
 		ts.Equal("", output.StdErr)
 		ts.Contains(output.StdOut, "Looking for metrics config at .resim/metrics/config.yml")
-		ts.Contains(output.StdOut, "Found template bar.json.heex")
+		ts.Contains(output.StdOut, "Found template bar.liquid")
 		ts.Contains(output.StdOut, "Successfully synced metrics config, and the following templates:")
 	})
 }


### PR DESCRIPTION
# Description of change

Metrics configs must now be synced to a specific project, not globally to only the org itself

https://linear.app/resim/issue/WOB-3501/associate-metrics-2-objects-to-projects

## Guide to reproduce test results

Add a .resim folder with a config like you see in: https://github.com/resim-ai/metrics-sync-testing

Test the command:

```shell
$ go run cmd/resim/cli.go --auth-url https://resim-dev.us.auth0.com --url https://api.resim.io/v1 metrics sync                              
2025/08/06 16:34:09 required flag(s) "project" not set
exit status 1

$ go run cmd/resim/cli.go --auth-url https://resim-dev.us.auth0.com --url https://dev-env-pr-2188.api.dev.resim.io/v1 metrics sync --project 'some-project-id' --verbose
Looking for metrics config at .resim/metrics/config.yml
Looking for templates in .resim/metrics/templates/
Found template custom_line.liquid
Skipping non .liquid file line.json.heex
Successfully synced metrics config, and the following templates:
        custom_line.liquid
```

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.