### PR TITLE
style(agents): cosmetic clean-up of agents utilization output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## ReSim CLI
 
-### v0.57.0 - Unreleased
+### v0.58.0 - June 16, 2026
+
+- Cosmetic clean-up of `agents utilization`
+
+### v0.57.0 - June 16, 2026
 
 - Adds `agents utilization`, returning a bucketed utilization time-series for HiL Agents. With `--agent-id` it fetches a single agent (`GET /agents/{agentID}/utilization`); without it, one request fetches every non-removed agent in the org (`GET /agents/utilization`), including all-zero series for agents with no activity in the window. Each bucket reports `utilization` (fraction of wall-clock time the agent was running at least one experience), the `idle`/`offline` split of the non-running remainder, `testsRun` (job runs started in the bucket), and `avgConcurrency` (average number of experiences running at once). The window summary reports the total tests run, the average and median queue wait of runs started in the window, and the top experiences by running time (`--top-experiences`, default 10, 0-50). Supports `--start-time`, `--end-time`, `--interval hour|day`, and `--json`. Requires a server with the utilization endpoints deployed.
 - Library consumers: the regenerated client adds the `getAgentUtilization` / `listAgentUtilization` methods to `ClientWithResponsesInterface`.

--- a/cmd/resim/commands/agents.go
+++ b/cmd/resim/commands/agents.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"unicode/utf8"
 
 	"github.com/resim-ai/api-client/api"
 	. "github.com/resim-ai/api-client/cmd/resim/commands/utils"
@@ -395,6 +396,13 @@ const agentListHeader = "NAME\tSTATUS\tVERSION\tPOOL LABELS\tLAST CHECK-IN\n"
 // the table under the "Recent activity:" line.
 const agentActivityHeader = "  PROJECT\tBATCH\tBATCH STATUS\tTEST\tTEST STATUS\tBRANCH\tTIMESTAMP\n"
 
+// displayVersion renders a version string with exactly one leading "v",
+// regardless of whether the server already prefixed it. Without this the CLI
+// double-prefixes server-supplied "v1.2.3" values into "vv1.2.3".
+func displayVersion(version string) string {
+	return "v" + strings.TrimPrefix(version, "v")
+}
+
 // formatAgentRow renders a one-line summary suitable for `agents list`,
 // aligned under agentListHeader. The version trailer carries an explicit
 // "(out of date)" suffix so the CLI surfaces the same signal as the UI; when
@@ -403,12 +411,12 @@ const agentActivityHeader = "  PROJECT\tBATCH\tBATCH STATUS\tTEST\tTEST STATUS\t
 func formatAgentRow(a api.Agent, latestKnownVersion string) string {
 	verSuffix := ""
 	if a.IsOutOfDate && latestKnownVersion != "" {
-		verSuffix = fmt.Sprintf(" (out of date; latest %s)", latestKnownVersion)
+		verSuffix = fmt.Sprintf(" (out of date; latest %s)", displayVersion(latestKnownVersion))
 	}
-	return fmt.Sprintf("%s\t%s\tv%s%s\t%s\t%s\n",
+	return fmt.Sprintf("%s\t%s\t%s%s\t%s\t%s\n",
 		a.AgentID,
 		a.Activity,
-		a.Version,
+		displayVersion(a.Version),
 		verSuffix,
 		strings.Join(a.PoolLabels, ", "),
 		a.LastCheckin.Format("2006-01-02 15:04:05"),
@@ -419,7 +427,7 @@ func formatAgentDetail(a api.Agent) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Agent ID:        %s\n", a.AgentID)
 	fmt.Fprintf(&b, "Activity:        %s\n", a.Activity)
-	fmt.Fprintf(&b, "Version:         v%s", a.Version)
+	fmt.Fprintf(&b, "Version:         %s", displayVersion(a.Version))
 	if a.IsOutOfDate {
 		fmt.Fprint(&b, " (out of date — visit https://docs.resim.ai for the latest agent version)")
 	}
@@ -497,15 +505,34 @@ func formatSeconds(seconds float64) string {
 	return out
 }
 
+// utilLabelWidth is the column width of the summary header labels, sized to the
+// widest label ("Queue wait:") so their values line up in a single column.
+const utilLabelWidth = 11
+
 // writeUtilizationSummary renders the window-level counters shared by the
 // single-agent and org-wide outputs. The queue-wait line is omitted when the
 // server reported no started run with a measurable wait.
 func writeUtilizationSummary(b *strings.Builder, totalTestsRun int, avgQueueSeconds, medianQueueSeconds *float64) {
-	fmt.Fprintf(b, "Tests run: %d\n", totalTestsRun)
+	fmt.Fprintf(b, "%-*s %d\n", utilLabelWidth, "Tests run:", totalTestsRun)
 	if avgQueueSeconds != nil && medianQueueSeconds != nil {
-		fmt.Fprintf(b, "Queue wait: avg %s, median %s\n",
+		fmt.Fprintf(b, "%-*s avg %s, median %s\n", utilLabelWidth, "Queue wait:",
 			formatSeconds(*avgQueueSeconds), formatSeconds(*medianQueueSeconds))
 	}
+}
+
+// topExpNameWidth is the fixed width of the experience-name column. Names
+// longer than this are truncated so they don't push the other columns out of
+// alignment; the header line fits within an 80-column terminal.
+const topExpNameWidth = 44
+
+// truncate shortens s to at most maxRunes characters, replacing the tail with
+// an ellipsis when it overflows. It counts runes (not bytes) so the result is
+// maxRunes display columns wide, matching how fmt pads fixed-width fields.
+func truncate(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	return string([]rune(s)[:maxRunes-1]) + "…"
 }
 
 // writeTopExperiences renders the experiences ranked by running time in the
@@ -514,10 +541,13 @@ func writeTopExperiences(b *strings.Builder, tops []api.AgentUtilizationTopExper
 	if len(tops) == 0 {
 		return
 	}
-	fmt.Fprintf(b, "\n%-40s%-7s%-11s%s\n", "TOP EXPERIENCES", "RUNS", "RUN TIME", "SHARE OF BUSY TIME")
+	fmt.Fprintf(b, "\n%-*s%-7s%-11s%s\n", topExpNameWidth, "TOP EXPERIENCES", "RUNS", "RUN TIME", "SHARE OF BUSY TIME")
 	for _, e := range tops {
-		fmt.Fprintf(b, "%-40s%-7d%-11s%.1f%%\n",
-			e.ExperienceName, e.RunCount, formatSeconds(e.TotalRunSeconds), e.Share*100)
+		// Truncate one rune short of the column width so a clipped name still
+		// leaves at least one space before the RUNS column.
+		fmt.Fprintf(b, "%-*s%-7d%-11s%.1f%%\n",
+			topExpNameWidth, truncate(e.ExperienceName, topExpNameWidth-1),
+			e.RunCount, formatSeconds(e.TotalRunSeconds), e.Share*100)
 	}
 }
 
@@ -525,9 +555,9 @@ func writeTopExperiences(b *strings.Builder, tops []api.AgentUtilizationTopExper
 // bucket table.
 func formatAgentUtilization(out api.AgentUtilizationOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Agent:    %s\n", out.AgentID)
-	fmt.Fprintf(&b, "Interval: %s\n", out.Interval)
-	fmt.Fprintf(&b, "Window:   %s — %s\n",
+	fmt.Fprintf(&b, "%-*s %s\n", utilLabelWidth, "Agent:", out.AgentID)
+	fmt.Fprintf(&b, "%-*s %s\n", utilLabelWidth, "Interval:", out.Interval)
+	fmt.Fprintf(&b, "%-*s %s — %s\n", utilLabelWidth, "Window:",
 		out.WindowStart.Format("2006-01-02 15:04:05 MST"),
 		out.WindowEnd.Format("2006-01-02 15:04:05 MST"),
 	)
@@ -546,8 +576,8 @@ func formatAgentUtilization(out api.AgentUtilizationOutput) string {
 // so they are not repeated per section.
 func formatListAgentUtilization(out api.ListAgentUtilizationOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Interval: %s\n", out.Interval)
-	fmt.Fprintf(&b, "Window:   %s — %s\n",
+	fmt.Fprintf(&b, "%-*s %s\n", utilLabelWidth, "Interval:", out.Interval)
+	fmt.Fprintf(&b, "%-*s %s — %s\n", utilLabelWidth, "Window:",
 		out.WindowStart.Format("2006-01-02 15:04:05 MST"),
 		out.WindowEnd.Format("2006-01-02 15:04:05 MST"),
 	)
@@ -562,7 +592,7 @@ func formatListAgentUtilization(out api.ListAgentUtilizationOutput) string {
 			fmt.Fprintln(&b, "No buckets in the window.")
 			continue
 		}
-		fmt.Fprintf(&b, "Tests run: %d\n", sumBucketTestsRun(series.Buckets))
+		fmt.Fprintf(&b, "%-*s %d\n", utilLabelWidth, "Tests run:", sumBucketTestsRun(series.Buckets))
 		writeUtilizationBuckets(&b, series.Buckets)
 	}
 	writeTopExperiences(&b, out.TopExperiences)

--- a/cmd/resim/commands/agents_test.go
+++ b/cmd/resim/commands/agents_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/resim-ai/api-client/api"
@@ -122,14 +123,31 @@ func (s *CommandsSuite) TestListAgentsTableOutput() {
 	s.Contains(out, "LAST CHECK-IN")
 	s.Contains(out, "agent-1")
 	s.Contains(out, "agent-2")
-	s.Contains(out, "(out of date; latest 1.2.3)")
+	s.Contains(out, "(out of date; latest v1.2.3)")
 	// The header carries the label, so rows no longer repeat it.
 	s.NotContains(out, "last check-in")
 }
 
 func (s *CommandsSuite) TestFormatAgentRowOutOfDateSuffix() {
 	row := formatAgentRow(sampleAgent("agent-1", true), "1.2.3")
-	s.Contains(row, "(out of date; latest 1.2.3)")
+	s.Contains(row, "(out of date; latest v1.2.3)")
+}
+
+// TestFormatAgentVersionSinglePrefix guards against double-prefixing: the CLI
+// renders exactly one leading "v" whether or not the server already supplied
+// the prefix on the agent version or the latest-known version.
+func (s *CommandsSuite) TestFormatAgentVersionSinglePrefix() {
+	agent := sampleAgent("agent-1", true)
+	agent.Version = "v1.0.0"
+	row := formatAgentRow(agent, "v1.2.3")
+	s.Contains(row, "v1.0.0")
+	s.NotContains(row, "vv1.0.0")
+	s.Contains(row, "(out of date; latest v1.2.3)")
+	s.NotContains(row, "vv1.2.3")
+
+	detail := formatAgentDetail(agent)
+	s.Contains(detail, "Version:         v1.0.0")
+	s.NotContains(detail, "vv1.0.0")
 }
 
 func (s *CommandsSuite) TestFormatAgentRowSuppressesSuffixWithoutLatestVersion() {
@@ -531,8 +549,8 @@ func (s *CommandsSuite) TestActualAgentUtilization() {
 
 func (s *CommandsSuite) TestFormatAgentUtilization() {
 	out := formatAgentUtilization(sampleUtilizationOutput())
-	s.Contains(out, "Agent:    agent-1")
-	s.Contains(out, "Interval: day")
+	s.Contains(out, "Agent:      agent-1")
+	s.Contains(out, "Interval:   day")
 	s.Contains(out, "BUCKET START")
 	// Utilization renders as a percentage; the empty bucket carries explicit
 	// zeros. There is no concurrency column — an agent runs one test at a time.
@@ -545,7 +563,7 @@ func (s *CommandsSuite) TestFormatAgentUtilization() {
 	s.Contains(out, "OFFLINE")
 	s.Contains(out, "12.5%")
 	// Window-level summary: total tests, queue wait, top experiences.
-	s.Contains(out, "Tests run: 12")
+	s.Contains(out, "Tests run:  12")
 	s.Contains(out, "Queue wait: avg 1m35s, median 34s")
 	s.Contains(out, "TOP EXPERIENCES")
 	s.Contains(out, "Highway merge")
@@ -571,6 +589,28 @@ func (s *CommandsSuite) TestFormatSeconds() {
 	s.Equal("2h", formatSeconds(7200))
 	s.Equal("3h12m", formatSeconds(11520))
 	s.Equal("1h0m5s", formatSeconds(3605))
+}
+
+func (s *CommandsSuite) TestTruncate() {
+	// Short strings pass through unchanged.
+	s.Equal("Highway merge", truncate("Highway merge", 44))
+	// A string exactly at the limit is not truncated.
+	s.Equal("abcde", truncate("abcde", 5))
+	// Overflow is clipped to maxRunes display columns, ending in an ellipsis.
+	got := truncate("vat_37_state_impartial_tests--vadc-starts-in-active_moving-full", 43)
+	s.Equal(43, utf8.RuneCountInString(got))
+	s.True(strings.HasSuffix(got, "…"))
+}
+
+func (s *CommandsSuite) TestFormatAgentUtilizationTruncatesLongExperienceName() {
+	out := sampleUtilizationOutput()
+	longName := "vat_37_state_impartial_tests--vadc-starts-in-active_moving-full"
+	out.TopExperiences[0].ExperienceName = longName
+	formatted := formatAgentUtilization(out)
+	// The full name overflows the column, so it must not appear verbatim; an
+	// ellipsis-clipped prefix appears instead.
+	s.NotContains(formatted, longName)
+	s.Contains(formatted, "vat_37_state_impartial_tests--vadc-starts-…")
 }
 
 func (s *CommandsSuite) TestFormatAgentUtilizationEmptyBuckets() {
@@ -606,7 +646,7 @@ func (s *CommandsSuite) TestAgentUtilizationTableOutput() {
 	s.mockAgentUtilization(&out)
 
 	stdout := captureStdout(s, func() { agentUtilization(nil, nil) })
-	s.Contains(stdout, "Agent:    agent-1")
+	s.Contains(stdout, "Agent:      agent-1")
 	s.Contains(stdout, "42.5%")
 }
 
@@ -678,7 +718,7 @@ func (s *CommandsSuite) TestActualListAgentUtilization() {
 func (s *CommandsSuite) TestFormatListAgentUtilization() {
 	out := formatListAgentUtilization(sampleListUtilizationOutput())
 	// The shared window header renders once; each agent gets its own section.
-	s.Contains(out, "Interval: day")
+	s.Contains(out, "Interval:   day")
 	s.Equal(1, strings.Count(out, "Window:"))
 	s.Contains(out, "=== agent-1 ===")
 	s.Contains(out, "=== agent-idle ===")
@@ -687,7 +727,7 @@ func (s *CommandsSuite) TestFormatListAgentUtilization() {
 	s.Equal(2, strings.Count(out, "BUCKET START"))
 	// The fleet-wide summary renders once before the per-agent sections; the
 	// top-experiences table renders once at the very bottom, after them.
-	s.Contains(out, "Tests run: 12")
+	s.Contains(out, "Tests run:  12")
 	s.Contains(out, "Queue wait: avg 1m35s, median 34s")
 	s.Equal(1, strings.Count(out, "TOP EXPERIENCES"))
 	s.Contains(out, "Highway merge")
@@ -696,7 +736,7 @@ func (s *CommandsSuite) TestFormatListAgentUtilization() {
 	// Each agent section also carries its own absolute tests-run total. The
 	// fleet line (12), agent-1's sum (12), and the idle agent's (0) make three
 	// "Tests run:" lines; the idle agent's 0 is distinct from the fleet total.
-	s.Contains(out, "Tests run: 0")
+	s.Contains(out, "Tests run:  0")
 	s.Equal(3, strings.Count(out, "Tests run:"))
 }
 


### PR DESCRIPTION
## Summary

Cosmetic clean-up of `resim agents utilization` output — no behavior change beyond formatting:

- Render agent versions with exactly one leading `v` (no `vv1.2.3` double-prefix).
- Align the window/summary labels via a shared label width.
- Truncate long top-experience names with an ellipsis so columns stay aligned.

Base of the stack under #212 (`agents results` + `pool-labels list`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
