### PR TITLE
projects can now have a resim.md

### DIFF
--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -1165,11 +1165,14 @@ type KeyMetricTarget struct {
 
 // LightBatchInput defines model for lightBatchInput.
 type LightBatchInput struct {
-	BatchName      *Name           `json:"batchName,omitempty" yaml:"batchName,omitempty"`
-	BranchID       BranchID        `json:"branchID" yaml:"branchID"`
-	MetricsSetName *MetricsSetName `json:"metricsSetName" yaml:"metricsSetName"`
+	BatchName         *Name              `json:"batchName,omitempty" yaml:"batchName,omitempty"`
+	BranchID          BranchID           `json:"branchID" yaml:"branchID"`
+	MetricsSetName    *MetricsSetName    `json:"metricsSetName" yaml:"metricsSetName"`
+	SystemID          *SystemID          `json:"systemID,omitempty" yaml:"systemID,omitempty"`
+	TestSuiteID       *TestSuiteID       `json:"testSuiteID,omitempty" yaml:"testSuiteID,omitempty"`
+	TestSuiteRevision *TestSuiteRevision `json:"testSuiteRevision,omitempty" yaml:"testSuiteRevision,omitempty"`
 
-	// Version A version string representing your build. For example, this could be a commit sha or semver number
+	// Version Optional. When provided, the latest existing build matching (branchID, systemID, version) is reused; a new build is created only if none is found. When omitted, a new build is always created with version "n/a".
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
@@ -1670,6 +1673,7 @@ type Profile = string
 
 // Project defines model for project.
 type Project struct {
+	AgentMarkdown     *string   `json:"agentMarkdown,omitempty" yaml:"agentMarkdown,omitempty"`
 	Archived          Archived  `json:"archived" yaml:"archived"`
 	CreationTimestamp Timestamp `json:"creationTimestamp" yaml:"creationTimestamp"`
 	Description       string    `json:"description" yaml:"description"`
@@ -2051,8 +2055,9 @@ type UpdateMask = []string
 
 // UpdateProjectFields defines model for updateProjectFields.
 type UpdateProjectFields struct {
-	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
-	Name        *string `json:"name,omitempty" yaml:"name,omitempty"`
+	AgentMarkdown *string `json:"agentMarkdown,omitempty" yaml:"agentMarkdown,omitempty"`
+	Description   *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Name          *string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 // UpdateProjectInput defines model for updateProjectInput.
@@ -3637,6 +3642,9 @@ type ClientInterface interface {
 
 	// GetSystemsForExperience request
 	GetSystemsForExperience(ctx context.Context, projectID ProjectID, experienceID ExperienceID, params *GetSystemsForExperienceParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetLogByID request
+	GetLogByID(ctx context.Context, projectID ProjectID, logID LogID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListMetricsBuilds request
 	ListMetricsBuilds(ctx context.Context, projectID ProjectID, params *ListMetricsBuildsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5386,6 +5394,18 @@ func (c *Client) RestoreExperience(ctx context.Context, projectID ProjectID, exp
 
 func (c *Client) GetSystemsForExperience(ctx context.Context, projectID ProjectID, experienceID ExperienceID, params *GetSystemsForExperienceParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetSystemsForExperienceRequest(c.Server, projectID, experienceID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetLogByID(ctx context.Context, projectID ProjectID, logID LogID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetLogByIDRequest(c.Server, projectID, logID)
 	if err != nil {
 		return nil, err
 	}
@@ -13067,6 +13087,47 @@ func NewGetSystemsForExperienceRequest(server string, projectID ProjectID, exper
 	return req, nil
 }
 
+// NewGetLogByIDRequest generates requests for GetLogByID
+func NewGetLogByIDRequest(server string, projectID ProjectID, logID LogID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "projectID", runtime.ParamLocationPath, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "logID", runtime.ParamLocationPath, logID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/logs/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListMetricsBuildsRequest generates requests for ListMetricsBuilds
 func NewListMetricsBuildsRequest(server string, projectID ProjectID, params *ListMetricsBuildsParams) (*http.Request, error) {
 	var err error
@@ -17835,6 +17896,9 @@ type ClientWithResponsesInterface interface {
 	// GetSystemsForExperienceWithResponse request
 	GetSystemsForExperienceWithResponse(ctx context.Context, projectID ProjectID, experienceID ExperienceID, params *GetSystemsForExperienceParams, reqEditors ...RequestEditorFn) (*GetSystemsForExperienceResponse, error)
 
+	// GetLogByIDWithResponse request
+	GetLogByIDWithResponse(ctx context.Context, projectID ProjectID, logID LogID, reqEditors ...RequestEditorFn) (*GetLogByIDResponse, error)
+
 	// ListMetricsBuildsWithResponse request
 	ListMetricsBuildsWithResponse(ctx context.Context, projectID ProjectID, params *ListMetricsBuildsParams, reqEditors ...RequestEditorFn) (*ListMetricsBuildsResponse, error)
 
@@ -20245,6 +20309,28 @@ func (r GetSystemsForExperienceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetSystemsForExperienceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetLogByIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *JobLog
+}
+
+// Status returns HTTPResponse.Status
+func (r GetLogByIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetLogByIDResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -22898,6 +22984,15 @@ func (c *ClientWithResponses) GetSystemsForExperienceWithResponse(ctx context.Co
 		return nil, err
 	}
 	return ParseGetSystemsForExperienceResponse(rsp)
+}
+
+// GetLogByIDWithResponse request returning *GetLogByIDResponse
+func (c *ClientWithResponses) GetLogByIDWithResponse(ctx context.Context, projectID ProjectID, logID LogID, reqEditors ...RequestEditorFn) (*GetLogByIDResponse, error) {
+	rsp, err := c.GetLogByID(ctx, projectID, logID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetLogByIDResponse(rsp)
 }
 
 // ListMetricsBuildsWithResponse request returning *ListMetricsBuildsResponse
@@ -26079,6 +26174,32 @@ func ParseGetSystemsForExperienceResponse(rsp *http.Response) (*GetSystemsForExp
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ListSystemsOutput
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetLogByIDResponse parses an HTTP response from a GetLogByIDWithResponse call
+func ParseGetLogByIDResponse(rsp *http.Response) (*GetLogByIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetLogByIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest JobLog
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/api/mocks/client_interface.gen.go
+++ b/api/mocks/client_interface.gen.go
@@ -7157,6 +7157,81 @@ func (_c *ClientInterface_GetJobLog_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// GetLogByID provides a mock function with given fields: ctx, projectID, logID, reqEditors
+func (_m *ClientInterface) GetLogByID(ctx context.Context, projectID uuid.UUID, logID uuid.UUID, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, projectID, logID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLogByID")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, projectID, logID, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, projectID, logID, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, projectID, logID, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_GetLogByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLogByID'
+type ClientInterface_GetLogByID_Call struct {
+	*mock.Call
+}
+
+// GetLogByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID uuid.UUID
+//   - logID uuid.UUID
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) GetLogByID(ctx interface{}, projectID interface{}, logID interface{}, reqEditors ...interface{}) *ClientInterface_GetLogByID_Call {
+	return &ClientInterface_GetLogByID_Call{Call: _e.mock.On("GetLogByID",
+		append([]interface{}{ctx, projectID, logID}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_GetLogByID_Call) Run(run func(ctx context.Context, projectID uuid.UUID, logID uuid.UUID, reqEditors ...api.RequestEditorFn)) *ClientInterface_GetLogByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(uuid.UUID), args[2].(uuid.UUID), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_GetLogByID_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_GetLogByID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_GetLogByID_Call) RunAndReturn(run func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_GetLogByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLogStream provides a mock function with given fields: ctx, projectID, batchID, jobID, logName, reqEditors
 func (_m *ClientInterface) GetLogStream(ctx context.Context, projectID uuid.UUID, batchID uuid.UUID, jobID uuid.UUID, logName string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/api/mocks/client_with_responses_interface.gen.go
+++ b/api/mocks/client_with_responses_interface.gen.go
@@ -7155,6 +7155,81 @@ func (_c *ClientWithResponsesInterface_GetJobWithResponse_Call) RunAndReturn(run
 	return _c
 }
 
+// GetLogByIDWithResponse provides a mock function with given fields: ctx, projectID, logID, reqEditors
+func (_m *ClientWithResponsesInterface) GetLogByIDWithResponse(ctx context.Context, projectID uuid.UUID, logID uuid.UUID, reqEditors ...api.RequestEditorFn) (*api.GetLogByIDResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, projectID, logID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLogByIDWithResponse")
+	}
+
+	var r0 *api.GetLogByIDResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) (*api.GetLogByIDResponse, error)); ok {
+		return rf(ctx, projectID, logID, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) *api.GetLogByIDResponse); ok {
+		r0 = rf(ctx, projectID, logID, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.GetLogByIDResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, projectID, logID, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_GetLogByIDWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLogByIDWithResponse'
+type ClientWithResponsesInterface_GetLogByIDWithResponse_Call struct {
+	*mock.Call
+}
+
+// GetLogByIDWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID uuid.UUID
+//   - logID uuid.UUID
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) GetLogByIDWithResponse(ctx interface{}, projectID interface{}, logID interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_GetLogByIDWithResponse_Call {
+	return &ClientWithResponsesInterface_GetLogByIDWithResponse_Call{Call: _e.mock.On("GetLogByIDWithResponse",
+		append([]interface{}{ctx, projectID, logID}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_GetLogByIDWithResponse_Call) Run(run func(ctx context.Context, projectID uuid.UUID, logID uuid.UUID, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_GetLogByIDWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(uuid.UUID), args[2].(uuid.UUID), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_GetLogByIDWithResponse_Call) Return(_a0 *api.GetLogByIDResponse, _a1 error) *ClientWithResponsesInterface_GetLogByIDWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_GetLogByIDWithResponse_Call) RunAndReturn(run func(context.Context, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) (*api.GetLogByIDResponse, error)) *ClientWithResponsesInterface_GetLogByIDWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLogStreamWithResponse provides a mock function with given fields: ctx, projectID, batchID, jobID, logName, reqEditors
 func (_m *ClientWithResponsesInterface) GetLogStreamWithResponse(ctx context.Context, projectID uuid.UUID, batchID uuid.UUID, jobID uuid.UUID, logName string, reqEditors ...api.RequestEditorFn) (*api.GetLogStreamResponse, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/cmd/resim/commands/project.go
+++ b/cmd/resim/commands/project.go
@@ -59,13 +59,21 @@ var (
 		Long:  ``,
 		Run:   selectProject,
 	}
+
+	updateProjectCmd = &cobra.Command{
+		Use:   "update",
+		Short: "update - Updates an existing project",
+		Long:  ``,
+		Run:   updateProject,
+	}
 )
 
 const (
-	projectKey            = "project"
-	projectNameKey        = "name"
-	projectDescriptionKey = "description"
-	projectGithubKey      = "github"
+	projectKey                  = "project"
+	projectNameKey              = "name"
+	projectDescriptionKey       = "description"
+	projectGithubKey            = "github"
+	projectAgentMarkdownFileKey = "agent-markdown-file"
 )
 
 func init() {
@@ -89,6 +97,13 @@ func init() {
 	projectCmd.AddCommand(listProjectsCmd)
 
 	projectCmd.AddCommand(selectProjectCmd)
+
+	updateProjectCmd.Flags().String(projectKey, "", "The name or the ID of the project to update")
+	updateProjectCmd.MarkFlagRequired(projectKey)
+	updateProjectCmd.Flags().String(projectNameKey, "", "New name for the project")
+	updateProjectCmd.Flags().String(projectDescriptionKey, "", "New description for the project")
+	updateProjectCmd.Flags().String(projectAgentMarkdownFileKey, "", "Path to a markdown file containing agent rules for this project")
+	projectCmd.AddCommand(updateProjectCmd)
 
 	rootCmd.AddCommand(projectCmd)
 }
@@ -313,6 +328,34 @@ func getProjectID(client api.ClientWithResponsesInterface, identifier string) uu
 		log.Fatal("failed to find project with name or ID: ", identifier)
 	}
 	return projectID
+}
+
+func updateProject(ccmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(projectKey))
+	fields := api.UpdateProjectFields{}
+	if ccmd.Flags().Changed(projectNameKey) {
+		fields.Name = Ptr(viper.GetString(projectNameKey))
+	}
+	if ccmd.Flags().Changed(projectDescriptionKey) {
+		fields.Description = Ptr(viper.GetString(projectDescriptionKey))
+	}
+	if ccmd.Flags().Changed(projectAgentMarkdownFileKey) {
+		filePath := viper.GetString(projectAgentMarkdownFileKey)
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			log.Fatal("failed to read agent markdown file: ", err)
+		}
+		fields.AgentMarkdown = Ptr(string(content))
+	}
+	body := api.UpdateProjectInput{
+		Project: &fields,
+	}
+	response, err := Client.UpdateProjectWithResponse(context.Background(), projectID, body)
+	if err != nil {
+		log.Fatal("failed to update project: ", err)
+	}
+	ValidateResponse(http.StatusOK, "failed to update project", response.HTTPResponse, response.Body)
+	fmt.Println("Updated project successfully!")
 }
 
 func aliasProjectNameFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {


### PR DESCRIPTION
# Add agent markdown support to projects

Projects can now store a markdown rules file that gets automatically injected into the IDE handoff prompt. When a user redeems a handoff token in their IDE, the project's agent markdown is prepended to the chat prompt so the AI coding assistant has project-specific
context from the start.

## API changes

- Added `agentMarkdown` field to Project and UpdateProjectFields models
- Added `agent_markdown` column to the projects table (nullable TEXT)

## CLI

- Added `resim projects update` command supporting `--name`, `--description`, and `--agent-markdown <path>` (reads markdown content from a local file)

## Codegen sync

- Regenerated client from production spec — picks up `GetLogByID` endpoint and extended `LightBatchInput` fields (systemID, testSuiteID, testSuiteRevision) that were already live in the API

---

## Guide to reproduce test results

1. Test project updates:
2. Test enhanced batch input with new optional fields when creating light batches

## Checklist

- [x] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
- [ ] I have updated the changelog, if appropriate.