### PR TITLE
Override and/or Ignore Metrics Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.48.1 - April 1, 2026
+
+- Fixes a bug where you can't determine to ignore the metrics set. Adds `--ignore-metrics-set`.
+
 ### v0.48.0 - March 27, 2026
 - Updates default `--metrics-config-path` to `.resim/metrics/config.resim.yml` to match rest of our tooling.
 - Updates `resim logs download` to support new "System Logs" feature. These will be downloaded to a `logs/` directory.

--- a/cmd/resim/commands/sync/command.go
+++ b/cmd/resim/commands/sync/command.go
@@ -2,11 +2,12 @@ package sync
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
 	"gopkg.in/yaml.v3"
-	"log"
-	"os"
 )
 
 func SyncExperiences(client api.ClientWithResponsesInterface,

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -94,6 +94,7 @@ const (
 	testSuiteMetricsBuildKey            = "metrics-build"
 	testSuiteMetricsSetKey              = "metrics-set"
 	testSuitePoolLabelsKey              = "pool-labels"
+	testSuiteIgnoreMetricsSetKey        = "ignore-metrics-set"
 	testSuiteAccountKey                 = "account"
 	testSuiteShowOnSummaryKey           = "show-on-summary"
 	testSuiteBatchNameKey               = "batch-name"
@@ -203,6 +204,7 @@ func init() {
 	runTestSuiteCmd.Flags().StringSlice(testSuiteParameterKey, []string{}, "(Optional) Parameter overrides to pass to the build. Format: <parameter-name>=<parameter-value> or <parameter-name>:<parameter-value>. The equals sign (=) is recommended, especially if parameter names contain colons. Accepts repeated parameters or comma-separated parameters e.g. 'param1=value1,param2=value2'. If multiple = signs are used, the first one will be used to determine the key, and the rest will be part of the value.")
 	// Pool Labels
 	runTestSuiteCmd.Flags().StringSlice(testSuitePoolLabelsKey, []string{}, "Pool labels to determine where to run this test suite. Pool labels are interpreted as a logical AND. Accepts repeated labels or comma-separated labels.")
+	runTestSuiteCmd.Flags().Bool(testSuiteIgnoreMetricsSetKey, false, "If set, do not automatically add the default resim:metrics2 pool label when the test suite has a metrics set.")
 	runTestSuiteCmd.Flags().String(testSuiteAccountKey, "", "Specify a username for a CI/CD platform account to associate with this test suite run.")
 	// Optional: Friendly name
 	runTestSuiteCmd.Flags().String(testSuiteBatchNameKey, "", "An optional name for the batch. If not supplied, ReSim generates a pseudo-unique name e.g rejoicing-aquamarine-starfish. This name need not be unique, but uniqueness is recommended to make it easier to identify batches.")
@@ -604,7 +606,7 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 
 	poolLabels := getAndValidatePoolLabels(testSuitePoolLabelsKey)
 
-	if testSuite.MetricsSetName != nil {
+	if HasMetricsSetName(testSuite.MetricsSetName) && !viper.GetBool(testSuiteIgnoreMetricsSetKey) {
 		AddMetrics2PoolLabels(&poolLabels)
 	}
 
@@ -646,7 +648,7 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 			ExperienceIDs:     &testSuite.Experiences,
 			Parameters:        &parameters,
 			AssociatedAccount: &associatedAccount,
-			MetricsSetName:    testSuite.MetricsSetName,
+			MetricsSetName:    NormalizeMetricsSetName(testSuite.MetricsSetName),
 		}
 
 		// Add the pool labels if any

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -100,6 +100,7 @@ const (
 	testSuiteBatchNameKey               = "batch-name"
 	testSuiteAllowableFailurePercentKey = "allowable-failure-percent"
 	testSuiteMetricsBuildOverrideKey    = "metrics-build-override"
+	testSuiteMetricsSetOverrideKey      = "metrics-set-name-override"
 	testSuiteSyncMetricsConfigKey       = "sync-metrics-config"
 	testSuitesMetricsConfigPathKey      = "metrics-config-path"
 	testSuitesMetricsTemplatesPathKey   = "metrics-templates-path"
@@ -211,6 +212,7 @@ func init() {
 	runTestSuiteCmd.Flags().Int(testSuiteAllowableFailurePercentKey, 0, "An optional percentage (0-100) that determines the maximum percentage of tests that can have an execution error and have aggregate metrics be computed and consider the batch successfully completed. If not supplied, ReSim defaults to 0, which means that the batch will only be considered successful if all tests complete successfully.")
 	// Optional: Metrics build override:
 	runTestSuiteCmd.Flags().String(testSuiteMetricsBuildOverrideKey, "", "An optional ID of a metrics build to override the standard metrics build in this test suite run (which will be run as an adhoc batch).")
+	runTestSuiteCmd.Flags().String(testSuiteMetricsSetOverrideKey, "", "An optional metrics set name to override the test suite's metrics set for this run. Supplying this flag runs the test suite as an adhoc batch.")
 	// Optional: Sync metrics config
 	runTestSuiteCmd.Flags().Bool(testSuiteSyncMetricsConfigKey, false, "If set, run metrics sync before running the test suite")
 	runTestSuiteCmd.Flags().StringSlice(testSuitesMetricsConfigPathKey, []string{".resim/metrics/config.resim.yml"}, "The path(s) to the metrics config file(s). Supports glob patterns (e.g. \"metrics/*.yml\"). Can be specified multiple times or comma-separated. Files are merged in order. Only used if sync-metrics-config is set to true")
@@ -605,8 +607,12 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 	}
 
 	poolLabels := getAndValidatePoolLabels(testSuitePoolLabelsKey)
+	effectiveMetricsSetName := NormalizeMetricsSetName(testSuite.MetricsSetName)
+	if viper.IsSet(testSuiteMetricsSetOverrideKey) {
+		effectiveMetricsSetName = NormalizeMetricsSetName(Ptr(viper.GetString(testSuiteMetricsSetOverrideKey)))
+	}
 
-	if HasMetricsSetName(testSuite.MetricsSetName) && !viper.GetBool(testSuiteIgnoreMetricsSetKey) {
+	if HasMetricsSetName(effectiveMetricsSetName) && !viper.GetBool(testSuiteIgnoreMetricsSetKey) {
 		AddMetrics2PoolLabels(&poolLabels)
 	}
 
@@ -635,20 +641,24 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 	}
 
 	var batch api.Batch
-	// If the user supplies a metrics build override, we run an adhoc batch:
-	if viper.IsSet(testSuiteMetricsBuildOverrideKey) {
-		metricsBuildID, err := uuid.Parse(viper.GetString(testSuiteMetricsBuildOverrideKey))
-		if err != nil {
-			log.Fatal("failed to parse metrics-build ID: ", err)
+	// If the user supplies an override, we run an adhoc batch:
+	if viper.IsSet(testSuiteMetricsBuildOverrideKey) || viper.IsSet(testSuiteMetricsSetOverrideKey) {
+		var metricsBuildID *uuid.UUID
+		if viper.IsSet(testSuiteMetricsBuildOverrideKey) {
+			parsedMetricsBuildID, err := uuid.Parse(viper.GetString(testSuiteMetricsBuildOverrideKey))
+			if err != nil {
+				log.Fatal("failed to parse metrics-build ID: ", err)
+			}
+			metricsBuildID = &parsedMetricsBuildID
 		}
 		// Build the request body
 		body := api.BatchInput{
 			BuildID:           &buildID,
-			MetricsBuildID:    &metricsBuildID,
+			MetricsBuildID:    metricsBuildID,
 			ExperienceIDs:     &testSuite.Experiences,
 			Parameters:        &parameters,
 			AssociatedAccount: &associatedAccount,
-			MetricsSetName:    NormalizeMetricsSetName(testSuite.MetricsSetName),
+			MetricsSetName:    effectiveMetricsSetName,
 		}
 
 		// Add the pool labels if any

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -191,6 +191,21 @@ func mergeConfigFiles(paths []string, verbose bool) ([]byte, error) {
 
 const METRICS_2_POOL_LABEL = "resim:metrics2"
 
+// HasMetricsSetName returns true when the metrics set pointer references a
+// non-empty metrics set name.
+func HasMetricsSetName(metricsSet *string) bool {
+	return metricsSet != nil && *metricsSet != ""
+}
+
+// NormalizeMetricsSetName returns nil when a metrics set name is missing or
+// explicitly empty so runtime callers can treat both cases as "unset".
+func NormalizeMetricsSetName(metricsSet *string) *string {
+	if !HasMetricsSetName(metricsSet) {
+		return nil
+	}
+	return metricsSet
+}
+
 // Add Metrics 2.0 Pool labels to the list of pool labels:
 func AddMetrics2PoolLabels(poolLabels *[]api.PoolLabel) {
 	*poolLabels = append(*poolLabels, METRICS_2_POOL_LABEL)
@@ -205,6 +220,9 @@ func ProcessMetricsSet(metricsSetKey string, poolLabels *[]api.PoolLabel) *strin
 	}
 
 	metricsSet := Ptr(viper.GetString(metricsSetKey))
+	if !HasMetricsSetName(metricsSet) {
+		return nil
+	}
 
 	// Metrics 2.0 steps will only be run if we use the special pool
 	// label, so let's enable it automatically if the user requested a

--- a/cmd/resim/commands/utils_test.go
+++ b/cmd/resim/commands/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/resim-ai/api-client/api"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -620,4 +621,53 @@ func TestAddMetrics2PoolLabelsWithExistingLabels(t *testing.T) {
 	AddMetrics2PoolLabels(&poolLabels)
 	assert.Contains(t, poolLabels, METRICS_2_POOL_LABEL)
 	assert.Equal(t, []api.PoolLabel{"foo", "bar", METRICS_2_POOL_LABEL}, poolLabels)
+}
+
+func TestHasMetricsSetName(t *testing.T) {
+	metricsSetName := "metrics-set"
+	emptyMetricsSetName := ""
+
+	assert.False(t, HasMetricsSetName(nil))
+	assert.False(t, HasMetricsSetName(&emptyMetricsSetName))
+	assert.True(t, HasMetricsSetName(&metricsSetName))
+}
+
+func TestNormalizeMetricsSetName(t *testing.T) {
+	metricsSetName := "metrics-set"
+	emptyMetricsSetName := ""
+
+	assert.Nil(t, NormalizeMetricsSetName(nil))
+	assert.Nil(t, NormalizeMetricsSetName(&emptyMetricsSetName))
+	assert.Equal(t, &metricsSetName, NormalizeMetricsSetName(&metricsSetName))
+}
+
+func TestProcessMetricsSetEmptyStringSkipsPoolLabel(t *testing.T) {
+	const metricsSetKey = "test-empty-metrics-set"
+	t.Cleanup(func() {
+		viper.Set(metricsSetKey, nil)
+	})
+
+	viper.Set(metricsSetKey, "")
+	poolLabels := []api.PoolLabel{"foo"}
+
+	metricsSet := ProcessMetricsSet(metricsSetKey, &poolLabels)
+
+	assert.Nil(t, metricsSet)
+	assert.Equal(t, []api.PoolLabel{"foo"}, poolLabels)
+}
+
+func TestProcessMetricsSetAddsPoolLabelForNonEmptyValue(t *testing.T) {
+	const metricsSetKey = "test-non-empty-metrics-set"
+	t.Cleanup(func() {
+		viper.Set(metricsSetKey, nil)
+	})
+
+	viper.Set(metricsSetKey, "metrics-set")
+	poolLabels := []api.PoolLabel{"foo"}
+
+	metricsSet := ProcessMetricsSet(metricsSetKey, &poolLabels)
+
+	assert.NotNil(t, metricsSet)
+	assert.Equal(t, "metrics-set", *metricsSet)
+	assert.Equal(t, []api.PoolLabel{"foo", METRICS_2_POOL_LABEL}, poolLabels)
 }

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
-	github.com/schollz/progressbar/v3 v3.18.0 // indirect
 	github.com/sirupsen/logrus v1.9.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.0 // indirect

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -2550,7 +2550,7 @@ func getTestSuiteBatches(projectID uuid.UUID, testSuiteName string, revision *in
 	return []CommandBuilder{testSuitesCommand, batchesCommand}
 }
 
-func runTestSuite(projectID uuid.UUID, testSuiteName string, revision *int32, buildID string, parameters map[string]string, github bool, account string, batchName *string, allowableFailurePercent *int, metricsBuildID *string, ignoreMetricsSet bool) []CommandBuilder {
+func runTestSuite(projectID uuid.UUID, testSuiteName string, revision *int32, buildID string, parameters map[string]string, github bool, account string, batchName *string, allowableFailurePercent *int, metricsBuildID *string, metricsSetOverride *string, ignoreMetricsSet bool) []CommandBuilder {
 	// We build a get batch command with the name flag
 	testSuiteCommand := CommandBuilder{
 		Command: "suites",
@@ -2617,6 +2617,13 @@ func runTestSuite(projectID uuid.UUID, testSuiteName string, revision *int32, bu
 		runCommand.Flags = append(runCommand.Flags, Flag{
 			Name:  "--metrics-build-override",
 			Value: *metricsBuildID,
+		})
+	}
+
+	if metricsSetOverride != nil {
+		runCommand.Flags = append(runCommand.Flags, Flag{
+			Name:  "--metrics-set-name-override",
+			Value: *metricsSetOverride,
 		})
 	}
 
@@ -5350,7 +5357,7 @@ func TestTestSuites(t *testing.T) {
 	ts.Len(testSuite.Experiences, 1)
 	ts.ElementsMatch(experienceIDs[0], testSuite.Experiences[0])
 	// Then run.
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, nil, nil, false), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, nil, nil, nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
 	// Then list the test suite batches
 	output = s.runCommand(ts, getTestSuiteBatches(projectID, firstTestSuiteName, nil), ExpectNoError)
@@ -5365,7 +5372,7 @@ func TestTestSuites(t *testing.T) {
 
 	// Create a new run using github and with a specific batch name:
 	batchName := fmt.Sprintf("test-batch-%s", uuid.New().String())
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, &batchName, Ptr(100), nil, false), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, &batchName, Ptr(100), nil, nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, GithubCreatedBatch)
 	// Parse the output to get a batch id:
 	batchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
@@ -5390,13 +5397,13 @@ func TestTestSuites(t *testing.T) {
 	ts.True(found)
 
 	// Try running a test suite with a non-percentage allowable failure percent:
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(101), nil, false), ExpectError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(101), nil, nil, false), ExpectError)
 	ts.Contains(output.StdErr, AllowableFailurePercent)
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(-1), nil, false), ExpectError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(-1), nil, nil, false), ExpectError)
 	ts.Contains(output.StdErr, AllowableFailurePercent)
 
 	// Try running a test suite with a metrics build override:
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, nil, nil, Ptr(metricsBuildIDString), false), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, nil, nil, Ptr(metricsBuildIDString), nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, GithubCreatedBatch)
 	// Parse the output to get a batch id:
 	batchIDString = output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
@@ -5415,6 +5422,19 @@ func TestTestSuites(t *testing.T) {
 	ts.Len(jobs, 1)
 	// The job should have the correct experience ID:
 	ts.Equal(experienceIDs[0], *jobs[0].ExperienceID)
+
+	// Try running a test suite with a metrics set override, which should force an adhoc batch:
+	metricsSetOverrideName := fmt.Sprintf("metrics-set-override-%s", uuid.New().String())
+	metricsSetOverrideBatchName := fmt.Sprintf("metrics-set-override-batch-%s", uuid.New().String())
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &metricsSetOverrideBatchName, nil, nil, &metricsSetOverrideName, false), ExpectNoError)
+	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
+	output = s.runCommand(ts, getBatchByName(projectID, metricsSetOverrideBatchName, ExitStatusFalse), ExpectNoError)
+	err = json.Unmarshal([]byte(output.StdOut), &batch)
+	ts.NoError(err)
+	ts.NotNil(batch.MetricsSetName)
+	ts.Equal(metricsSetOverrideName, *batch.MetricsSetName)
+	ts.NotNil(batch.PoolLabels)
+	ts.Contains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
 
 	// Archive the test suite
 	output = s.runCommand(ts, archiveTestSuite(projectID, firstTestSuiteName), false)
@@ -5456,7 +5476,7 @@ func TestTestSuites(t *testing.T) {
 	ts.Equal(emptyMetricsSet, *testSuite.MetricsSetName)
 
 	emptyMetricsPoolBatchName := fmt.Sprintf("empty-metrics-pool-batch-%s", uuid.New().String())
-	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &emptyMetricsPoolBatchName, nil, nil, false), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &emptyMetricsPoolBatchName, nil, nil, nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
 	output = s.runCommand(ts, getBatchByName(projectID, emptyMetricsPoolBatchName, ExitStatusFalse), ExpectNoError)
 	err = json.Unmarshal([]byte(output.StdOut), &batch)
@@ -5476,7 +5496,7 @@ func TestTestSuites(t *testing.T) {
 	ts.Equal(newMetricsSetName, *testSuite.MetricsSetName)
 
 	defaultMetricsPoolBatchName := fmt.Sprintf("metrics-pool-batch-%s", uuid.New().String())
-	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &defaultMetricsPoolBatchName, nil, nil, false), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &defaultMetricsPoolBatchName, nil, nil, nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
 	output = s.runCommand(ts, getBatchByName(projectID, defaultMetricsPoolBatchName, ExitStatusFalse), ExpectNoError)
 	err = json.Unmarshal([]byte(output.StdOut), &batch)
@@ -5485,7 +5505,7 @@ func TestTestSuites(t *testing.T) {
 	ts.Contains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
 
 	noMetricsPoolBatchName := fmt.Sprintf("no-metrics-pool-batch-%s", uuid.New().String())
-	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &noMetricsPoolBatchName, nil, nil, true), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &noMetricsPoolBatchName, nil, nil, nil, true), ExpectNoError)
 	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
 	output = s.runCommand(ts, getBatchByName(projectID, noMetricsPoolBatchName, ExitStatusFalse), ExpectNoError)
 	err = json.Unmarshal([]byte(output.StdOut), &batch)

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -2550,7 +2550,7 @@ func getTestSuiteBatches(projectID uuid.UUID, testSuiteName string, revision *in
 	return []CommandBuilder{testSuitesCommand, batchesCommand}
 }
 
-func runTestSuite(projectID uuid.UUID, testSuiteName string, revision *int32, buildID string, parameters map[string]string, github bool, account string, batchName *string, allowableFailurePercent *int, metricsBuildID *string) []CommandBuilder {
+func runTestSuite(projectID uuid.UUID, testSuiteName string, revision *int32, buildID string, parameters map[string]string, github bool, account string, batchName *string, allowableFailurePercent *int, metricsBuildID *string, ignoreMetricsSet bool) []CommandBuilder {
 	// We build a get batch command with the name flag
 	testSuiteCommand := CommandBuilder{
 		Command: "suites",
@@ -2617,6 +2617,13 @@ func runTestSuite(projectID uuid.UUID, testSuiteName string, revision *int32, bu
 		runCommand.Flags = append(runCommand.Flags, Flag{
 			Name:  "--metrics-build-override",
 			Value: *metricsBuildID,
+		})
+	}
+
+	if ignoreMetricsSet {
+		runCommand.Flags = append(runCommand.Flags, Flag{
+			Name:  "--ignore-metrics-set",
+			Value: "",
 		})
 	}
 
@@ -5343,7 +5350,7 @@ func TestTestSuites(t *testing.T) {
 	ts.Len(testSuite.Experiences, 1)
 	ts.ElementsMatch(experienceIDs[0], testSuite.Experiences[0])
 	// Then run.
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, nil, nil), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, nil, nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
 	// Then list the test suite batches
 	output = s.runCommand(ts, getTestSuiteBatches(projectID, firstTestSuiteName, nil), ExpectNoError)
@@ -5358,7 +5365,7 @@ func TestTestSuites(t *testing.T) {
 
 	// Create a new run using github and with a specific batch name:
 	batchName := fmt.Sprintf("test-batch-%s", uuid.New().String())
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, &batchName, Ptr(100), nil), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, &batchName, Ptr(100), nil, false), ExpectNoError)
 	ts.Contains(output.StdOut, GithubCreatedBatch)
 	// Parse the output to get a batch id:
 	batchIDString := output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
@@ -5383,13 +5390,13 @@ func TestTestSuites(t *testing.T) {
 	ts.True(found)
 
 	// Try running a test suite with a non-percentage allowable failure percent:
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(101), nil), ExpectError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(101), nil, false), ExpectError)
 	ts.Contains(output.StdErr, AllowableFailurePercent)
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(-1), nil), ExpectError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, nil, Ptr(-1), nil, false), ExpectError)
 	ts.Contains(output.StdErr, AllowableFailurePercent)
 
 	// Try running a test suite with a metrics build override:
-	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, nil, nil, Ptr(metricsBuildIDString)), ExpectNoError)
+	output = s.runCommand(ts, runTestSuite(projectID, firstTestSuiteName, nil, buildIDString, map[string]string{}, GithubTrue, AssociatedAccount, nil, nil, Ptr(metricsBuildIDString), false), ExpectNoError)
 	ts.Contains(output.StdOut, GithubCreatedBatch)
 	// Parse the output to get a batch id:
 	batchIDString = output.StdOut[len(GithubCreatedBatch) : len(output.StdOut)-1]
@@ -5448,6 +5455,16 @@ func TestTestSuites(t *testing.T) {
 	ts.NotNil(testSuite.MetricsSetName)
 	ts.Equal(emptyMetricsSet, *testSuite.MetricsSetName)
 
+	emptyMetricsPoolBatchName := fmt.Sprintf("empty-metrics-pool-batch-%s", uuid.New().String())
+	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &emptyMetricsPoolBatchName, nil, nil, false), ExpectNoError)
+	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
+	output = s.runCommand(ts, getBatchByName(projectID, emptyMetricsPoolBatchName, ExitStatusFalse), ExpectNoError)
+	err = json.Unmarshal([]byte(output.StdOut), &batch)
+	ts.NoError(err)
+	if batch.PoolLabels != nil {
+		ts.NotContains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+	}
+
 	// Then set a new metrics set name
 	newMetricsSetName := fmt.Sprintf("metrics-set-%s", uuid.New().String())
 	output = s.runCommand(ts, reviseTestSuite(projectID, metricsSetTestSuiteName, nil, nil, nil, Ptr([]string{experienceNames[0]}), nil, nil, &newMetricsSetName, GithubFalse), ExpectNoError)
@@ -5457,6 +5474,25 @@ func TestTestSuites(t *testing.T) {
 	ts.NoError(err)
 	ts.NotNil(testSuite.MetricsSetName)
 	ts.Equal(newMetricsSetName, *testSuite.MetricsSetName)
+
+	defaultMetricsPoolBatchName := fmt.Sprintf("metrics-pool-batch-%s", uuid.New().String())
+	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &defaultMetricsPoolBatchName, nil, nil, false), ExpectNoError)
+	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
+	output = s.runCommand(ts, getBatchByName(projectID, defaultMetricsPoolBatchName, ExitStatusFalse), ExpectNoError)
+	err = json.Unmarshal([]byte(output.StdOut), &batch)
+	ts.NoError(err)
+	ts.NotNil(batch.PoolLabels)
+	ts.Contains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+
+	noMetricsPoolBatchName := fmt.Sprintf("no-metrics-pool-batch-%s", uuid.New().String())
+	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &noMetricsPoolBatchName, nil, nil, true), ExpectNoError)
+	ts.Contains(output.StdOut, CreatedTestSuiteBatch)
+	output = s.runCommand(ts, getBatchByName(projectID, noMetricsPoolBatchName, ExitStatusFalse), ExpectNoError)
+	err = json.Unmarshal([]byte(output.StdOut), &batch)
+	ts.NoError(err)
+	if batch.PoolLabels != nil {
+		ts.NotContains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+	}
 }
 func TestReports(t *testing.T) {
 	ts := assert.New(t)


### PR DESCRIPTION
# Description of change

ReSim customers can currently live in two phases as we roll out our new metrics iteration. This PR makes it easy to maintain a test suite using both.

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.