### PR TITLE
WOB-4084 | Add new dashboards command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.52.0 - May 12, 2026
+
+- Adds a new `dashboards` command with a `create` subcommand for creating dashboards.
+
 ### v0.51.0 - May 4, 2026
 
 - Adds `--fail-on-states=BLOCKER,ERROR,WARNING` flag on `batch wait`, `batch get`, `batch supervise`, and `workflow runs supervise`. When set, the exit code is derived from `Batch.ConflatedStatus` filtered to the supplied states, with two new exit codes: `7` for BLOCKER and `8` for WARNING. When unset, `batch wait` and `batch get --exit-status` keep their historical `Batch.Status`-based exit codes bit-for-bit.

--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -96,14 +96,6 @@ const (
 	RELATIVE EventTimestampType = "RELATIVE"
 )
 
-// Defines values for ExecutionStep.
-const (
-	BATCHMETRICS ExecutionStep = "BATCH_METRICS"
-	EXPERIENCE   ExecutionStep = "EXPERIENCE"
-	METRICS      ExecutionStep = "METRICS"
-	REPORT       ExecutionStep = "REPORT"
-)
-
 // Defines values for JobStatus.
 const (
 	JobStatusCANCELLED         JobStatus = "CANCELLED"
@@ -317,6 +309,7 @@ type Batch struct {
 	JobMetricsStatusCounts  *JobMetricsStatusCounts `json:"jobMetricsStatusCounts,omitempty" yaml:"jobMetricsStatusCounts,omitempty"`
 	JobStatusCounts         *BatchJobStatusCounts   `json:"jobStatusCounts,omitempty" yaml:"jobStatusCounts,omitempty"`
 	JobsMetricsStatus       *MetricStatus           `json:"jobsMetricsStatus,omitempty" yaml:"jobsMetricsStatus,omitempty"`
+	LabelledBuilds          *LabelledBuilds         `json:"labelledBuilds" yaml:"labelledBuilds"`
 	LastRunTimestamp        *Timestamp              `json:"lastRunTimestamp,omitempty" yaml:"lastRunTimestamp,omitempty"`
 	LastUpdatedTimestamp    *Timestamp              `json:"lastUpdatedTimestamp,omitempty" yaml:"lastUpdatedTimestamp,omitempty"`
 	MetricsBuildID          *MetricsBuildID         `json:"metricsBuildID,omitempty" yaml:"metricsBuildID,omitempty"`
@@ -346,6 +339,8 @@ type BatchInput struct {
 	AllowableFailurePercent *int                    `json:"allowableFailurePercent" yaml:"allowableFailurePercent"`
 	AssociatedAccount       *AssociatedAccount      `json:"associatedAccount,omitempty" yaml:"associatedAccount,omitempty"`
 	BatchName               *Name                   `json:"batchName,omitempty" yaml:"batchName,omitempty"`
+	BlueprintName           *string                 `json:"blueprintName" yaml:"blueprintName"`
+	BlueprintVersion        *int                    `json:"blueprintVersion" yaml:"blueprintVersion"`
 	BuildID                 *BuildID                `json:"buildID,omitempty" yaml:"buildID,omitempty"`
 	ExcludedExperienceIDs   *[]ExcludedExperienceID `json:"excludedExperienceIDs" yaml:"excludedExperienceIDs"`
 	ExperienceIDs           *[]ExperienceID         `json:"experienceIDs" yaml:"experienceIDs"`
@@ -353,6 +348,7 @@ type BatchInput struct {
 	ExperienceTagIDs        *[]ExperienceTagID      `json:"experienceTagIDs" yaml:"experienceTagIDs"`
 	ExperienceTagNames      *[]ExperienceTagName    `json:"experienceTagNames" yaml:"experienceTagNames"`
 	Filters                 *ExperienceFilterInput  `json:"filters,omitempty" yaml:"filters,omitempty"`
+	LabelledBuilds          *LabelledBuilds         `json:"labelledBuilds" yaml:"labelledBuilds"`
 	MetricsBuildID          *MetricsBuildID         `json:"metricsBuildID,omitempty" yaml:"metricsBuildID,omitempty"`
 	MetricsSetName          *MetricsSetName         `json:"metricsSetName" yaml:"metricsSetName"`
 	Parameters              *BatchParameters        `json:"parameters,omitempty" yaml:"parameters,omitempty"`
@@ -374,11 +370,17 @@ type BatchJobStatusCounts struct {
 
 // BatchLog defines model for batchLog.
 type BatchLog struct {
-	BatchID           *BatchID       `json:"batchID,omitempty" yaml:"batchID,omitempty"`
-	Checksum          *Checksum      `json:"checksum,omitempty" yaml:"checksum,omitempty"`
-	CreationTimestamp *Timestamp     `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-	ExecutionStep     *ExecutionStep `json:"executionStep,omitempty" yaml:"executionStep,omitempty"`
-	FileName          *FileName      `json:"fileName,omitempty" yaml:"fileName,omitempty"`
+	BatchID           *BatchID   `json:"batchID,omitempty" yaml:"batchID,omitempty"`
+	Checksum          *Checksum  `json:"checksum,omitempty" yaml:"checksum,omitempty"`
+	CreationTimestamp *Timestamp `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+
+	// DownloadUrl Presigned URL with Content-Disposition attachment header for browser-native file downloads. Not set for external (BYO-bucket) logs.
+	DownloadUrl   *string        `json:"downloadUrl,omitempty" yaml:"downloadUrl,omitempty"`
+	ExecutionStep *ExecutionStep `json:"executionStep,omitempty" yaml:"executionStep,omitempty"`
+
+	// External True if the log is stored in a customer-owned (BYO) bucket. For external logs, logOutputLocation will echo the raw location (no presigned URL).
+	External *bool     `json:"external,omitempty" yaml:"external,omitempty"`
+	FileName *FileName `json:"fileName,omitempty" yaml:"fileName,omitempty"`
 
 	// FilePath The directory path relative to the output root (empty for root-level files)
 	FilePath *string   `json:"filePath,omitempty" yaml:"filePath,omitempty"`
@@ -463,6 +465,17 @@ type BatchTotalJobs = int
 
 // BatchType defines model for batchType.
 type BatchType string
+
+// Blueprint defines model for blueprint.
+type Blueprint struct {
+	BlueprintID openapi_types.UUID `json:"blueprintID" yaml:"blueprintID"`
+	CreatedAt   Timestamp          `json:"createdAt" yaml:"createdAt"`
+	CueContent  string             `json:"cueContent" yaml:"cueContent"`
+	Name        string             `json:"name" yaml:"name"`
+	OrgID       OrgID              `json:"orgID" yaml:"orgID"`
+	UserID      UserID             `json:"userID" yaml:"userID"`
+	Version     int                `json:"version" yaml:"version"`
+}
 
 // Branch defines model for branch.
 type Branch struct {
@@ -614,6 +627,12 @@ type CreateAssetInput struct {
 	Version     string   `json:"version" yaml:"version"`
 }
 
+// CreateBlueprintInput defines model for createBlueprintInput.
+type CreateBlueprintInput struct {
+	CueContent string `json:"cueContent" yaml:"cueContent"`
+	Name       string `json:"name" yaml:"name"`
+}
+
 // CreateBranchInput defines model for createBranchInput.
 type CreateBranchInput struct {
 	BranchType BranchType `json:"branchType" yaml:"branchType"`
@@ -631,10 +650,11 @@ type CreateBuildForBranchInput struct {
 	ImageUri    *BuildImageUri    `json:"imageUri,omitempty" yaml:"imageUri,omitempty"`
 
 	// Name The name of the build.
-	Name     *BuildName   `json:"name,omitempty" yaml:"name,omitempty"`
-	SystemID SystemID     `json:"systemID" yaml:"systemID"`
-	Version  BuildVersion `json:"version" yaml:"version"`
-	union    json.RawMessage
+	Name              *BuildName   `json:"name,omitempty" yaml:"name,omitempty"`
+	NoBuildDefinition *bool        `json:"noBuildDefinition,omitempty" yaml:"noBuildDefinition,omitempty"`
+	SystemID          SystemID     `json:"systemID" yaml:"systemID"`
+	Version           BuildVersion `json:"version" yaml:"version"`
+	union             json.RawMessage
 }
 
 // CreateBuildForBranchInput0 defines model for .
@@ -642,6 +662,9 @@ type CreateBuildForBranchInput0 = interface{}
 
 // CreateBuildForBranchInput1 defines model for .
 type CreateBuildForBranchInput1 = interface{}
+
+// CreateBuildForBranchInput2 defines model for .
+type CreateBuildForBranchInput2 = interface{}
 
 // CreateBuildForSystemInput defines model for createBuildForSystemInput.
 type CreateBuildForSystemInput struct {
@@ -655,10 +678,11 @@ type CreateBuildForSystemInput struct {
 	ImageUri    *BuildImageUri    `json:"imageUri,omitempty" yaml:"imageUri,omitempty"`
 
 	// Name The name of the build.
-	Name         *BuildName    `json:"name,omitempty" yaml:"name,omitempty"`
-	TriggeredVia *TriggeredVia `json:"triggeredVia,omitempty" yaml:"triggeredVia,omitempty"`
-	Version      BuildVersion  `json:"version" yaml:"version"`
-	union        json.RawMessage
+	Name              *BuildName    `json:"name,omitempty" yaml:"name,omitempty"`
+	NoBuildDefinition *bool         `json:"noBuildDefinition,omitempty" yaml:"noBuildDefinition,omitempty"`
+	TriggeredVia      *TriggeredVia `json:"triggeredVia,omitempty" yaml:"triggeredVia,omitempty"`
+	Version           BuildVersion  `json:"version" yaml:"version"`
+	union             json.RawMessage
 }
 
 // CreateBuildForSystemInput0 defines model for .
@@ -666,6 +690,9 @@ type CreateBuildForSystemInput0 = interface{}
 
 // CreateBuildForSystemInput1 defines model for .
 type CreateBuildForSystemInput1 = interface{}
+
+// CreateBuildForSystemInput2 defines model for .
+type CreateBuildForSystemInput2 = interface{}
 
 // CreateExperienceInput defines model for createExperienceInput.
 type CreateExperienceInput struct {
@@ -909,7 +936,7 @@ type ExecutionError struct {
 }
 
 // ExecutionStep defines model for executionStep.
-type ExecutionStep string
+type ExecutionStep = string
 
 // Experience defines model for experience.
 type Experience struct {
@@ -1086,10 +1113,16 @@ type JobID = openapi_types.UUID
 
 // JobLog defines model for jobLog.
 type JobLog struct {
-	Checksum          *Checksum      `json:"checksum,omitempty" yaml:"checksum,omitempty"`
-	CreationTimestamp *Timestamp     `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-	ExecutionStep     *ExecutionStep `json:"executionStep,omitempty" yaml:"executionStep,omitempty"`
-	FileName          *FileName      `json:"fileName,omitempty" yaml:"fileName,omitempty"`
+	Checksum          *Checksum  `json:"checksum,omitempty" yaml:"checksum,omitempty"`
+	CreationTimestamp *Timestamp `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+
+	// DownloadUrl Presigned URL with Content-Disposition attachment header for browser-native file downloads. Not set for external (BYO-bucket) logs.
+	DownloadUrl   *string        `json:"downloadUrl,omitempty" yaml:"downloadUrl,omitempty"`
+	ExecutionStep *ExecutionStep `json:"executionStep,omitempty" yaml:"executionStep,omitempty"`
+
+	// External True if the log is stored in a customer-owned (BYO) bucket. For external logs, logOutputLocation will echo the raw location (no presigned URL).
+	External *bool     `json:"external,omitempty" yaml:"external,omitempty"`
+	FileName *FileName `json:"fileName,omitempty" yaml:"fileName,omitempty"`
 
 	// FilePath The directory path relative to the output root (empty for root-level files)
 	FilePath *string   `json:"filePath,omitempty" yaml:"filePath,omitempty"`
@@ -1189,6 +1222,15 @@ type KeyMetricTarget struct {
 	Value    float64 `json:"value" yaml:"value"`
 }
 
+// LabelledBuild defines model for labelledBuild.
+type LabelledBuild struct {
+	BuildID   BuildID `json:"buildID" yaml:"buildID"`
+	BuildType string  `json:"buildType" yaml:"buildType"`
+}
+
+// LabelledBuilds defines model for labelledBuilds.
+type LabelledBuilds = []LabelledBuild
+
 // LightBatchInput defines model for lightBatchInput.
 type LightBatchInput struct {
 	BatchName         *Name              `json:"batchName,omitempty" yaml:"batchName,omitempty"`
@@ -1284,6 +1326,12 @@ type ListBatchesOutput struct {
 	Batches       *[]Batch `json:"batches,omitempty" yaml:"batches,omitempty"`
 	NextPageToken *string  `json:"nextPageToken,omitempty" yaml:"nextPageToken,omitempty"`
 	Total         *int     `json:"total,omitempty" yaml:"total,omitempty"`
+}
+
+// ListBlueprintsOutput defines model for listBlueprintsOutput.
+type ListBlueprintsOutput struct {
+	Blueprints    *[]Blueprint `json:"blueprints,omitempty" yaml:"blueprints,omitempty"`
+	NextPageToken *string      `json:"nextPageToken,omitempty" yaml:"nextPageToken,omitempty"`
 }
 
 // ListBranchesOutput defines model for listBranchesOutput.
@@ -1487,10 +1535,16 @@ type ListWorkflowsOutput struct {
 
 // Log defines model for log.
 type Log struct {
-	Checksum          *Checksum      `json:"checksum,omitempty" yaml:"checksum,omitempty"`
-	CreationTimestamp *Timestamp     `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-	ExecutionStep     *ExecutionStep `json:"executionStep,omitempty" yaml:"executionStep,omitempty"`
-	FileName          *FileName      `json:"fileName,omitempty" yaml:"fileName,omitempty"`
+	Checksum          *Checksum  `json:"checksum,omitempty" yaml:"checksum,omitempty"`
+	CreationTimestamp *Timestamp `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+
+	// DownloadUrl Presigned URL with Content-Disposition attachment header for browser-native file downloads. Not set for external (BYO-bucket) logs.
+	DownloadUrl   *string        `json:"downloadUrl,omitempty" yaml:"downloadUrl,omitempty"`
+	ExecutionStep *ExecutionStep `json:"executionStep,omitempty" yaml:"executionStep,omitempty"`
+
+	// External True if the log is stored in a customer-owned (BYO) bucket. For external logs, logOutputLocation will echo the raw location (no presigned URL).
+	External *bool     `json:"external,omitempty" yaml:"external,omitempty"`
+	FileName *FileName `json:"fileName,omitempty" yaml:"fileName,omitempty"`
 
 	// FilePath The directory path relative to the output root (empty for root-level files)
 	FilePath *string   `json:"filePath,omitempty" yaml:"filePath,omitempty"`
@@ -1679,6 +1733,8 @@ type ParameterSweepID = openapi_types.UUID
 type ParameterSweepInput struct {
 	AllowableFailurePercent *int                 `json:"allowableFailurePercent" yaml:"allowableFailurePercent"`
 	AssociatedAccount       *AssociatedAccount   `json:"associatedAccount,omitempty" yaml:"associatedAccount,omitempty"`
+	BlueprintName           *string              `json:"blueprintName" yaml:"blueprintName"`
+	BlueprintVersion        *int                 `json:"blueprintVersion" yaml:"blueprintVersion"`
 	BuildID                 *BuildID             `json:"buildID,omitempty" yaml:"buildID,omitempty"`
 	ExperienceIDs           *[]ExperienceID      `json:"experienceIDs" yaml:"experienceIDs"`
 	ExperienceNames         *[]ExperienceName    `json:"experienceNames" yaml:"experienceNames"`
@@ -1714,7 +1770,7 @@ type Profile = string
 
 // Project defines model for project.
 type Project struct {
-	AgentMarkdown     *string   `json:"agentMarkdown,omitempty" yaml:"agentMarkdown,omitempty"`
+	AgentMarkdown     string    `json:"agentMarkdown" yaml:"agentMarkdown"`
 	Archived          Archived  `json:"archived" yaml:"archived"`
 	CreationTimestamp Timestamp `json:"creationTimestamp" yaml:"creationTimestamp"`
 	Description       string    `json:"description" yaml:"description"`
@@ -1787,7 +1843,13 @@ type ReportInput struct {
 type ReportLog struct {
 	Checksum          Checksum  `json:"checksum" yaml:"checksum"`
 	CreationTimestamp Timestamp `json:"creationTimestamp" yaml:"creationTimestamp"`
-	FileName          FileName  `json:"fileName" yaml:"fileName"`
+
+	// DownloadUrl Presigned URL with Content-Disposition attachment header for browser-native file downloads. Not set for external (BYO-bucket) logs.
+	DownloadUrl *string `json:"downloadUrl,omitempty" yaml:"downloadUrl,omitempty"`
+
+	// External True if the log is stored in a customer-owned (BYO) bucket.
+	External *bool    `json:"external,omitempty" yaml:"external,omitempty"`
+	FileName FileName `json:"fileName" yaml:"fileName"`
 
 	// FilePath The directory path relative to the output root (empty for root-level files)
 	FilePath *string  `json:"filePath,omitempty" yaml:"filePath,omitempty"`
@@ -1950,7 +2012,10 @@ type TestSuiteBatchInput struct {
 	AllowableFailurePercent *int               `json:"allowableFailurePercent" yaml:"allowableFailurePercent"`
 	AssociatedAccount       *AssociatedAccount `json:"associatedAccount,omitempty" yaml:"associatedAccount,omitempty"`
 	BatchName               *Name              `json:"batchName,omitempty" yaml:"batchName,omitempty"`
+	BlueprintName           *string            `json:"blueprintName" yaml:"blueprintName"`
+	BlueprintVersion        *int               `json:"blueprintVersion" yaml:"blueprintVersion"`
 	BuildID                 BuildID            `json:"buildID" yaml:"buildID"`
+	LabelledBuilds          *LabelledBuilds    `json:"labelledBuilds" yaml:"labelledBuilds"`
 	Parameters              *BatchParameters   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	PoolLabels              *PoolLabels        `json:"poolLabels,omitempty" yaml:"poolLabels,omitempty"`
 	Priority                *int               `json:"priority" yaml:"priority"`
@@ -2267,6 +2332,12 @@ type PageSizeUnbounded = int
 
 // PageToken defines model for pageToken.
 type PageToken = string
+
+// ListBlueprintsParams defines parameters for ListBlueprints.
+type ListBlueprintsParams struct {
+	PageSize  *PageSize  `form:"pageSize,omitempty" json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
+	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty" yaml:"pageToken,omitempty"`
+}
 
 // ListPoolLabelsParams defines parameters for ListPoolLabels.
 type ListPoolLabelsParams struct {
@@ -2780,6 +2851,9 @@ type ListViewSessionsParams struct {
 	OrderBy   *OrderBy   `form:"orderBy,omitempty" json:"orderBy,omitempty" yaml:"orderBy,omitempty"`
 }
 
+// CreateBlueprintJSONRequestBody defines body for CreateBlueprint for application/json ContentType.
+type CreateBlueprintJSONRequestBody = CreateBlueprintInput
+
 // CreateProjectJSONRequestBody defines body for CreateProject for application/json ContentType.
 type CreateProjectJSONRequestBody = CreateProjectInput
 
@@ -2976,6 +3050,32 @@ func (t *CreateBuildForBranchInput) MergeCreateBuildForBranchInput1(v CreateBuil
 	return err
 }
 
+// AsCreateBuildForBranchInput2 returns the union data inside the CreateBuildForBranchInput as a CreateBuildForBranchInput2
+func (t CreateBuildForBranchInput) AsCreateBuildForBranchInput2() (CreateBuildForBranchInput2, error) {
+	var body CreateBuildForBranchInput2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateBuildForBranchInput2 overwrites any union data inside the CreateBuildForBranchInput as the provided CreateBuildForBranchInput2
+func (t *CreateBuildForBranchInput) FromCreateBuildForBranchInput2(v CreateBuildForBranchInput2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateBuildForBranchInput2 performs a merge with any union data inside the CreateBuildForBranchInput, using the provided CreateBuildForBranchInput2
+func (t *CreateBuildForBranchInput) MergeCreateBuildForBranchInput2(v CreateBuildForBranchInput2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t CreateBuildForBranchInput) MarshalJSON() ([]byte, error) {
 	b, err := t.union.MarshalJSON()
 	if err != nil {
@@ -3021,6 +3121,13 @@ func (t CreateBuildForBranchInput) MarshalJSON() ([]byte, error) {
 		object["name"], err = json.Marshal(t.Name)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'name': %w", err)
+		}
+	}
+
+	if t.NoBuildDefinition != nil {
+		object["noBuildDefinition"], err = json.Marshal(t.NoBuildDefinition)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'noBuildDefinition': %w", err)
 		}
 	}
 
@@ -3081,6 +3188,13 @@ func (t *CreateBuildForBranchInput) UnmarshalJSON(b []byte) error {
 		err = json.Unmarshal(raw, &t.Name)
 		if err != nil {
 			return fmt.Errorf("error reading 'name': %w", err)
+		}
+	}
+
+	if raw, found := object["noBuildDefinition"]; found {
+		err = json.Unmarshal(raw, &t.NoBuildDefinition)
+		if err != nil {
+			return fmt.Errorf("error reading 'noBuildDefinition': %w", err)
 		}
 	}
 
@@ -3153,6 +3267,32 @@ func (t *CreateBuildForSystemInput) MergeCreateBuildForSystemInput1(v CreateBuil
 	return err
 }
 
+// AsCreateBuildForSystemInput2 returns the union data inside the CreateBuildForSystemInput as a CreateBuildForSystemInput2
+func (t CreateBuildForSystemInput) AsCreateBuildForSystemInput2() (CreateBuildForSystemInput2, error) {
+	var body CreateBuildForSystemInput2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateBuildForSystemInput2 overwrites any union data inside the CreateBuildForSystemInput as the provided CreateBuildForSystemInput2
+func (t *CreateBuildForSystemInput) FromCreateBuildForSystemInput2(v CreateBuildForSystemInput2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateBuildForSystemInput2 performs a merge with any union data inside the CreateBuildForSystemInput, using the provided CreateBuildForSystemInput2
+func (t *CreateBuildForSystemInput) MergeCreateBuildForSystemInput2(v CreateBuildForSystemInput2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t CreateBuildForSystemInput) MarshalJSON() ([]byte, error) {
 	b, err := t.union.MarshalJSON()
 	if err != nil {
@@ -3203,6 +3343,13 @@ func (t CreateBuildForSystemInput) MarshalJSON() ([]byte, error) {
 		object["name"], err = json.Marshal(t.Name)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'name': %w", err)
+		}
+	}
+
+	if t.NoBuildDefinition != nil {
+		object["noBuildDefinition"], err = json.Marshal(t.NoBuildDefinition)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'noBuildDefinition': %w", err)
 		}
 	}
 
@@ -3272,6 +3419,13 @@ func (t *CreateBuildForSystemInput) UnmarshalJSON(b []byte) error {
 		err = json.Unmarshal(raw, &t.Name)
 		if err != nil {
 			return fmt.Errorf("error reading 'name': %w", err)
+		}
+	}
+
+	if raw, found := object["noBuildDefinition"]; found {
+		err = json.Unmarshal(raw, &t.NoBuildDefinition)
+		if err != nil {
+			return fmt.Errorf("error reading 'noBuildDefinition': %w", err)
 		}
 	}
 
@@ -3365,6 +3519,26 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// ListBlueprints request
+	ListBlueprints(ctx context.Context, params *ListBlueprintsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateBlueprintWithBody request with any body
+	CreateBlueprintWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateBlueprint(ctx context.Context, body CreateBlueprintJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ArchiveBlueprint request
+	ArchiveBlueprint(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetLatestBlueprint request
+	GetLatestBlueprint(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ArchiveBlueprintVersion request
+	ArchiveBlueprintVersion(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBlueprintVersion request
+	GetBlueprintVersion(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// Health request
 	Health(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3979,6 +4153,90 @@ type ClientInterface interface {
 
 	// CreateViewUpdateWithBody request with any body
 	CreateViewUpdateWithBody(ctx context.Context, viewSessionID ViewSessionID, viewUpdateID ViewUpdateID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) ListBlueprints(ctx context.Context, params *ListBlueprintsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListBlueprintsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateBlueprintWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateBlueprintRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateBlueprint(ctx context.Context, body CreateBlueprintJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateBlueprintRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ArchiveBlueprint(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewArchiveBlueprintRequest(c.Server, blueprintName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetLatestBlueprint(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetLatestBlueprintRequest(c.Server, blueprintName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ArchiveBlueprintVersion(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewArchiveBlueprintVersionRequest(c.Server, blueprintName, blueprintVersion)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetBlueprintVersion(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetBlueprintVersionRequest(c.Server, blueprintName, blueprintVersion)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) Health(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -6631,6 +6889,261 @@ func (c *Client) CreateViewUpdateWithBody(ctx context.Context, viewSessionID Vie
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewListBlueprintsRequest generates requests for ListBlueprints
+func NewListBlueprintsRequest(server string, params *ListBlueprintsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/blueprints")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pageSize", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageToken != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pageToken", runtime.ParamLocationQuery, *params.PageToken); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateBlueprintRequest calls the generic CreateBlueprint builder with application/json body
+func NewCreateBlueprintRequest(server string, body CreateBlueprintJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateBlueprintRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateBlueprintRequestWithBody generates requests for CreateBlueprint with any type of body
+func NewCreateBlueprintRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/blueprints")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewArchiveBlueprintRequest generates requests for ArchiveBlueprint
+func NewArchiveBlueprintRequest(server string, blueprintName string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "blueprintName", runtime.ParamLocationPath, blueprintName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/blueprints/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetLatestBlueprintRequest generates requests for GetLatestBlueprint
+func NewGetLatestBlueprintRequest(server string, blueprintName string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "blueprintName", runtime.ParamLocationPath, blueprintName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/blueprints/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewArchiveBlueprintVersionRequest generates requests for ArchiveBlueprintVersion
+func NewArchiveBlueprintVersionRequest(server string, blueprintName string, blueprintVersion int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "blueprintName", runtime.ParamLocationPath, blueprintName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "blueprintVersion", runtime.ParamLocationPath, blueprintVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/blueprints/%s/versions/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBlueprintVersionRequest generates requests for GetBlueprintVersion
+func NewGetBlueprintVersionRequest(server string, blueprintName string, blueprintVersion int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "blueprintName", runtime.ParamLocationPath, blueprintName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "blueprintVersion", runtime.ParamLocationPath, blueprintVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/blueprints/%s/versions/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewHealthRequest generates requests for Health
@@ -17849,6 +18362,26 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// ListBlueprintsWithResponse request
+	ListBlueprintsWithResponse(ctx context.Context, params *ListBlueprintsParams, reqEditors ...RequestEditorFn) (*ListBlueprintsResponse, error)
+
+	// CreateBlueprintWithBodyWithResponse request with any body
+	CreateBlueprintWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateBlueprintResponse, error)
+
+	CreateBlueprintWithResponse(ctx context.Context, body CreateBlueprintJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateBlueprintResponse, error)
+
+	// ArchiveBlueprintWithResponse request
+	ArchiveBlueprintWithResponse(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*ArchiveBlueprintResponse, error)
+
+	// GetLatestBlueprintWithResponse request
+	GetLatestBlueprintWithResponse(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*GetLatestBlueprintResponse, error)
+
+	// ArchiveBlueprintVersionWithResponse request
+	ArchiveBlueprintVersionWithResponse(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*ArchiveBlueprintVersionResponse, error)
+
+	// GetBlueprintVersionWithResponse request
+	GetBlueprintVersionWithResponse(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*GetBlueprintVersionResponse, error)
+
 	// HealthWithResponse request
 	HealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthResponse, error)
 
@@ -18463,6 +18996,136 @@ type ClientWithResponsesInterface interface {
 
 	// CreateViewUpdateWithBodyWithResponse request with any body
 	CreateViewUpdateWithBodyWithResponse(ctx context.Context, viewSessionID ViewSessionID, viewUpdateID ViewUpdateID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateViewUpdateResponse, error)
+}
+
+type ListBlueprintsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListBlueprintsOutput
+}
+
+// Status returns HTTPResponse.Status
+func (r ListBlueprintsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListBlueprintsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateBlueprintResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *Blueprint
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateBlueprintResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateBlueprintResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ArchiveBlueprintResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r ArchiveBlueprintResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ArchiveBlueprintResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetLatestBlueprintResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Blueprint
+}
+
+// Status returns HTTPResponse.Status
+func (r GetLatestBlueprintResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetLatestBlueprintResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ArchiveBlueprintVersionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r ArchiveBlueprintVersionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ArchiveBlueprintVersionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetBlueprintVersionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Blueprint
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBlueprintVersionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBlueprintVersionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type HealthResponse struct {
@@ -22239,6 +22902,68 @@ func (r CreateViewUpdateResponse) StatusCode() int {
 	return 0
 }
 
+// ListBlueprintsWithResponse request returning *ListBlueprintsResponse
+func (c *ClientWithResponses) ListBlueprintsWithResponse(ctx context.Context, params *ListBlueprintsParams, reqEditors ...RequestEditorFn) (*ListBlueprintsResponse, error) {
+	rsp, err := c.ListBlueprints(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListBlueprintsResponse(rsp)
+}
+
+// CreateBlueprintWithBodyWithResponse request with arbitrary body returning *CreateBlueprintResponse
+func (c *ClientWithResponses) CreateBlueprintWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateBlueprintResponse, error) {
+	rsp, err := c.CreateBlueprintWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateBlueprintResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateBlueprintWithResponse(ctx context.Context, body CreateBlueprintJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateBlueprintResponse, error) {
+	rsp, err := c.CreateBlueprint(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateBlueprintResponse(rsp)
+}
+
+// ArchiveBlueprintWithResponse request returning *ArchiveBlueprintResponse
+func (c *ClientWithResponses) ArchiveBlueprintWithResponse(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*ArchiveBlueprintResponse, error) {
+	rsp, err := c.ArchiveBlueprint(ctx, blueprintName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseArchiveBlueprintResponse(rsp)
+}
+
+// GetLatestBlueprintWithResponse request returning *GetLatestBlueprintResponse
+func (c *ClientWithResponses) GetLatestBlueprintWithResponse(ctx context.Context, blueprintName string, reqEditors ...RequestEditorFn) (*GetLatestBlueprintResponse, error) {
+	rsp, err := c.GetLatestBlueprint(ctx, blueprintName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetLatestBlueprintResponse(rsp)
+}
+
+// ArchiveBlueprintVersionWithResponse request returning *ArchiveBlueprintVersionResponse
+func (c *ClientWithResponses) ArchiveBlueprintVersionWithResponse(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*ArchiveBlueprintVersionResponse, error) {
+	rsp, err := c.ArchiveBlueprintVersion(ctx, blueprintName, blueprintVersion, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseArchiveBlueprintVersionResponse(rsp)
+}
+
+// GetBlueprintVersionWithResponse request returning *GetBlueprintVersionResponse
+func (c *ClientWithResponses) GetBlueprintVersionWithResponse(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...RequestEditorFn) (*GetBlueprintVersionResponse, error) {
+	rsp, err := c.GetBlueprintVersion(ctx, blueprintName, blueprintVersion, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBlueprintVersionResponse(rsp)
+}
+
 // HealthWithResponse request returning *HealthResponse
 func (c *ClientWithResponses) HealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthResponse, error) {
 	rsp, err := c.Health(ctx, reqEditors...)
@@ -24178,6 +24903,142 @@ func (c *ClientWithResponses) CreateViewUpdateWithBodyWithResponse(ctx context.C
 		return nil, err
 	}
 	return ParseCreateViewUpdateResponse(rsp)
+}
+
+// ParseListBlueprintsResponse parses an HTTP response from a ListBlueprintsWithResponse call
+func ParseListBlueprintsResponse(rsp *http.Response) (*ListBlueprintsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListBlueprintsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListBlueprintsOutput
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateBlueprintResponse parses an HTTP response from a CreateBlueprintWithResponse call
+func ParseCreateBlueprintResponse(rsp *http.Response) (*CreateBlueprintResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateBlueprintResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest Blueprint
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseArchiveBlueprintResponse parses an HTTP response from a ArchiveBlueprintWithResponse call
+func ParseArchiveBlueprintResponse(rsp *http.Response) (*ArchiveBlueprintResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ArchiveBlueprintResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseGetLatestBlueprintResponse parses an HTTP response from a GetLatestBlueprintWithResponse call
+func ParseGetLatestBlueprintResponse(rsp *http.Response) (*GetLatestBlueprintResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetLatestBlueprintResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Blueprint
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseArchiveBlueprintVersionResponse parses an HTTP response from a ArchiveBlueprintVersionWithResponse call
+func ParseArchiveBlueprintVersionResponse(rsp *http.Response) (*ArchiveBlueprintVersionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ArchiveBlueprintVersionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseGetBlueprintVersionResponse parses an HTTP response from a GetBlueprintVersionWithResponse call
+func ParseGetBlueprintVersionResponse(rsp *http.Response) (*GetBlueprintVersionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBlueprintVersionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Blueprint
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseHealthResponse parses an HTTP response from a HealthWithResponse call

--- a/api/mocks/client_interface.gen.go
+++ b/api/mocks/client_interface.gen.go
@@ -1091,6 +1091,155 @@ func (_c *ClientInterface_ArchiveAsset_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// ArchiveBlueprint provides a mock function with given fields: ctx, blueprintName, reqEditors
+func (_m *ClientInterface) ArchiveBlueprint(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ArchiveBlueprint")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, blueprintName, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_ArchiveBlueprint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ArchiveBlueprint'
+type ClientInterface_ArchiveBlueprint_Call struct {
+	*mock.Call
+}
+
+// ArchiveBlueprint is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) ArchiveBlueprint(ctx interface{}, blueprintName interface{}, reqEditors ...interface{}) *ClientInterface_ArchiveBlueprint_Call {
+	return &ClientInterface_ArchiveBlueprint_Call{Call: _e.mock.On("ArchiveBlueprint",
+		append([]interface{}{ctx, blueprintName}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_ArchiveBlueprint_Call) Run(run func(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn)) *ClientInterface_ArchiveBlueprint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_ArchiveBlueprint_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_ArchiveBlueprint_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_ArchiveBlueprint_Call) RunAndReturn(run func(context.Context, string, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_ArchiveBlueprint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ArchiveBlueprintVersion provides a mock function with given fields: ctx, blueprintName, blueprintVersion, reqEditors
+func (_m *ClientInterface) ArchiveBlueprintVersion(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName, blueprintVersion)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ArchiveBlueprintVersion")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_ArchiveBlueprintVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ArchiveBlueprintVersion'
+type ClientInterface_ArchiveBlueprintVersion_Call struct {
+	*mock.Call
+}
+
+// ArchiveBlueprintVersion is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - blueprintVersion int
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) ArchiveBlueprintVersion(ctx interface{}, blueprintName interface{}, blueprintVersion interface{}, reqEditors ...interface{}) *ClientInterface_ArchiveBlueprintVersion_Call {
+	return &ClientInterface_ArchiveBlueprintVersion_Call{Call: _e.mock.On("ArchiveBlueprintVersion",
+		append([]interface{}{ctx, blueprintName, blueprintVersion}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_ArchiveBlueprintVersion_Call) Run(run func(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn)) *ClientInterface_ArchiveBlueprintVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(int), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_ArchiveBlueprintVersion_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_ArchiveBlueprintVersion_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_ArchiveBlueprintVersion_Call) RunAndReturn(run func(context.Context, string, int, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_ArchiveBlueprintVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ArchiveExperience provides a mock function with given fields: ctx, projectID, experienceID, reqEditors
 func (_m *ClientInterface) ArchiveExperience(ctx context.Context, projectID uuid.UUID, experienceID uuid.UUID, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	_va := make([]interface{}, len(reqEditors))
@@ -2604,6 +2753,155 @@ func (_c *ClientInterface_CreateBatchWithBody_Call) Return(_a0 *http.Response, _
 }
 
 func (_c *ClientInterface_CreateBatchWithBody_Call) RunAndReturn(run func(context.Context, uuid.UUID, string, io.Reader, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_CreateBatchWithBody_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateBlueprint provides a mock function with given fields: ctx, body, reqEditors
+func (_m *ClientInterface) CreateBlueprint(ctx context.Context, body api.CreateBlueprintInput, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBlueprint")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, body, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_CreateBlueprint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateBlueprint'
+type ClientInterface_CreateBlueprint_Call struct {
+	*mock.Call
+}
+
+// CreateBlueprint is a helper method to define mock.On call
+//   - ctx context.Context
+//   - body api.CreateBlueprintInput
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) CreateBlueprint(ctx interface{}, body interface{}, reqEditors ...interface{}) *ClientInterface_CreateBlueprint_Call {
+	return &ClientInterface_CreateBlueprint_Call{Call: _e.mock.On("CreateBlueprint",
+		append([]interface{}{ctx, body}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_CreateBlueprint_Call) Run(run func(ctx context.Context, body api.CreateBlueprintInput, reqEditors ...api.RequestEditorFn)) *ClientInterface_CreateBlueprint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(api.CreateBlueprintInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_CreateBlueprint_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_CreateBlueprint_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_CreateBlueprint_Call) RunAndReturn(run func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_CreateBlueprint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateBlueprintWithBody provides a mock function with given fields: ctx, contentType, body, reqEditors
+func (_m *ClientInterface) CreateBlueprintWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, contentType, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBlueprintWithBody")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, io.Reader, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, contentType, body, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, io.Reader, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, contentType, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, io.Reader, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, contentType, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_CreateBlueprintWithBody_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateBlueprintWithBody'
+type ClientInterface_CreateBlueprintWithBody_Call struct {
+	*mock.Call
+}
+
+// CreateBlueprintWithBody is a helper method to define mock.On call
+//   - ctx context.Context
+//   - contentType string
+//   - body io.Reader
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) CreateBlueprintWithBody(ctx interface{}, contentType interface{}, body interface{}, reqEditors ...interface{}) *ClientInterface_CreateBlueprintWithBody_Call {
+	return &ClientInterface_CreateBlueprintWithBody_Call{Call: _e.mock.On("CreateBlueprintWithBody",
+		append([]interface{}{ctx, contentType, body}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_CreateBlueprintWithBody_Call) Run(run func(ctx context.Context, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn)) *ClientInterface_CreateBlueprintWithBody_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(io.Reader), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_CreateBlueprintWithBody_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_CreateBlueprintWithBody_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_CreateBlueprintWithBody_Call) RunAndReturn(run func(context.Context, string, io.Reader, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_CreateBlueprintWithBody_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6399,6 +6697,81 @@ func (_c *ClientInterface_GetBatchSuggestions_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// GetBlueprintVersion provides a mock function with given fields: ctx, blueprintName, blueprintVersion, reqEditors
+func (_m *ClientInterface) GetBlueprintVersion(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName, blueprintVersion)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBlueprintVersion")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_GetBlueprintVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBlueprintVersion'
+type ClientInterface_GetBlueprintVersion_Call struct {
+	*mock.Call
+}
+
+// GetBlueprintVersion is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - blueprintVersion int
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) GetBlueprintVersion(ctx interface{}, blueprintName interface{}, blueprintVersion interface{}, reqEditors ...interface{}) *ClientInterface_GetBlueprintVersion_Call {
+	return &ClientInterface_GetBlueprintVersion_Call{Call: _e.mock.On("GetBlueprintVersion",
+		append([]interface{}{ctx, blueprintName, blueprintVersion}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_GetBlueprintVersion_Call) Run(run func(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn)) *ClientInterface_GetBlueprintVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(int), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_GetBlueprintVersion_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_GetBlueprintVersion_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_GetBlueprintVersion_Call) RunAndReturn(run func(context.Context, string, int, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_GetBlueprintVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBranchForProject provides a mock function with given fields: ctx, projectID, branchID, reqEditors
 func (_m *ClientInterface) GetBranchForProject(ctx context.Context, projectID uuid.UUID, branchID uuid.UUID, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	_va := make([]interface{}, len(reqEditors))
@@ -7153,6 +7526,80 @@ func (_c *ClientInterface_GetJobLog_Call) Return(_a0 *http.Response, _a1 error) 
 }
 
 func (_c *ClientInterface_GetJobLog_Call) RunAndReturn(run func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_GetJobLog_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLatestBlueprint provides a mock function with given fields: ctx, blueprintName, reqEditors
+func (_m *ClientInterface) GetLatestBlueprint(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestBlueprint")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, blueprintName, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_GetLatestBlueprint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestBlueprint'
+type ClientInterface_GetLatestBlueprint_Call struct {
+	*mock.Call
+}
+
+// GetLatestBlueprint is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) GetLatestBlueprint(ctx interface{}, blueprintName interface{}, reqEditors ...interface{}) *ClientInterface_GetLatestBlueprint_Call {
+	return &ClientInterface_GetLatestBlueprint_Call{Call: _e.mock.On("GetLatestBlueprint",
+		append([]interface{}{ctx, blueprintName}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_GetLatestBlueprint_Call) Run(run func(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn)) *ClientInterface_GetLatestBlueprint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_GetLatestBlueprint_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_GetLatestBlueprint_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_GetLatestBlueprint_Call) RunAndReturn(run func(context.Context, string, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_GetLatestBlueprint_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -9945,6 +10392,80 @@ func (_c *ClientInterface_ListBatchesForTestSuiteRevision_Call) Return(_a0 *http
 }
 
 func (_c *ClientInterface_ListBatchesForTestSuiteRevision_Call) RunAndReturn(run func(context.Context, uuid.UUID, uuid.UUID, int32, *api.ListBatchesForTestSuiteRevisionParams, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_ListBatchesForTestSuiteRevision_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListBlueprints provides a mock function with given fields: ctx, params, reqEditors
+func (_m *ClientInterface) ListBlueprints(ctx context.Context, params *api.ListBlueprintsParams, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListBlueprints")
+	}
+
+	var r0 *http.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) (*http.Response, error)); ok {
+		return rf(ctx, params, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) *http.Response); ok {
+		r0 = rf(ctx, params, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, params, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientInterface_ListBlueprints_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBlueprints'
+type ClientInterface_ListBlueprints_Call struct {
+	*mock.Call
+}
+
+// ListBlueprints is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *api.ListBlueprintsParams
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientInterface_Expecter) ListBlueprints(ctx interface{}, params interface{}, reqEditors ...interface{}) *ClientInterface_ListBlueprints_Call {
+	return &ClientInterface_ListBlueprints_Call{Call: _e.mock.On("ListBlueprints",
+		append([]interface{}{ctx, params}, reqEditors...)...)}
+}
+
+func (_c *ClientInterface_ListBlueprints_Call) Run(run func(ctx context.Context, params *api.ListBlueprintsParams, reqEditors ...api.RequestEditorFn)) *ClientInterface_ListBlueprints_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ListBlueprintsParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientInterface_ListBlueprints_Call) Return(_a0 *http.Response, _a1 error) *ClientInterface_ListBlueprints_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientInterface_ListBlueprints_Call) RunAndReturn(run func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) (*http.Response, error)) *ClientInterface_ListBlueprints_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/mocks/client_with_responses_interface.gen.go
+++ b/api/mocks/client_with_responses_interface.gen.go
@@ -1089,6 +1089,155 @@ func (_c *ClientWithResponsesInterface_ArchiveAssetWithResponse_Call) RunAndRetu
 	return _c
 }
 
+// ArchiveBlueprintVersionWithResponse provides a mock function with given fields: ctx, blueprintName, blueprintVersion, reqEditors
+func (_m *ClientWithResponsesInterface) ArchiveBlueprintVersionWithResponse(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn) (*api.ArchiveBlueprintVersionResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName, blueprintVersion)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ArchiveBlueprintVersionWithResponse")
+	}
+
+	var r0 *api.ArchiveBlueprintVersionResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) (*api.ArchiveBlueprintVersionResponse, error)); ok {
+		return rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) *api.ArchiveBlueprintVersionResponse); ok {
+		r0 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.ArchiveBlueprintVersionResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ArchiveBlueprintVersionWithResponse'
+type ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call struct {
+	*mock.Call
+}
+
+// ArchiveBlueprintVersionWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - blueprintVersion int
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) ArchiveBlueprintVersionWithResponse(ctx interface{}, blueprintName interface{}, blueprintVersion interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call {
+	return &ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call{Call: _e.mock.On("ArchiveBlueprintVersionWithResponse",
+		append([]interface{}{ctx, blueprintName, blueprintVersion}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call) Run(run func(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(int), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call) Return(_a0 *api.ArchiveBlueprintVersionResponse, _a1 error) *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call) RunAndReturn(run func(context.Context, string, int, ...api.RequestEditorFn) (*api.ArchiveBlueprintVersionResponse, error)) *ClientWithResponsesInterface_ArchiveBlueprintVersionWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ArchiveBlueprintWithResponse provides a mock function with given fields: ctx, blueprintName, reqEditors
+func (_m *ClientWithResponsesInterface) ArchiveBlueprintWithResponse(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn) (*api.ArchiveBlueprintResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ArchiveBlueprintWithResponse")
+	}
+
+	var r0 *api.ArchiveBlueprintResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) (*api.ArchiveBlueprintResponse, error)); ok {
+		return rf(ctx, blueprintName, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) *api.ArchiveBlueprintResponse); ok {
+		r0 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.ArchiveBlueprintResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ArchiveBlueprintWithResponse'
+type ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call struct {
+	*mock.Call
+}
+
+// ArchiveBlueprintWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) ArchiveBlueprintWithResponse(ctx interface{}, blueprintName interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call {
+	return &ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call{Call: _e.mock.On("ArchiveBlueprintWithResponse",
+		append([]interface{}{ctx, blueprintName}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call) Run(run func(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call) Return(_a0 *api.ArchiveBlueprintResponse, _a1 error) *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call) RunAndReturn(run func(context.Context, string, ...api.RequestEditorFn) (*api.ArchiveBlueprintResponse, error)) *ClientWithResponsesInterface_ArchiveBlueprintWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ArchiveExperienceWithResponse provides a mock function with given fields: ctx, projectID, experienceID, reqEditors
 func (_m *ClientWithResponsesInterface) ArchiveExperienceWithResponse(ctx context.Context, projectID uuid.UUID, experienceID uuid.UUID, reqEditors ...api.RequestEditorFn) (*api.ArchiveExperienceResponse, error) {
 	_va := make([]interface{}, len(reqEditors))
@@ -2602,6 +2751,155 @@ func (_c *ClientWithResponsesInterface_CreateBatchWithResponse_Call) Return(_a0 
 }
 
 func (_c *ClientWithResponsesInterface_CreateBatchWithResponse_Call) RunAndReturn(run func(context.Context, uuid.UUID, api.BatchInput, ...api.RequestEditorFn) (*api.CreateBatchResponse, error)) *ClientWithResponsesInterface_CreateBatchWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateBlueprintWithBodyWithResponse provides a mock function with given fields: ctx, contentType, body, reqEditors
+func (_m *ClientWithResponsesInterface) CreateBlueprintWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*api.CreateBlueprintResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, contentType, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBlueprintWithBodyWithResponse")
+	}
+
+	var r0 *api.CreateBlueprintResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, io.Reader, ...api.RequestEditorFn) (*api.CreateBlueprintResponse, error)); ok {
+		return rf(ctx, contentType, body, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, io.Reader, ...api.RequestEditorFn) *api.CreateBlueprintResponse); ok {
+		r0 = rf(ctx, contentType, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.CreateBlueprintResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, io.Reader, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, contentType, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateBlueprintWithBodyWithResponse'
+type ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call struct {
+	*mock.Call
+}
+
+// CreateBlueprintWithBodyWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - contentType string
+//   - body io.Reader
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) CreateBlueprintWithBodyWithResponse(ctx interface{}, contentType interface{}, body interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call {
+	return &ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call{Call: _e.mock.On("CreateBlueprintWithBodyWithResponse",
+		append([]interface{}{ctx, contentType, body}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call) Run(run func(ctx context.Context, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(io.Reader), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call) Return(_a0 *api.CreateBlueprintResponse, _a1 error) *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call) RunAndReturn(run func(context.Context, string, io.Reader, ...api.RequestEditorFn) (*api.CreateBlueprintResponse, error)) *ClientWithResponsesInterface_CreateBlueprintWithBodyWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateBlueprintWithResponse provides a mock function with given fields: ctx, body, reqEditors
+func (_m *ClientWithResponsesInterface) CreateBlueprintWithResponse(ctx context.Context, body api.CreateBlueprintInput, reqEditors ...api.RequestEditorFn) (*api.CreateBlueprintResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBlueprintWithResponse")
+	}
+
+	var r0 *api.CreateBlueprintResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) (*api.CreateBlueprintResponse, error)); ok {
+		return rf(ctx, body, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) *api.CreateBlueprintResponse); ok {
+		r0 = rf(ctx, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.CreateBlueprintResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_CreateBlueprintWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateBlueprintWithResponse'
+type ClientWithResponsesInterface_CreateBlueprintWithResponse_Call struct {
+	*mock.Call
+}
+
+// CreateBlueprintWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - body api.CreateBlueprintInput
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) CreateBlueprintWithResponse(ctx interface{}, body interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call {
+	return &ClientWithResponsesInterface_CreateBlueprintWithResponse_Call{Call: _e.mock.On("CreateBlueprintWithResponse",
+		append([]interface{}{ctx, body}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call) Run(run func(ctx context.Context, body api.CreateBlueprintInput, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(api.CreateBlueprintInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call) Return(_a0 *api.CreateBlueprintResponse, _a1 error) *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call) RunAndReturn(run func(context.Context, api.CreateBlueprintInput, ...api.RequestEditorFn) (*api.CreateBlueprintResponse, error)) *ClientWithResponsesInterface_CreateBlueprintWithResponse_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6397,6 +6695,81 @@ func (_c *ClientWithResponsesInterface_GetBatchWithResponse_Call) RunAndReturn(r
 	return _c
 }
 
+// GetBlueprintVersionWithResponse provides a mock function with given fields: ctx, blueprintName, blueprintVersion, reqEditors
+func (_m *ClientWithResponsesInterface) GetBlueprintVersionWithResponse(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn) (*api.GetBlueprintVersionResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName, blueprintVersion)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBlueprintVersionWithResponse")
+	}
+
+	var r0 *api.GetBlueprintVersionResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) (*api.GetBlueprintVersionResponse, error)); ok {
+		return rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, ...api.RequestEditorFn) *api.GetBlueprintVersionResponse); ok {
+		r0 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.GetBlueprintVersionResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, blueprintVersion, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBlueprintVersionWithResponse'
+type ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call struct {
+	*mock.Call
+}
+
+// GetBlueprintVersionWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - blueprintVersion int
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) GetBlueprintVersionWithResponse(ctx interface{}, blueprintName interface{}, blueprintVersion interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call {
+	return &ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call{Call: _e.mock.On("GetBlueprintVersionWithResponse",
+		append([]interface{}{ctx, blueprintName, blueprintVersion}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call) Run(run func(ctx context.Context, blueprintName string, blueprintVersion int, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(int), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call) Return(_a0 *api.GetBlueprintVersionResponse, _a1 error) *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call) RunAndReturn(run func(context.Context, string, int, ...api.RequestEditorFn) (*api.GetBlueprintVersionResponse, error)) *ClientWithResponsesInterface_GetBlueprintVersionWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBranchForProjectWithResponse provides a mock function with given fields: ctx, projectID, branchID, reqEditors
 func (_m *ClientWithResponsesInterface) GetBranchForProjectWithResponse(ctx context.Context, projectID uuid.UUID, branchID uuid.UUID, reqEditors ...api.RequestEditorFn) (*api.GetBranchForProjectResponse, error) {
 	_va := make([]interface{}, len(reqEditors))
@@ -7151,6 +7524,80 @@ func (_c *ClientWithResponsesInterface_GetJobWithResponse_Call) Return(_a0 *api.
 }
 
 func (_c *ClientWithResponsesInterface_GetJobWithResponse_Call) RunAndReturn(run func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, ...api.RequestEditorFn) (*api.GetJobResponse, error)) *ClientWithResponsesInterface_GetJobWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLatestBlueprintWithResponse provides a mock function with given fields: ctx, blueprintName, reqEditors
+func (_m *ClientWithResponsesInterface) GetLatestBlueprintWithResponse(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn) (*api.GetLatestBlueprintResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, blueprintName)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestBlueprintWithResponse")
+	}
+
+	var r0 *api.GetLatestBlueprintResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) (*api.GetLatestBlueprintResponse, error)); ok {
+		return rf(ctx, blueprintName, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...api.RequestEditorFn) *api.GetLatestBlueprintResponse); ok {
+		r0 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.GetLatestBlueprintResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, blueprintName, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestBlueprintWithResponse'
+type ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call struct {
+	*mock.Call
+}
+
+// GetLatestBlueprintWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blueprintName string
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) GetLatestBlueprintWithResponse(ctx interface{}, blueprintName interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call {
+	return &ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call{Call: _e.mock.On("GetLatestBlueprintWithResponse",
+		append([]interface{}{ctx, blueprintName}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call) Run(run func(ctx context.Context, blueprintName string, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call) Return(_a0 *api.GetLatestBlueprintResponse, _a1 error) *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call) RunAndReturn(run func(context.Context, string, ...api.RequestEditorFn) (*api.GetLatestBlueprintResponse, error)) *ClientWithResponsesInterface_GetLatestBlueprintWithResponse_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -9943,6 +10390,80 @@ func (_c *ClientWithResponsesInterface_ListBatchesWithResponse_Call) Return(_a0 
 }
 
 func (_c *ClientWithResponsesInterface_ListBatchesWithResponse_Call) RunAndReturn(run func(context.Context, uuid.UUID, *api.ListBatchesParams, ...api.RequestEditorFn) (*api.ListBatchesResponse, error)) *ClientWithResponsesInterface_ListBatchesWithResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListBlueprintsWithResponse provides a mock function with given fields: ctx, params, reqEditors
+func (_m *ClientWithResponsesInterface) ListBlueprintsWithResponse(ctx context.Context, params *api.ListBlueprintsParams, reqEditors ...api.RequestEditorFn) (*api.ListBlueprintsResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListBlueprintsWithResponse")
+	}
+
+	var r0 *api.ListBlueprintsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) (*api.ListBlueprintsResponse, error)); ok {
+		return rf(ctx, params, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) *api.ListBlueprintsResponse); ok {
+		r0 = rf(ctx, params, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.ListBlueprintsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) error); ok {
+		r1 = rf(ctx, params, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ClientWithResponsesInterface_ListBlueprintsWithResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBlueprintsWithResponse'
+type ClientWithResponsesInterface_ListBlueprintsWithResponse_Call struct {
+	*mock.Call
+}
+
+// ListBlueprintsWithResponse is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *api.ListBlueprintsParams
+//   - reqEditors ...api.RequestEditorFn
+func (_e *ClientWithResponsesInterface_Expecter) ListBlueprintsWithResponse(ctx interface{}, params interface{}, reqEditors ...interface{}) *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call {
+	return &ClientWithResponsesInterface_ListBlueprintsWithResponse_Call{Call: _e.mock.On("ListBlueprintsWithResponse",
+		append([]interface{}{ctx, params}, reqEditors...)...)}
+}
+
+func (_c *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call) Run(run func(ctx context.Context, params *api.ListBlueprintsParams, reqEditors ...api.RequestEditorFn)) *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]api.RequestEditorFn, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(api.RequestEditorFn)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ListBlueprintsParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call) Return(_a0 *api.ListBlueprintsResponse, _a1 error) *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call) RunAndReturn(run func(context.Context, *api.ListBlueprintsParams, ...api.RequestEditorFn) (*api.ListBlueprintsResponse, error)) *ClientWithResponsesInterface_ListBlueprintsWithResponse_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/bff/queries.gen.go
+++ b/bff/queries.gen.go
@@ -8,6 +8,29 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// CreateDashboardCreateDashboard includes the requested fields of the GraphQL type Dashboard.
+type CreateDashboardCreateDashboard struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetId returns CreateDashboardCreateDashboard.Id, and is useful for accessing the field via an interface.
+func (v *CreateDashboardCreateDashboard) GetId() string { return v.Id }
+
+// GetName returns CreateDashboardCreateDashboard.Name, and is useful for accessing the field via an interface.
+func (v *CreateDashboardCreateDashboard) GetName() string { return v.Name }
+
+// CreateDashboardResponse is returned by CreateDashboard on success.
+type CreateDashboardResponse struct {
+	// Create a new dashboard
+	CreateDashboard CreateDashboardCreateDashboard `json:"createDashboard"`
+}
+
+// GetCreateDashboard returns CreateDashboardResponse.CreateDashboard, and is useful for accessing the field via an interface.
+func (v *CreateDashboardResponse) GetCreateDashboard() CreateDashboardCreateDashboard {
+	return v.CreateDashboard
+}
+
 // CreateDebugDashboardCreateDebugDashboard includes the requested fields of the GraphQL type Dashboard.
 type CreateDebugDashboardCreateDebugDashboard struct {
 	Id   string `json:"id"`
@@ -80,6 +103,30 @@ type UpdateMetricsConfigResponse struct {
 // GetUpdateMetricsConfig returns UpdateMetricsConfigResponse.UpdateMetricsConfig, and is useful for accessing the field via an interface.
 func (v *UpdateMetricsConfigResponse) GetUpdateMetricsConfig() string { return v.UpdateMetricsConfig }
 
+// __CreateDashboardInput is used internally by genqlient
+type __CreateDashboardInput struct {
+	ProjectId  string `json:"projectId"`
+	BranchId   string `json:"branchId"`
+	Name       string `json:"name"`
+	DayRange   int    `json:"dayRange"`
+	MetricsSet string `json:"metricsSet"`
+}
+
+// GetProjectId returns __CreateDashboardInput.ProjectId, and is useful for accessing the field via an interface.
+func (v *__CreateDashboardInput) GetProjectId() string { return v.ProjectId }
+
+// GetBranchId returns __CreateDashboardInput.BranchId, and is useful for accessing the field via an interface.
+func (v *__CreateDashboardInput) GetBranchId() string { return v.BranchId }
+
+// GetName returns __CreateDashboardInput.Name, and is useful for accessing the field via an interface.
+func (v *__CreateDashboardInput) GetName() string { return v.Name }
+
+// GetDayRange returns __CreateDashboardInput.DayRange, and is useful for accessing the field via an interface.
+func (v *__CreateDashboardInput) GetDayRange() int { return v.DayRange }
+
+// GetMetricsSet returns __CreateDashboardInput.MetricsSet, and is useful for accessing the field via an interface.
+func (v *__CreateDashboardInput) GetMetricsSet() string { return v.MetricsSet }
+
 // __CreateDebugDashboardInput is used internally by genqlient
 type __CreateDebugDashboardInput struct {
 	ProjectId      string            `json:"projectId"`
@@ -135,6 +182,49 @@ func (v *__UpdateMetricsConfigInput) GetTemplateFiles() []MetricsTemplate { retu
 
 // GetBranch returns __UpdateMetricsConfigInput.Branch, and is useful for accessing the field via an interface.
 func (v *__UpdateMetricsConfigInput) GetBranch() string { return v.Branch }
+
+// The mutation executed by CreateDashboard.
+const CreateDashboard_Operation = `
+mutation CreateDashboard ($projectId: String!, $branchId: String!, $name: String!, $dayRange: Int, $metricsSet: String) {
+	createDashboard(input: {branchId:$branchId,dayRange:$dayRange,name:$name,projectId:$projectId,metricsSet:$metricsSet}) {
+		id
+		name
+	}
+}
+`
+
+func CreateDashboard(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	projectId string,
+	branchId string,
+	name string,
+	dayRange int,
+	metricsSet string,
+) (data_ *CreateDashboardResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "CreateDashboard",
+		Query:  CreateDashboard_Operation,
+		Variables: &__CreateDashboardInput{
+			ProjectId:  projectId,
+			BranchId:   branchId,
+			Name:       name,
+			DayRange:   dayRange,
+			MetricsSet: metricsSet,
+		},
+	}
+
+	data_ = &CreateDashboardResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
 
 // The mutation executed by CreateDebugDashboard.
 const CreateDebugDashboard_Operation = `

--- a/bff/queries/create_dashboard.graphql
+++ b/bff/queries/create_dashboard.graphql
@@ -1,0 +1,6 @@
+mutation CreateDashboard($projectId: String!, $branchId: String!, $name: String!, $dayRange: Int, $metricsSet: String) {
+    createDashboard( input: {branchId: $branchId, dayRange: $dayRange, name: $name, projectId: $projectId, metricsSet: $metricsSet}) {
+        id
+        name
+    }
+}

--- a/cmd/resim/commands/dashboards.go
+++ b/cmd/resim/commands/dashboards.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/resim-ai/api-client/auth"
+	"github.com/resim-ai/api-client/bff"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	dashboardCmd = &cobra.Command{
+		Use:     "dashboards",
+		Short:   "dashboards contains commands for managing dashboards",
+		Long:    ``,
+		Aliases: []string{"dashboard"},
+	}
+	createDashboardCmd = &cobra.Command{
+		Use:   "create",
+		Short: "create - Creates a new dashboard",
+		Long:  ``,
+		Run:   createDashboard,
+	}
+)
+
+const (
+	dashboardProjectKey    = "project"
+	dashboardBranchKey     = "branch"
+	dashboardNameKey       = "name"
+	dashboardDayRangeKey   = "day-range"
+	dashboardMetricsSetKey = "metrics-set"
+)
+
+func init() {
+	createDashboardCmd.Flags().String(dashboardProjectKey, "", "The name or ID of the project")
+	createDashboardCmd.MarkFlagRequired(dashboardProjectKey)
+	createDashboardCmd.Flags().String(dashboardBranchKey, "", "The name or ID of the branch")
+	createDashboardCmd.MarkFlagRequired(dashboardBranchKey)
+	createDashboardCmd.Flags().String(dashboardNameKey, "", "The display name for the dashboard")
+	createDashboardCmd.MarkFlagRequired(dashboardNameKey)
+	createDashboardCmd.Flags().Int(dashboardDayRangeKey, 31, "Number of days of data to include")
+	createDashboardCmd.MarkFlagRequired(dashboardDayRangeKey)
+	createDashboardCmd.Flags().String(dashboardMetricsSetKey, "", "The name of the metrics set to use")
+
+	dashboardCmd.AddCommand(createDashboardCmd)
+	rootCmd.AddCommand(dashboardCmd)
+}
+
+func createDashboard(cmd *cobra.Command, args []string) {
+	projectID := getProjectID(Client, viper.GetString(dashboardProjectKey))
+	branchID := getBranchID(Client, projectID, viper.GetString(dashboardBranchKey), true)
+
+	resp, err := bff.CreateDashboard(
+		context.Background(),
+		BffClient,
+		projectID.String(),
+		branchID.String(),
+		viper.GetString(dashboardNameKey),
+		viper.GetInt(dashboardDayRangeKey),
+		viper.GetString(dashboardMetricsSetKey),
+	)
+	if err != nil {
+		log.Fatalf("failed to create dashboard: %v", err)
+	}
+
+	fmt.Println("Created dashboard successfully!")
+	fmt.Printf("Dashboard ID: %s\n", resp.CreateDashboard.Id)
+	appURL := inferAppURL(viper.GetString(auth.KeyURL))
+	fmt.Printf("%s/projects/%s/dashboards/%s\n", appURL, projectID.String(), resp.CreateDashboard.Id)
+}

--- a/cmd/resim/commands/dashboards_test.go
+++ b/cmd/resim/commands/dashboards_test.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/google/uuid"
+	"github.com/resim-ai/api-client/api"
+	"github.com/resim-ai/api-client/bff"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCreateDashboardCmdHasRequiredFlags(t *testing.T) {
+	requiredFlags := []string{
+		dashboardProjectKey,
+		dashboardBranchKey,
+		dashboardNameKey,
+		dashboardDayRangeKey,
+	}
+	for _, name := range requiredFlags {
+		flag := createDashboardCmd.Flags().Lookup(name)
+		assert.NotNil(t, flag, "--%s flag should exist on createDashboardCmd", name)
+		assert.Equal(t, []string{"true"}, flag.Annotations[cobra.BashCompOneRequiredFlag], "--%s should be required", name)
+	}
+}
+
+func TestCreateDashboardCmdMetricsSetIsOptional(t *testing.T) {
+	flag := createDashboardCmd.Flags().Lookup(dashboardMetricsSetKey)
+	assert.NotNil(t, flag, "--metrics-set flag should exist on createDashboardCmd")
+	assert.Nil(t, flag.Annotations[cobra.BashCompOneRequiredFlag], "--metrics-set should not be required")
+}
+
+func (s *CommandsSuite) TestCreateDashboard_Success() {
+	projectID := uuid.New()
+	branchID := uuid.New()
+
+	viper.Set(dashboardProjectKey, "test-project")
+	viper.Set(dashboardBranchKey, "main")
+	viper.Set(dashboardNameKey, "From CLI")
+	viper.Set(dashboardDayRangeKey, 180)
+	viper.Set(dashboardMetricsSetKey, "my dashboard")
+
+	s.mockClient.On("ListProjectsWithResponse", matchContext, mock.MatchedBy(func(params *api.ListProjectsParams) bool {
+		return true
+	})).Return(&api.ListProjectsResponse{
+		HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+		JSON200: &api.ListProjectsOutput{
+			Projects: &[]api.Project{{ProjectID: projectID, Name: "test-project"}},
+		},
+	}, nil)
+
+	s.mockClient.On("ListBranchesForProjectWithResponse", matchContext, projectID, mock.Anything).Return(&api.ListBranchesForProjectResponse{
+		HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+		JSON200: &api.ListBranchesOutput{
+			Branches: &[]api.Branch{{BranchID: branchID, Name: "main"}},
+		},
+	}, nil)
+
+	mockBff := new(mockGraphQLClient)
+	mockBff.On("MakeRequest", matchContext, mock.MatchedBy(func(req *graphql.Request) bool {
+		return req.OpName == "CreateDashboard"
+	}), mock.Anything).Run(func(args mock.Arguments) {
+		resp := args.Get(2).(*graphql.Response)
+		data := resp.Data.(*bff.CreateDashboardResponse)
+		data.CreateDashboard = bff.CreateDashboardCreateDashboard{
+			Id:   "dash-abc-123",
+			Name: "From CLI",
+		}
+	}).Return(nil).Once()
+
+	origBffClient := BffClient
+	BffClient = mockBff
+	defer func() { BffClient = origBffClient }()
+
+	createDashboard(nil, []string{})
+
+	mockBff.AssertExpectations(s.T())
+}


### PR DESCRIPTION
# Description of change

Adds a new `resim dashboards create` command, to allow creating dashboards via CLI.

Requires https://github.com/resim-ai/rerun/pull/3194 to merge and deploy first.

https://linear.app/resim/issue/WOB-4084/allow-storing-dashboards-in-config-file
https://linear.app/resim/issue/WOB-4166/cli-updates-for-dashboard-creation

## Guide to reproduce test results

1. Sync a config `resim metrics sync --project project`
2. Create a dashboard
```
resim dashboards create \
  --branch main \
  --metrics-set "my dashboard" \
  --project project \
  --name "From CLI" \
  --day-range 180
```

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.