### PR TITLE
Don't add pool labels when triggering a test suite batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## ReSim CLI
 
+### v0.48.3 - April 15, 2026
+- Removes the automatic addition of the `resim:metrics2` pool label when a metrics set is specified. This is now handled by the backend.
+
 ### v0.48.2 - April 11, 2026
 
 - Fixes a bug where `--metrics-set-name-override` on `test-suites run` would clear the test suite's metrics build ID when `--metrics-build-override` was not also supplied.

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -612,10 +612,6 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 		effectiveMetricsSetName = NormalizeMetricsSetName(Ptr(viper.GetString(testSuiteMetricsSetOverrideKey)))
 	}
 
-	if HasMetricsSetName(effectiveMetricsSetName) && !viper.GetBool(testSuiteIgnoreMetricsSetKey) {
-		AddMetrics2PoolLabels(&poolLabels)
-	}
-
 	// Process the associated account: by default, we try to get from CI/CD environment variables
 	// Otherwise, we use the account flag. The default is "".
 	associatedAccount := GetCIEnvironmentVariableAccount()

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -217,11 +217,6 @@ func ProcessMetricsSet(metricsSetKey string, poolLabels *[]api.PoolLabel) *strin
 		return nil
 	}
 
-	// Metrics 2.0 steps will only be run if we use the special pool
-	// label, so let's enable it automatically if the user requested a
-	// metrics set
-	AddMetrics2PoolLabels(poolLabels)
-
 	return metricsSet
 }
 

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -189,8 +189,6 @@ func mergeConfigFiles(paths []string, verbose bool) ([]byte, error) {
 	return out, nil
 }
 
-const METRICS_2_POOL_LABEL = "resim:metrics2"
-
 // HasMetricsSetName returns true when the metrics set pointer references a
 // non-empty metrics set name.
 func HasMetricsSetName(metricsSet *string) bool {
@@ -204,11 +202,6 @@ func NormalizeMetricsSetName(metricsSet *string) *string {
 		return nil
 	}
 	return metricsSet
-}
-
-// Add Metrics 2.0 Pool labels to the list of pool labels:
-func AddMetrics2PoolLabels(poolLabels *[]api.PoolLabel) {
-	*poolLabels = append(*poolLabels, METRICS_2_POOL_LABEL)
 }
 
 // ProcessMetricsSet handles the common logic for processing metrics sets

--- a/cmd/resim/commands/utils_test.go
+++ b/cmd/resim/commands/utils_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/resim-ai/api-client/api"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -610,19 +608,6 @@ func TestContainsGlobChars(t *testing.T) {
 	}
 }
 
-func TestAddMetrics2PoolLabels(t *testing.T) {
-	poolLabels := []api.PoolLabel{}
-	AddMetrics2PoolLabels(&poolLabels)
-	assert.Contains(t, poolLabels, METRICS_2_POOL_LABEL)
-}
-
-func TestAddMetrics2PoolLabelsWithExistingLabels(t *testing.T) {
-	poolLabels := []api.PoolLabel{"foo", "bar"}
-	AddMetrics2PoolLabels(&poolLabels)
-	assert.Contains(t, poolLabels, METRICS_2_POOL_LABEL)
-	assert.Equal(t, []api.PoolLabel{"foo", "bar", METRICS_2_POOL_LABEL}, poolLabels)
-}
-
 func TestHasMetricsSetName(t *testing.T) {
 	metricsSetName := "metrics-set"
 	emptyMetricsSetName := ""
@@ -639,35 +624,4 @@ func TestNormalizeMetricsSetName(t *testing.T) {
 	assert.Nil(t, NormalizeMetricsSetName(nil))
 	assert.Nil(t, NormalizeMetricsSetName(&emptyMetricsSetName))
 	assert.Equal(t, &metricsSetName, NormalizeMetricsSetName(&metricsSetName))
-}
-
-func TestProcessMetricsSetEmptyStringSkipsPoolLabel(t *testing.T) {
-	const metricsSetKey = "test-empty-metrics-set"
-	t.Cleanup(func() {
-		viper.Set(metricsSetKey, nil)
-	})
-
-	viper.Set(metricsSetKey, "")
-	poolLabels := []api.PoolLabel{"foo"}
-
-	metricsSet := ProcessMetricsSet(metricsSetKey, &poolLabels)
-
-	assert.Nil(t, metricsSet)
-	assert.Equal(t, []api.PoolLabel{"foo"}, poolLabels)
-}
-
-func TestProcessMetricsSetAddsPoolLabelForNonEmptyValue(t *testing.T) {
-	const metricsSetKey = "test-non-empty-metrics-set"
-	t.Cleanup(func() {
-		viper.Set(metricsSetKey, nil)
-	})
-
-	viper.Set(metricsSetKey, "metrics-set")
-	poolLabels := []api.PoolLabel{"foo"}
-
-	metricsSet := ProcessMetricsSet(metricsSetKey, &poolLabels)
-
-	assert.NotNil(t, metricsSet)
-	assert.Equal(t, "metrics-set", *metricsSet)
-	assert.Equal(t, []api.PoolLabel{"foo", METRICS_2_POOL_LABEL}, poolLabels)
 }

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -5434,7 +5434,7 @@ func TestTestSuites(t *testing.T) {
 	ts.NotNil(batch.MetricsSetName)
 	ts.Equal(metricsSetOverrideName, *batch.MetricsSetName)
 	ts.NotNil(batch.PoolLabels)
-	ts.Contains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+	ts.Contains((*batch.PoolLabels)[0], "metrics2")
 
 	// Archive the test suite
 	output = s.runCommand(ts, archiveTestSuite(projectID, firstTestSuiteName), false)
@@ -5482,7 +5482,7 @@ func TestTestSuites(t *testing.T) {
 	err = json.Unmarshal([]byte(output.StdOut), &batch)
 	ts.NoError(err)
 	if batch.PoolLabels != nil {
-		ts.NotContains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+		ts.Contains((*batch.PoolLabels)[0], "metrics2")
 	}
 
 	// Then set a new metrics set name
@@ -5502,7 +5502,7 @@ func TestTestSuites(t *testing.T) {
 	err = json.Unmarshal([]byte(output.StdOut), &batch)
 	ts.NoError(err)
 	ts.NotNil(batch.PoolLabels)
-	ts.Contains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+	ts.Contains((*batch.PoolLabels)[0], "metrics2")
 
 	noMetricsPoolBatchName := fmt.Sprintf("no-metrics-pool-batch-%s", uuid.New().String())
 	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &noMetricsPoolBatchName, nil, nil, nil, true), ExpectNoError)
@@ -5511,7 +5511,7 @@ func TestTestSuites(t *testing.T) {
 	err = json.Unmarshal([]byte(output.StdOut), &batch)
 	ts.NoError(err)
 	if batch.PoolLabels != nil {
-		ts.NotContains(*batch.PoolLabels, commands.METRICS_2_POOL_LABEL)
+		ts.Contains((*batch.PoolLabels)[0], "metrics2")
 	}
 }
 func TestReports(t *testing.T) {


### PR DESCRIPTION
# Description of change

The backend already handles this and the current behaviour is wrong due to all of the fun new features we have applied now!

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.