### PR TITLE
Draft - Added batches supervise command to autorerun failing tests in a batch

### DIFF
--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -76,6 +76,13 @@ var (
 		Long:  ``,
 		Run:   rerunBatch,
 	}
+
+	superviseBatchCmd = &cobra.Command{
+		Use:   "supervise",
+		Short: "supervise - Supervises batch operations",
+		Long:  ``,
+		Run:   superviseBatch,
+	}
 )
 
 const (
@@ -171,6 +178,8 @@ func init() {
 	rerunBatchCmd.Flags().StringSlice(batchTestIDsKey, []string{}, "Comma-separated list of test IDs to rerun. If none are provided, only the batch-metrics phase will be rerun.")
 	batchCmd.AddCommand(rerunBatchCmd)
 
+	batchCmd.AddCommand(superviseBatchCmd)
+
 	rootCmd.AddCommand(batchCmd)
 }
 
@@ -207,6 +216,10 @@ func DetermineTriggerMethod() *api.TriggeredVia {
 		return nil
 	}
 	return Ptr(api.LOCAL)
+}
+
+func superviseBatch(ccmd *cobra.Command, args []string) {
+	fmt.Println("I am Supervisor")
 }
 
 func createBatch(ccmd *cobra.Command, args []string) {

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -178,6 +178,12 @@ func init() {
 	rerunBatchCmd.Flags().StringSlice(batchTestIDsKey, []string{}, "Comma-separated list of test IDs to rerun. If none are provided, only the batch-metrics phase will be rerun.")
 	batchCmd.AddCommand(rerunBatchCmd)
 
+	superviseBatchCmd.Flags().String(batchProjectKey, "", "The name or ID of the project to supervise")
+	superviseBatchCmd.MarkFlagRequired(batchProjectKey)
+	superviseBatchCmd.Flags().String(batchIDKey, "", "The ID of the batch to supervise.")
+	superviseBatchCmd.Flags().String(batchNameKey, "", "The name of the batch to supervise (e.g. rejoicing-aquamarine-starfish). If the name is not unique, this supervises the most recent batch with that name.")
+	superviseBatchCmd.MarkFlagsMutuallyExclusive(batchIDKey, batchNameKey)
+	superviseBatchCmd.MarkFlagsOneRequired(batchIDKey, batchNameKey)
 	batchCmd.AddCommand(superviseBatchCmd)
 
 	rootCmd.AddCommand(batchCmd)
@@ -219,7 +225,9 @@ func DetermineTriggerMethod() *api.TriggeredVia {
 }
 
 func superviseBatch(ccmd *cobra.Command, args []string) {
-	fmt.Println("I am Supervisor")
+	projectID := getProjectID(Client, viper.GetString(batchProjectKey))
+	batch := actualGetBatch(projectID, viper.GetString(batchIDKey), viper.GetString(batchNameKey))
+	fmt.Printf("I am Supervisor for project: %s and batch: %s\n", projectID.String(), batch.BatchID.String())
 }
 
 func createBatch(ccmd *cobra.Command, args []string) {

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Development helper functions for resim CLI
+
+# Build the resim binary
+build() {
+    echo "Building resim binary..."
+    go build -o resim ./cmd/resim
+    if [ $? -eq 0 ]; then
+        echo "Build successful! Binary created as 'resim'"
+    else
+        echo "Build failed!"
+        return 1
+    fi
+}
+
+# Run the test command script
+runCommand() {
+    if [ ! -f "./runCommand.sh" ]; then
+        echo "Error: runCommand.sh not found!"
+        echo "Create runCommand.sh with your test commands"
+        return 1
+    fi
+    
+    echo "Running test command..."
+    ./runCommand.sh
+}
+
+# Show available commands
+help() {
+    echo "Available commands:"
+    echo "  build      - Build the resim binary (go build -o resim ./cmd/resim)"
+    echo "  runCommand - Run ./runCommand.sh"
+    echo "  help       - Show this help message"
+}
+
+# Export functions so they're available when sourced
+export -f build
+export -f runCommand
+export -f help

--- a/runCommand.sh
+++ b/runCommand.sh
@@ -2,18 +2,21 @@
 
 # Configuration variables - edit these as needed
 PROJECT_NAME="karthik-test"
-BATCH_NAME="reanimated-poppy-ox"
+BATCH_NAME="respectable-gray-moth"
 
 # Supervise command variables
-MAX_RERUN_ATTEMPTS=3
-MAX_FAILED_JOB_THRESHOLD=25
-RERUN_ON_STATES="Warning,Error"
+MAX_RERUN_ATTEMPTS=2
+MAX_FAILED_JOB_THRESHOLD=100
+RERUN_ON_STATES="Error, Blocker"
 
 # Add your test commands here
 echo "Running resim command..."
 
 # Example commands you might want to test:
 ./resim batches supervise --project "$PROJECT_NAME" --batch-name "$BATCH_NAME" --max-rerun-attempts "$MAX_RERUN_ATTEMPTS" --max-failed-job-threshold "$MAX_FAILED_JOB_THRESHOLD" --rerun-on-states "$RERUN_ON_STATES"
+
+# Wait batch command
+# ./resim batches tests --project "$PROJECT_NAME" --batch-name "$BATCH_NAME"
 
 # Or test other commands:
 # ./resim batches create --project "$PROJECT_NAME" --build-id "build-uuid" --experiences "test-exp"

--- a/runCommand.sh
+++ b/runCommand.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Configuration variables - edit these as needed
+PROJECT_NAME="karthik-test"
+BATCH_NAME="reanimated-poppy-ox"
+
+# Supervise command variables
+MAX_RERUN_ATTEMPTS=3
+MAX_FAILED_JOB_THRESHOLD=25
+RERUN_ON_STATES="Warning,Error"
+
+# Add your test commands here
+echo "Running resim command..."
+
+# Example commands you might want to test:
+./resim batches supervise --project "$PROJECT_NAME" --batch-name "$BATCH_NAME" --max-rerun-attempts "$MAX_RERUN_ATTEMPTS" --max-failed-job-threshold "$MAX_FAILED_JOB_THRESHOLD" --rerun-on-states "$RERUN_ON_STATES"
+
+# Or test other commands:
+# ./resim batches create --project "$PROJECT_NAME" --build-id "build-uuid" --experiences "test-exp"
+# ./resim systems create --project "$PROJECT_NAME" --name "test-system" --description "test" --build-vcpus 4


### PR DESCRIPTION
# Description of change
Added a supervise command that takes the args 

```
./resim batches supervise --help
supervise - Supervises batch operations

USAGE
  resim batches supervise [flags]

REQUIRED FLAGS
      --project string   The name or ID of the project to supervise

OPTIONAL FLAGS
      --batch-id string                The ID of the batch to supervise.
      --batch-name string              The name of the batch to supervise (e.g. rejoicing-aquamarine-starfish). If the name is not unique, this supervises the most recent batch with that name.
  -h, --help                           help for supervise
      --max-failed-job-threshold int   Maximum percentage of failed jobs before stopping (1-99, default: 50) (default 50)
      --max-rerun-attempts int         Maximum number of rerun attempts for failed tests (default: 0)
      --poll-every string              Interval between checking batch status, expressed in Golang duration string. (default "30s")
      --rerun-on-states string         States to trigger rerun on (e.g. Warning, Error, Blocker)
```

## Guide to reproduce test results
* Build the client
* use runCommand.sh. Play around with the args, like adding states, changing threshold and so on. 

TODO - Add testing
## Checklist

- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.