### PR TITLE
RSC-508 Ensure env files aren't printed in --github mode

### DIFF
--- a/cmd/resim/commands/build.go
+++ b/cmd/resim/commands/build.go
@@ -293,6 +293,7 @@ func createBuild(ccmd *cobra.Command, args []string) {
 			viper.GetBool(buildUseOsEnvKey),
 			viper.GetStringSlice(buildEnvFilesKey),
 			composeProfiles,
+			buildGithub,
 		)
 		if err != nil {
 			log.Fatal("failed to parse build spec:", err)

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -33,7 +33,7 @@ func ParseParameterString(parameterString string) (string, string, error) {
 	return "", "", fmt.Errorf("failed to parse parameter: %s - must be in the format <parameter-name>=<parameter-value> or <parameter-name>:<parameter-value>", parameterString)
 }
 
-func ParseBuildSpec(buildSpecLocation string, withOsEnv bool, withEnvFiles []string, profiles []string) (*compose_types.Project, error) {
+func ParseBuildSpec(buildSpecLocation string, withOsEnv bool, withEnvFiles []string, profiles []string, quiet bool) (*compose_types.Project, error) {
 	// We assume that the build spec is a valid YAML file
 	ctx := context.Background()
 
@@ -55,7 +55,9 @@ func ParseBuildSpec(buildSpecLocation string, withOsEnv bool, withEnvFiles []str
 		}
 	}
 	if len(withEnvFiles) > 0 {
-		fmt.Println("withEnvFiles", withEnvFiles)
+		if !quiet {
+			fmt.Println("withEnvFiles", withEnvFiles)
+		}
 		err = cli.WithEnvFiles(withEnvFiles...)(options)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/resim/commands/utils_test.go
+++ b/cmd/resim/commands/utils_test.go
@@ -121,7 +121,7 @@ func TestParseParameterString(t *testing.T) {
 }
 
 func TestParseBuildSpec(t *testing.T) {
-	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", false, []string{}, []string{"*"})
+	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", false, []string{}, []string{"*"}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, buildSpec)
 
@@ -143,7 +143,7 @@ func TestParseBuildSpecWithOsEnv(t *testing.T) {
 	os.Setenv("SET_BY_OUTSIDE_ENV", "test_value")
 	defer os.Unsetenv("SET_BY_OUTSIDE_ENV")
 
-	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", true, []string{}, []string{"*"})
+	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", true, []string{}, []string{"*"}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, buildSpec)
 
@@ -163,7 +163,7 @@ func TestParseBuildSpecWithEnvFiles(t *testing.T) {
 	envFile.WriteString(fmt.Sprintf("%s=%s\n", envName, envValue))
 	envFile.Close()
 
-	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", false, []string{envFile.Name()}, []string{"*"})
+	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", false, []string{envFile.Name()}, []string{"*"}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, buildSpec)
 
@@ -175,7 +175,7 @@ func TestParseBuildSpecWithEnvFiles(t *testing.T) {
 }
 
 func TestParseBuildSpecWithProfiles(t *testing.T) {
-	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", false, []string{}, []string{"profile2"})
+	buildSpec, err := ParseBuildSpec("../../../testing/data/test_build_spec.yaml", false, []string{}, []string{"profile2"}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, buildSpec)
 


### PR DESCRIPTION
# Description of change

Currently, when creating a build (resim builds create) with the --env-files flag, the CLI outputs an extra line of output describing the env files that have been passed in even when the --github flag is passed. Don't print these env files when running with --github.

## Guide to reproduce test results

Build and run the resulting binary on the repro case:
```bash
BUILDS_CREATE_OUTPUT=$(./resim builds create \
     --branch "${RESIM_BRANCH_NAME}" \
     --name "${RESIM_BUILD_NAME}" \
     --description "${RESIM_BUILD_DESCRIPTION}" \
     --project "${RESIM_PROJECT}" \
     --system "${RESIM_SYSTEM}" \
     --version "${RESIM_VERSION}" \
     --env-files version.env \
     --build-spec "${RESIM_COMPOSE_TEMPLATE}" \
     --auto-create-branch \
     --github)

echo "================================================================================"
echo "${BUILDS_CREATE_OUTPUT}"
```

## Checklist

- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.