### PR TITLE
PRO-257: No-archive flag for experience syncing

### DIFF
--- a/cmd/resim/commands/experience.go
+++ b/cmd/resim/commands/experience.go
@@ -102,6 +102,7 @@ const (
 	experienceKey                     = "experience"
 	experiencesConfigKey              = "experiences-config"
 	experiencesCloneKey               = "clone"
+	experiencesSyncNoArchiveKey       = "no-archive"	
 	experiencesUpdateConfigKey        = "update-config"
 	experienceIDKey                   = "id"
 	experienceDescriptionKey          = "description"
@@ -198,8 +199,12 @@ func init() {
 	syncExperienceCmd.Flags().String(experiencesConfigKey, "", "The path of the experiences config file to sync")
 	syncExperienceCmd.MarkFlagRequired(experiencesConfigKey)
 	syncExperienceCmd.Flags().Bool(experiencesUpdateConfigKey, false, "Whether to update the passed-in config in-place")
+	syncExperienceCmd.Flags().Bool(experiencesSyncNoArchiveKey, false, "Whether to archive experiences not listed in the config file")
+	
 	syncExperienceCmd.Flags().Bool(experiencesCloneKey, false, "Whether to clone the existing database state to the config file rather than the other way around")
 	syncExperienceCmd.MarkFlagsMutuallyExclusive(experiencesUpdateConfigKey, experiencesCloneKey)
+	syncExperienceCmd.MarkFlagsMutuallyExclusive(experiencesSyncNoArchiveKey, experiencesCloneKey)
+
 	experienceCmd.AddCommand(syncExperienceCmd)
 
 	// Systems-related sub-commands:
@@ -674,10 +679,11 @@ func syncExperience(ccmd *cobra.Command, args []string) {
 	projectID := getProjectID(Client, viper.GetString(experienceProjectKey))
 	configPath := viper.GetString(experiencesConfigKey)
 	updateConfig := viper.GetBool(experiencesUpdateConfigKey)
+	noArchive := viper.GetBool(experiencesSyncNoArchiveKey)
 	clone := viper.GetBool(experiencesCloneKey)
 
 	if !clone {
-		experience_sync.SyncExperiences(Client, projectID, configPath, updateConfig)
+		experience_sync.SyncExperiences(Client, projectID, configPath, updateConfig, noArchive)
 	} else {
 		experience_sync.CloneExperiences(Client, projectID, configPath)
 	}

--- a/cmd/resim/commands/sync/command.go
+++ b/cmd/resim/commands/sync/command.go
@@ -13,6 +13,7 @@ func SyncExperiences(client api.ClientWithResponsesInterface,
 	projectID uuid.UUID,
 	configPath string,
 	updateConfig bool,
+	noArchive bool,
 ) {
 	if configPath == "" {
 		log.Fatal("experiences-config not set")
@@ -25,7 +26,7 @@ func SyncExperiences(client api.ClientWithResponsesInterface,
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
-	experienceUpdates, err := computeExperienceUpdates(config, *currentState)
+	experienceUpdates, err := computeExperienceUpdates(config, *currentState, noArchive)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/cmd/resim/commands/sync/experiences.go
+++ b/cmd/resim/commands/sync/experiences.go
@@ -17,8 +17,9 @@ type ExperienceUpdates struct {
 // configuration.
 func computeExperienceUpdates(
 	config *ExperienceSyncConfig,
-	currentState DatabaseState) (*ExperienceUpdates, error) {
-	matchedExperiencesByNewName, err := matchExperiences(config, currentState.ExperiencesByName)
+	currentState DatabaseState,
+        noArchive bool) (*ExperienceUpdates, error) {
+	matchedExperiencesByNewName, err := matchExperiences(config, currentState.ExperiencesByName, noArchive)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to compute experience updates: %w", err)
 	}
@@ -56,7 +57,7 @@ type ExperienceMatch struct {
 
 // Perform a matching of the configured experiences to the current ones by name if possible, or by
 // ID if specified.
-func matchExperiences(config *ExperienceSyncConfig, currentExperiencesByName map[string]*Experience) (map[string]ExperienceMatch, error) {
+func matchExperiences(config *ExperienceSyncConfig, currentExperiencesByName map[string]*Experience, noArchive bool) (map[string]ExperienceMatch, error) {
 	// Our algorithm can be summarized like so:
 	//
 	// For each configured experience, we attempt to match it to an existing experience if
@@ -157,14 +158,15 @@ func matchExperiences(config *ExperienceSyncConfig, currentExperiencesByName map
 		}
 
 	}
-	// Step 4: Any leftover experiences should be archived
+	// Step 4: Any leftover un-archived experiences should be archived or retained if noArchive
+	// is set
 	for _, experience := range remainingCurrentExperiencesByID {
 		if experience.Archived {
 			// No updates needed
 			continue
 		}
 		archivedVersion := *experience
-		archivedVersion.Archived = true
+		archivedVersion.Archived = !noArchive
 		checkedInsert(matches, experience.Name, ExperienceMatch{
 			Original: experience,
 			New:      &archivedVersion,


### PR DESCRIPTION
# Description of change

Add option so we don't archive experiences that aren't listed in the experiences config.

## Guide to reproduce test results
```bash
go test ./cmd/resim/...
```

## Checklist

- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.