### PR TITLE
Add batchURL to workflows runs get output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.54.0 - May 27, 2026
+
+- `resim workflows runs get` now includes a `batchURL` field per suite entry in the default output, linking directly to each batch in the ReSim app.
+
 ### v0.53.0 - May 15, 2026
 
 - `resim ingest` now supports metrics 2.0, mirroring `batches create`. Adds `--metrics-set` to specify a metrics set name, plus `--sync-metrics-config`, `--metrics-config-path`, and `--metrics-templates-path` to optionally sync the metrics config (and templates) for the build's branch before creating the ingestion batch.

--- a/cmd/resim/commands/batch_summary.go
+++ b/cmd/resim/commands/batch_summary.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/resim-ai/api-client/cmd/resim/commands/utils"
 
+	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
 	"github.com/resim-ai/api-client/auth"
 	"github.com/slack-go/slack"
@@ -42,15 +43,20 @@ type BatchMetadata struct {
 	SystemUrl string
 }
 
-func getBatchMetadata(batch *api.Batch) *BatchMetadata {
+func buildProjectBaseURL(projectID uuid.UUID) *url.URL {
 	baseUrl, err := url.Parse(strings.Replace(viper.GetString(auth.KeyURL), "api", "app", 1))
 	if err != nil {
 		log.Fatal("unable to parse url:", err)
 	}
-	baseUrl.Path, err = url.JoinPath("projects", batch.ProjectID.String())
+	baseUrl.Path, err = url.JoinPath("projects", projectID.String())
 	if err != nil {
 		log.Fatal("unable to build base url:", err)
 	}
+	return baseUrl
+}
+
+func getBatchMetadata(batch *api.Batch) *BatchMetadata {
+	baseUrl := buildProjectBaseURL(*batch.ProjectID)
 
 	// Get the suite object
 	suiteResponse, err := Client.GetTestSuiteWithResponse(context.Background(), *batch.ProjectID, *batch.TestSuiteID)

--- a/cmd/resim/commands/workflows.go
+++ b/cmd/resim/commands/workflows.go
@@ -739,7 +739,21 @@ func getWorkflowRun(ccmd *cobra.Command, args []string) {
 
 		OutputJson(payload)
 	} else {
-		OutputJson(resp.JSON200.WorkflowRunTestSuites)
+		type suiteOutput struct {
+			BatchID     api.BatchID     `json:"batchID"`
+			TestSuiteID api.TestSuiteID `json:"testSuiteID"`
+			BatchURL    string          `json:"batchURL"`
+		}
+		projectBaseURL := buildProjectBaseURL(projectID)
+		suites := make([]suiteOutput, 0, len(resp.JSON200.WorkflowRunTestSuites))
+		for _, s := range resp.JSON200.WorkflowRunTestSuites {
+			suites = append(suites, suiteOutput{
+				BatchID:     s.BatchID,
+				TestSuiteID: s.TestSuiteID,
+				BatchURL:    projectBaseURL.JoinPath("batches", s.BatchID.String()).String(),
+			})
+		}
+		OutputJson(suites)
 	}
 }
 

--- a/cmd/resim/commands/workflows.go
+++ b/cmd/resim/commands/workflows.go
@@ -225,6 +225,12 @@ func init() {
 	rootCmd.AddCommand(workflowCmd)
 }
 
+type workflowRunTestSuiteOutput struct {
+	BatchID     api.BatchID     `json:"batchID"`
+	TestSuiteID api.TestSuiteID `json:"testSuiteID"`
+	BatchURL    string          `json:"batchURL"`
+}
+
 type workflowSuiteSummary struct {
 	TestSuiteID uuid.UUID `json:"testSuiteID"`
 	Name        string    `json:"name"`
@@ -739,18 +745,13 @@ func getWorkflowRun(ccmd *cobra.Command, args []string) {
 
 		OutputJson(payload)
 	} else {
-		type suiteOutput struct {
-			BatchID     api.BatchID     `json:"batchID"`
-			TestSuiteID api.TestSuiteID `json:"testSuiteID"`
-			BatchURL    string          `json:"batchURL"`
-		}
 		projectBaseURL := buildProjectBaseURL(projectID)
-		suites := make([]suiteOutput, 0, len(resp.JSON200.WorkflowRunTestSuites))
-		for _, s := range resp.JSON200.WorkflowRunTestSuites {
-			suites = append(suites, suiteOutput{
-				BatchID:     s.BatchID,
-				TestSuiteID: s.TestSuiteID,
-				BatchURL:    projectBaseURL.JoinPath("batches", s.BatchID.String()).String(),
+		suites := make([]workflowRunTestSuiteOutput, 0, len(resp.JSON200.WorkflowRunTestSuites))
+		for _, suite := range resp.JSON200.WorkflowRunTestSuites {
+			suites = append(suites, workflowRunTestSuiteOutput{
+				BatchID:     suite.BatchID,
+				TestSuiteID: suite.TestSuiteID,
+				BatchURL:    projectBaseURL.JoinPath("batches", suite.BatchID.String()).String(),
 			})
 		}
 		OutputJson(suites)


### PR DESCRIPTION
## Summary

- `resim workflows runs get` now includes a `batchURL` field per suite entry in the default (non-Slack) output, constructed client-side from the API base URL
- Extracts a shared `buildProjectBaseURL` helper from `getBatchMetadata` in `batch_summary.go` for reuse
- Updated `CHANGELOG.md` for v0.54.0

## Local testing

Built and ran against a real workflow run (`6dbbb2a7-c250-4d37-aa8c-1146af7f0e2d`):

**Default output** — confirmed `batchURL` appears per suite entry and resolves to a valid ReSim app page.

**Slack output (`--slack`)** — confirmed unaffected; Slack Block Kit JSON is unchanged.

Unit tests pass (`go test ./cmd/resim/commands/...`).

## Test plan

- [x] Default output includes `batchURL` per suite entry
- [x] `batchURL` values resolve to valid pages in the ReSim app
- [x] `--slack` output is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)