### PR TITLE
WOB-4100: Allow unsetting metrics set when revising test suites

### DIFF
--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -238,6 +238,14 @@ type AddTagsToExperiencesInput struct {
 	Filters          *ExperienceFilterInput `json:"filters,omitempty" yaml:"filters,omitempty"`
 }
 
+// AgentMarkdownHistoryEntry defines model for agentMarkdownHistoryEntry.
+type AgentMarkdownHistoryEntry struct {
+	AgentMarkdown string             `json:"agentMarkdown" yaml:"agentMarkdown"`
+	EditedAt      Timestamp          `json:"editedAt" yaml:"editedAt"`
+	EditedBy      string             `json:"editedBy" yaml:"editedBy"`
+	Id            openapi_types.UUID `json:"id" yaml:"id"`
+}
+
 // Architecture defines model for architecture.
 type Architecture string
 
@@ -724,8 +732,9 @@ type CreateMetricsBuildInput struct {
 
 // CreateProjectInput defines model for createProjectInput.
 type CreateProjectInput struct {
-	Description string `json:"description" yaml:"description"`
-	Name        string `json:"name" yaml:"name"`
+	AgentMarkdown *string `json:"agentMarkdown,omitempty" yaml:"agentMarkdown,omitempty"`
+	Description   string  `json:"description" yaml:"description"`
+	Name          string  `json:"name" yaml:"name"`
 }
 
 // CreateSystemInput defines model for createSystemInput.
@@ -1199,6 +1208,13 @@ type LightJobStatus string
 
 // LineNumber defines model for lineNumber.
 type LineNumber = int32
+
+// ListAgentMarkdownHistoryOutput defines model for listAgentMarkdownHistoryOutput.
+type ListAgentMarkdownHistoryOutput struct {
+	Entries       []AgentMarkdownHistoryEntry `json:"entries" yaml:"entries"`
+	HasMore       bool                        `json:"hasMore" yaml:"hasMore"`
+	NextPageToken string                      `json:"nextPageToken" yaml:"nextPageToken"`
+}
 
 // ListAllJobsOutput defines model for listAllJobsOutput.
 type ListAllJobsOutput struct {
@@ -1816,8 +1832,9 @@ type RequiredHeaders map[string]string
 
 // RerunBatchInput defines model for rerunBatchInput.
 type RerunBatchInput struct {
-	JobIDs    *[]JobID `json:"jobIDs,omitempty" yaml:"jobIDs,omitempty"`
-	SyncBatch bool     `json:"syncBatch" yaml:"syncBatch"`
+	JobIDs           *[]JobID `json:"jobIDs,omitempty" yaml:"jobIDs,omitempty"`
+	RerunMetricsOnly *bool    `json:"rerunMetricsOnly,omitempty" yaml:"rerunMetricsOnly,omitempty"`
+	SyncBatch        bool     `json:"syncBatch" yaml:"syncBatch"`
 }
 
 // RerunBatchOutput defines model for rerunBatchOutput.
@@ -1851,6 +1868,7 @@ type ReviseTestSuiteInput struct {
 	ShowOnSummary         *bool                   `json:"show_on_summary,omitempty" yaml:"show_on_summary,omitempty"`
 	SystemID              *SystemID               `json:"systemID,omitempty" yaml:"systemID,omitempty"`
 	UpdateMetricsBuild    bool                    `json:"updateMetricsBuild" yaml:"updateMetricsBuild"`
+	UpdateMetricsSet      *bool                   `json:"updateMetricsSet,omitempty" yaml:"updateMetricsSet,omitempty"`
 }
 
 // RunCounter defines model for runCounter.
@@ -2267,6 +2285,12 @@ type ListProjectsParams struct {
 	PageSize  *PageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty" yaml:"pageToken,omitempty"`
 	OrderBy   *OrderBy   `form:"orderBy,omitempty" json:"orderBy,omitempty" yaml:"orderBy,omitempty"`
+}
+
+// ListAgentMarkdownHistoryParams defines parameters for ListAgentMarkdownHistory.
+type ListAgentMarkdownHistoryParams struct {
+	PageSize  *PageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
+	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty" yaml:"pageToken,omitempty"`
 }
 
 // ListAssetsParams defines parameters for ListAssets.
@@ -3366,6 +3390,9 @@ type ClientInterface interface {
 
 	UpdateProject(ctx context.Context, projectID ProjectID, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListAgentMarkdownHistory request
+	ListAgentMarkdownHistory(ctx context.Context, projectID ProjectID, params *ListAgentMarkdownHistoryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListAssets request
 	ListAssets(ctx context.Context, projectID ProjectID, params *ListAssetsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4052,6 +4079,18 @@ func (c *Client) UpdateProjectWithBody(ctx context.Context, projectID ProjectID,
 
 func (c *Client) UpdateProject(ctx context.Context, projectID ProjectID, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateProjectRequest(c.Server, projectID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAgentMarkdownHistory(ctx context.Context, projectID ProjectID, params *ListAgentMarkdownHistoryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAgentMarkdownHistoryRequest(c.Server, projectID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -6950,6 +6989,78 @@ func NewUpdateProjectRequestWithBody(server string, projectID ProjectID, content
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListAgentMarkdownHistoryRequest generates requests for ListAgentMarkdownHistory
+func NewListAgentMarkdownHistoryRequest(server string, projectID ProjectID, params *ListAgentMarkdownHistoryParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "projectID", runtime.ParamLocationPath, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/agent-markdown-history", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pageSize", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageToken != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pageToken", runtime.ParamLocationQuery, *params.PageToken); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -17763,6 +17874,9 @@ type ClientWithResponsesInterface interface {
 
 	UpdateProjectWithResponse(ctx context.Context, projectID ProjectID, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error)
 
+	// ListAgentMarkdownHistoryWithResponse request
+	ListAgentMarkdownHistoryWithResponse(ctx context.Context, projectID ProjectID, params *ListAgentMarkdownHistoryParams, reqEditors ...RequestEditorFn) (*ListAgentMarkdownHistoryResponse, error)
+
 	// ListAssetsWithResponse request
 	ListAssetsWithResponse(ctx context.Context, projectID ProjectID, params *ListAssetsParams, reqEditors ...RequestEditorFn) (*ListAssetsResponse, error)
 
@@ -18497,6 +18611,28 @@ func (r UpdateProjectResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListAgentMarkdownHistoryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListAgentMarkdownHistoryOutput
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAgentMarkdownHistoryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAgentMarkdownHistoryResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -22182,6 +22318,15 @@ func (c *ClientWithResponses) UpdateProjectWithResponse(ctx context.Context, pro
 	return ParseUpdateProjectResponse(rsp)
 }
 
+// ListAgentMarkdownHistoryWithResponse request returning *ListAgentMarkdownHistoryResponse
+func (c *ClientWithResponses) ListAgentMarkdownHistoryWithResponse(ctx context.Context, projectID ProjectID, params *ListAgentMarkdownHistoryParams, reqEditors ...RequestEditorFn) (*ListAgentMarkdownHistoryResponse, error) {
+	rsp, err := c.ListAgentMarkdownHistory(ctx, projectID, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAgentMarkdownHistoryResponse(rsp)
+}
+
 // ListAssetsWithResponse request returning *ListAssetsResponse
 func (c *ClientWithResponses) ListAssetsWithResponse(ctx context.Context, projectID ProjectID, params *ListAssetsParams, reqEditors ...RequestEditorFn) (*ListAssetsResponse, error) {
 	rsp, err := c.ListAssets(ctx, projectID, params, reqEditors...)
@@ -24187,6 +24332,32 @@ func ParseUpdateProjectResponse(rsp *http.Response) (*UpdateProjectResponse, err
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest Project
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAgentMarkdownHistoryResponse parses an HTTP response from a ListAgentMarkdownHistoryWithResponse call
+func ParseListAgentMarkdownHistoryResponse(rsp *http.Response) (*ListAgentMarkdownHistoryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAgentMarkdownHistoryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListAgentMarkdownHistoryOutput
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/api/mocks/client_interface.gen.go
+++ b/api/mocks/client_interface.gen.go
@@ -8584,6 +8584,81 @@ func (_c *ClientInterface_Health_Call) RunAndReturn(run func(context.Context, ..
 	return _c
 }
 
+// ListAgentMarkdownHistory provides a mock function with given fields: ctx, projectID, params, reqEditors
+func (_m *ClientInterface) ListAgentMarkdownHistory(ctx context.Context, projectID uuid.UUID, params *api.ListAgentMarkdownHistoryParams, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, projectID, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAgentMarkdownHistory")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, projectID, params, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, projectID, params, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, projectID, params, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_ListAgentMarkdownHistory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAgentMarkdownHistory'
+type ClientInterface_ListAgentMarkdownHistory_Call struct {
+	*mock.Call
+}
+
+// ListAgentMarkdownHistory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID uuid.UUID
+//   - params *api.ListAgentMarkdownHistoryParams
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) ListAgentMarkdownHistory(ctx interface{}, projectID interface{}, params interface{}, reqEditors ...interface{}) *ClientInterface_ListAgentMarkdownHistory_Call {
+	return &ClientInterface_ListAgentMarkdownHistory_Call{Call: _e.mock.On("ListAgentMarkdownHistory",
+		append([]interface{}{ctx, projectID, params}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_ListAgentMarkdownHistory_Call) Run(run func(ctx context.Context, projectID uuid.UUID, params *api.ListAgentMarkdownHistoryParams, reqEditors ...api.RequestEditorFn)) *ClientInterface_ListAgentMarkdownHistory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(uuid.UUID), args[2].(*api.ListAgentMarkdownHistoryParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_ListAgentMarkdownHistory_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_ListAgentMarkdownHistory_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_ListAgentMarkdownHistory_Call) RunAndReturn(run func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_ListAgentMarkdownHistory_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListAllJobs provides a mock function with given fields: ctx, projectID, params, reqEditors
 func (_m *ClientInterface) ListAllJobs(ctx context.Context, projectID uuid.UUID, params *api.ListAllJobsParams, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/api/mocks/client_with_responses_interface.gen.go
+++ b/api/mocks/client_with_responses_interface.gen.go
@@ -8582,6 +8582,81 @@ func (_c *ClientWithResponsesInterface_HealthWithResponse_Call) RunAndReturn(run
 	return _c
 }
 
+// ListAgentMarkdownHistoryWithResponse provides a mock function with given fields: ctx, projectID, params, reqEditors
+func (_m *ClientWithResponsesInterface) ListAgentMarkdownHistoryWithResponse(ctx context.Context, projectID uuid.UUID, params *api.ListAgentMarkdownHistoryParams, reqEditors ...api.RequestEditorFn) (*api.ListAgentMarkdownHistoryResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, projectID, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAgentMarkdownHistoryWithResponse")
+	}
+
+	var r0 *api.ListAgentMarkdownHistoryResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) (*api.ListAgentMarkdownHistoryResponse, error)); ok {
+		return rf(ctx, projectID, params, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) *api.ListAgentMarkdownHistoryResponse); ok {
+		r0 = rf(ctx, projectID, params, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.ListAgentMarkdownHistoryResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, projectID, params, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAgentMarkdownHistoryWithResponse'
+type ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call struct {
+	*mock.Call
+}
+
+// ListAgentMarkdownHistoryWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID uuid.UUID
+//   - params *api.ListAgentMarkdownHistoryParams
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) ListAgentMarkdownHistoryWithResponse(ctx interface{}, projectID interface{}, params interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call {
+	return &ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call{Call: _e.mock.On("ListAgentMarkdownHistoryWithResponse",
+		append([]interface{}{ctx, projectID, params}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call) Run(run func(ctx context.Context, projectID uuid.UUID, params *api.ListAgentMarkdownHistoryParams, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(uuid.UUID), args[2].(*api.ListAgentMarkdownHistoryParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call) Return(_a0 *api.ListAgentMarkdownHistoryResponse, _a1 error) *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call) RunAndReturn(run func(context.Context, uuid.UUID, *api.ListAgentMarkdownHistoryParams, ...api.RequestEditorFn) (*api.ListAgentMarkdownHistoryResponse, error)) *ClientWithResponsesInterface_ListAgentMarkdownHistoryWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListAllJobsWithResponse provides a mock function with given fields: ctx, projectID, params, reqEditors
 func (_m *ClientWithResponsesInterface) ListAllJobsWithResponse(ctx context.Context, projectID uuid.UUID, params *api.ListAllJobsParams, reqEditors ...api.RequestEditorFn) (*api.ListAllJobsResponse, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -387,7 +387,10 @@ func reviseTestSuite(ccmd *cobra.Command, args []string) {
 	// Optional metrics set name (can be set to empty string to unset)	)
 	if viper.IsSet(testSuiteMetricsSetKey) {
 		metricsSet := viper.GetString(testSuiteMetricsSetKey)
-		reviseRequest.MetricsSetName = &metricsSet
+		reviseRequest.UpdateMetricsSet = Ptr(true)
+		if metricsSet != "" {
+			reviseRequest.MetricsSetName = &metricsSet
+		}
 	}
 
 	// Parse --experiences into either IDs or names

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -5472,8 +5472,7 @@ func TestTestSuites(t *testing.T) {
 	output = s.runCommand(ts, getTestSuite(projectID, metricsSetTestSuiteName, nil, false), false)
 	err = json.Unmarshal([]byte(output.StdOut), &testSuite)
 	ts.NoError(err)
-	ts.NotNil(testSuite.MetricsSetName)
-	ts.Equal(emptyMetricsSet, *testSuite.MetricsSetName)
+	ts.Nil(testSuite.MetricsSetName)
 
 	emptyMetricsPoolBatchName := fmt.Sprintf("empty-metrics-pool-batch-%s", uuid.New().String())
 	output = s.runCommand(ts, runTestSuite(projectID, metricsSetTestSuiteName, nil, buildIDString, map[string]string{}, GithubFalse, AssociatedAccount, &emptyMetricsPoolBatchName, nil, nil, nil, false), ExpectNoError)
@@ -5482,7 +5481,7 @@ func TestTestSuites(t *testing.T) {
 	err = json.Unmarshal([]byte(output.StdOut), &batch)
 	ts.NoError(err)
 	if batch.PoolLabels != nil {
-		ts.Contains((*batch.PoolLabels)[0], "metrics2")
+		ts.NotContains((*batch.PoolLabels)[0], "metrics2")
 	}
 
 	// Then set a new metrics set name


### PR DESCRIPTION
# Description of change

Use `updateMetricsSet` flag to unset the field.

## Guide to reproduce test results

<!--
    Please help reviewers by including instructions
    on how to test this change
-->

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.