### PR TITLE
Ingestion Shouldn't Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.52.1 - May 14, 2026
+
+- `resim ingest` now creates ingested-log experiences with `cacheExempt: true`, so re-running an ingestion always re-processes the log instead of being served a cached result.
+
 ### v0.52.0 - May 12, 2026
 
 - Adds a new `dashboards` command with a `create` subcommand for creating dashboards.

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -211,11 +211,13 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 			continue
 		}
 
-		// Create the experience
+		// Create the experience. Ingested logs are one-shot inputs that should
+		// never be served from a cached run, so mark them cache-exempt.
 		experienceBody := api.CreateExperienceInput{
 			Name:        logConfig.Name,
 			Locations:   &[]string{logConfig.Location},
 			Description: "Ingested into ReSim via the CLI",
+			CacheExempt: Ptr(true),
 		}
 		experienceResponse, err := Client.CreateExperienceWithResponse(context.Background(), projectID, experienceBody)
 		if err != nil {


### PR DESCRIPTION
# Description of change

Caching happens by default in the ReSim platform. For log ingestion, however, the intent is often to only run evals once, so we default to not caching.

## Guide to reproduce test results

## Checklist

- [X] I have self-reviewed this change.
- [X] I have tested this change.
- [X] This change is covered by tests that are already landed, or in this PR.
- [X] I have updated the changelog, if appropriate.