### PR TITLE
WOB-3542 | Add metrics set flag to batches, reports, and sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Unreleased
 
-### v0.23.3 - August 21, 2025
+### v0.24.0 - August 21, 2025
 
 - Add support for specifying a metrics set when launching a batch, report, or parameter sweep
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Unreleased
 
+### v0.23.3 - August 21, 2025
+
+- Add support for specifying a metrics set when launching a batch, report, or parameter sweep
+
 ### v0.23.2 - August 19, 2025
 
 - Support for "debug mode" for experiences in Multi Container builds. One container/service can be put into debug mode by using the `--container` option to `resim debug`

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -299,16 +299,7 @@ func createBatch(ccmd *cobra.Command, args []string) {
 		associatedAccount = viper.GetString(batchAccountKey)
 	}
 
-	var metricsSet *string
-	if viper.IsSet(batchMetricsSetKey) {
-		metricsSet = Ptr(viper.GetString(batchMetricsSetKey))
-		// Metrics 2.0 steps will only be run if we use the special pool
-		// label, so let's enable it automatically if the user requested a
-		// metrics set
-		if len(poolLabels) == 0 {
-			poolLabels = append(poolLabels, METRICS_2_POOL_LABEL)
-		}
-	}
+	metricsSet := ProcessMetricsSet(batchMetricsSetKey, &poolLabels)
 
 	// Build the request body
 	body := api.BatchInput{

--- a/cmd/resim/commands/report.go
+++ b/cmd/resim/commands/report.go
@@ -62,6 +62,7 @@ const (
 	reportEndTimestampKey             = "end-timestamp"
 	reportRespectTestSuiteRevisionKey = "respect-revision-boundary"
 	reportMetricsBuildIDKey           = "metrics-build-id"
+	reportMetricsSetKey               = "metrics-set"
 	reportIDKey                       = "report-id"
 	reportNameKey                     = "report-name"
 	reportAccountKey                  = "account"
@@ -90,6 +91,8 @@ func init() {
 	// Metrics Build
 	createReportCmd.Flags().String(reportMetricsBuildIDKey, "", "The ID of the metrics build to use in this report.")
 	createReportCmd.MarkFlagRequired(reportMetricsBuildIDKey)
+	// Metrics Set
+	createReportCmd.Flags().String(reportMetricsSetKey, "", "The name of the metrics set to use in this report.")
 	// Length, Start, End Timestamps
 	createReportCmd.Flags().Int(reportLengthKey, 28, "The length of the report in days, from now. Cannot be used in combination with start and end timestamps. For a more precise report, use the start and end timestamps")
 	createReportCmd.Flags().String(reportStartTimestampKey, time.Now().UTC().String(), "The start timestamp of the report (in a Golang parsable format using RFC3339). Cannot be used in combination with length.")
@@ -189,6 +192,16 @@ func createReport(ccmd *cobra.Command, args []string) {
 		associatedAccount = viper.GetString(reportAccountKey)
 	}
 
+	var metricsSet *string
+	poolLabels := api.PoolLabels{}
+	if viper.IsSet(reportMetricsSetKey) {
+		metricsSet = Ptr(viper.GetString(reportMetricsSetKey))
+		// Metrics 2.0 steps will only be run if we use the special pool
+		// label, so let's enable it automatically if the user requested a
+		// metrics set
+		poolLabels = append(poolLabels, METRICS_2_POOL_LABEL)
+	}
+
 	// Build the request body
 	body := api.ReportInput{
 		TestSuiteID:             testSuite.TestSuiteID,
@@ -199,6 +212,7 @@ func createReport(ccmd *cobra.Command, args []string) {
 		EndTimestamp:            Ptr(endTimestamp),
 		AssociatedAccount:       &associatedAccount,
 		TriggeredVia:            DetermineTriggerMethod(),
+		MetricsSetName:          metricsSet,
 	}
 
 	if viper.IsSet(reportNameKey) {
@@ -207,6 +221,10 @@ func createReport(ccmd *cobra.Command, args []string) {
 
 	if viper.IsSet(reportTestSuiteRevisionKey) {
 		body.TestSuiteRevision = Ptr(viper.GetInt32(reportTestSuiteRevisionKey))
+	}
+
+	if len(poolLabels) > 0 {
+		body.PoolLabels = &poolLabels
 	}
 
 	// Make the request

--- a/cmd/resim/commands/report.go
+++ b/cmd/resim/commands/report.go
@@ -192,15 +192,8 @@ func createReport(ccmd *cobra.Command, args []string) {
 		associatedAccount = viper.GetString(reportAccountKey)
 	}
 
-	var metricsSet *string
 	poolLabels := api.PoolLabels{}
-	if viper.IsSet(reportMetricsSetKey) {
-		metricsSet = Ptr(viper.GetString(reportMetricsSetKey))
-		// Metrics 2.0 steps will only be run if we use the special pool
-		// label, so let's enable it automatically if the user requested a
-		// metrics set
-		poolLabels = append(poolLabels, METRICS_2_POOL_LABEL)
-	}
+	metricsSet := ProcessMetricsSet(reportMetricsSetKey, &poolLabels)
 
 	// Build the request body
 	body := api.ReportInput{

--- a/cmd/resim/commands/sweep.go
+++ b/cmd/resim/commands/sweep.go
@@ -209,16 +209,7 @@ func createSweep(ccmd *cobra.Command, args []string) {
 		}
 	}
 
-	var metricsSet *string
-	if viper.IsSet(sweepMetricsSetKey) {
-		metricsSet = Ptr(viper.GetString(sweepMetricsSetKey))
-		// Metrics 2.0 steps will only be run if we use the special pool
-		// label, so let's enable it automatically if the user requested a
-		// metrics set
-		if len(poolLabels) == 0 {
-			poolLabels = append(poolLabels, METRICS_2_POOL_LABEL)
-		}
-	}
+	metricsSet := ProcessMetricsSet(sweepMetricsSetKey, &poolLabels)
 
 	// Process the associated account: by default, we try to get from CI/CD environment variables
 	// Otherwise, we use the account flag. The default is "".

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const METRICS_2_POOL_LABEL = "resim:metrics2"
+
 // ParseParameterString parses a string in the format "key=value" or "key:value"
 // into a key-value pair. It first tries to split on "=" and falls back to ":" if that fails.
 // This is especially useful for cases where parameter names contain colons, which

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -10,10 +10,29 @@ import (
 	"github.com/compose-spec/compose-go/v2/loader"
 	compose_types "github.com/compose-spec/compose-go/v2/types"
 	"github.com/resim-ai/api-client/api"
+	. "github.com/resim-ai/api-client/ptr"
 	"github.com/spf13/viper"
 )
 
 const METRICS_2_POOL_LABEL = "resim:metrics2"
+
+// ProcessMetricsSet handles the common logic for processing metrics sets
+// and automatically adding the special metrics 2.0 pool label when needed.
+// Returns the metrics set name if set, nil otherwise.
+func ProcessMetricsSet(metricsSetKey string, poolLabels *[]api.PoolLabel) *string {
+	if !viper.IsSet(metricsSetKey) {
+		return nil
+	}
+
+	metricsSet := Ptr(viper.GetString(metricsSetKey))
+
+	// Metrics 2.0 steps will only be run if we use the special pool
+	// label, so let's enable it automatically if the user requested a
+	// metrics set
+	*poolLabels = append(*poolLabels, METRICS_2_POOL_LABEL)
+
+	return metricsSet
+}
 
 // ParseParameterString parses a string in the format "key=value" or "key:value"
 // into a key-value pair. It first tries to split on "=" and falls back to ":" if that fails.


### PR DESCRIPTION
# Description of change

Allow users to specify the metrics set they want when launching a batch, report, or sweep

```bash
resim batches create --metrics-set "hello world"
resim reports create --metrics-set "hello world"
resim sweep create --metrics-set "hello world"
```

https://linear.app/resim/issue/WOB-3542/add-metrics-set-to-resim-cli

## Guide to reproduce test results

Try one of the commands above.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.