### PR TITLE
feat(agents): resim agents results + pool-labels list CLI subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## ReSim CLI
 
-### v0.62.0 - Unreleased
+### v0.62.0 - July 7, 2026
 
 - Adds `pool-labels list`, listing the distinct HiL pool labels visible to your org (`GET /poolLabels`). Auto-paginates the full set. Supports `--name` (substring/trigram filter), `--order-by rank|timestamp` (default `timestamp`; `rank` is recommended alongside `--name`), and `--json`.
+- Reworks `pool-labels queue` output for scanning: idle labels (no agents, no runs) collapse into a one-line footer (pass `--all` to show them), each label renders as a card with its agents folded onto the header line, batch ages are relative (`3h ago`, `12d ago`), an active batch older than 24h is flagged `⚠ stale`, and a label that looks like a mis-quoted flag is called out by name. `--json` output is unchanged.
 - Adds `agents results`, listing a HiL Agent's full results history (`GET /agents/{agentID}/results`) — the complete, paginated set behind the agent detail page's Results tab, of which `agents get` shows only the most recent slice. Supports `--text` (case-insensitive substring on the test name), `--created-after` (RFC3339 lower bound), and `--json`.
 
 ### v0.61.0 - June 29, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## ReSim CLI
 
+### v0.62.0 - Unreleased
+
+- Adds `pool-labels list`, listing the distinct HiL pool labels visible to your org (`GET /poolLabels`). Auto-paginates the full set. Supports `--name` (substring/trigram filter), `--order-by rank|timestamp` (default `timestamp`; `rank` is recommended alongside `--name`), and `--json`.
+- Adds `agents results`, listing a HiL Agent's full results history (`GET /agents/{agentID}/results`) — the complete, paginated set behind the agent detail page's Results tab, of which `agents get` shows only the most recent slice. Supports `--text` (case-insensitive substring on the test name), `--created-after` (RFC3339 lower bound), and `--json`.
+
 ### v0.61.0 - June 29, 2026
 
 - Adds `resim metrics config-schema`, which prints the JSON Schema for the metrics configuration file to stdout (pipe to a file to use for editor validation and autocomplete).

--- a/cmd/resim/commands/agents.go
+++ b/cmd/resim/commands/agents.go
@@ -87,6 +87,17 @@ in earlier windows offline reads 0 and all non-running time appears as idle.`,
 		Short: "queue - Lists the per-pool-label batch queue across the caller's org",
 		Run:   queuePoolLabels,
 	}
+	listPoolLabelsCmd = &cobra.Command{
+		Use:   "list",
+		Short: "list - Lists the distinct HiL pool labels visible to the caller's org",
+		Long: `list - Lists the distinct pool labels visible to your org.
+
+Labels are ordered by most recent agent check-in (the default) or, with
+--order-by rank, by trigram similarity to --name. Use --name to filter to
+labels matching a search term; --order-by rank is recommended when --name is
+set so the closest matches come first.`,
+		Run: listPoolLabels,
+	}
 )
 
 const (
@@ -98,6 +109,8 @@ const (
 	agentIntervalKey           = "interval"
 	agentTopExperiencesKey     = "top-experiences"
 	poolLabelsCompletedDaysKey = "completed-since-days"
+	poolLabelsNameKey          = "name"
+	poolLabelsOrderByKey       = "order-by"
 
 	completedSinceDaysMin = 1
 	completedSinceDaysMax = 30
@@ -128,6 +141,10 @@ func init() {
 	queuePoolLabelsCmd.Flags().Int(poolLabelsCompletedDaysKey, 7, "Window for completed batches, in days (1-30)")
 	queuePoolLabelsCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of grouped output")
 
+	listPoolLabelsCmd.Flags().String(poolLabelsNameKey, "", "Filter pool labels by name (substring/trigram match). Pair with --order-by rank for the closest matches first")
+	listPoolLabelsCmd.Flags().String(poolLabelsOrderByKey, "", "Order results: timestamp (most recent check-in; default) or rank (similarity to --name)")
+	listPoolLabelsCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of a list")
+
 	agentsCmd.AddCommand(listAgentsCmd)
 	agentsCmd.AddCommand(getAgentCmd)
 	agentsCmd.AddCommand(archiveAgentCmd)
@@ -135,6 +152,7 @@ func init() {
 	rootCmd.AddCommand(agentsCmd)
 
 	poolLabelsCmd.AddCommand(queuePoolLabelsCmd)
+	poolLabelsCmd.AddCommand(listPoolLabelsCmd)
 	rootCmd.AddCommand(poolLabelsCmd)
 }
 
@@ -382,6 +400,72 @@ func queuePoolLabels(cmd *cobra.Command, args []string) {
 	}
 	for _, item := range output.Items {
 		fmt.Print(formatPoolLabelQueueGroup(item, days))
+	}
+}
+
+// validatePoolLabelsOrderBy checks the raw --order-by value client-side so a
+// malformed request never leaves the machine. An empty value stays unset so the
+// server applies its documented default (timestamp).
+func validatePoolLabelsOrderBy(orderBy string) error {
+	switch api.ListPoolLabelsParamsOrderBy(orderBy) {
+	case "", api.ListPoolLabelsParamsOrderByRank, api.ListPoolLabelsParamsOrderByTimestamp:
+		return nil
+	default:
+		return fmt.Errorf("--%s must be %s or %s, got %q",
+			poolLabelsOrderByKey,
+			api.ListPoolLabelsParamsOrderByTimestamp, api.ListPoolLabelsParamsOrderByRank, orderBy)
+	}
+}
+
+func listPoolLabels(cmd *cobra.Command, args []string) {
+	orderBy := viper.GetString(poolLabelsOrderByKey)
+	if err := validatePoolLabelsOrderBy(orderBy); err != nil {
+		log.Fatal(err)
+	}
+
+	params := api.ListPoolLabelsParams{PageSize: Ptr(100)}
+	if name := viper.GetString(poolLabelsNameKey); name != "" {
+		params.Name = Ptr(name)
+	}
+	if orderBy != "" {
+		ob := api.ListPoolLabelsParamsOrderBy(orderBy)
+		params.OrderBy = &ob
+	}
+
+	// Auto-paginate the full set: an org's distinct pool labels are bounded, and
+	// the rest of the CLI hides pagination behind a single command. Validate and
+	// nil-check the body before reading the token so a null page can't panic.
+	var labels []api.PoolLabel
+	for {
+		response, err := Client.ListPoolLabelsWithResponse(context.Background(), &params)
+		if err != nil {
+			log.Fatal("failed to list pool labels:", err)
+		}
+		ValidateResponse(http.StatusOK, "failed to list pool labels", response.HTTPResponse, response.Body)
+		if response.JSON200 == nil {
+			log.Fatal("empty response from listPoolLabels")
+		}
+		if response.JSON200.PoolLabels != nil {
+			labels = append(labels, *response.JSON200.PoolLabels...)
+		}
+		if response.JSON200.NextPageToken == nil || *response.JSON200.NextPageToken == "" {
+			break
+		}
+		params.PageToken = response.JSON200.NextPageToken
+	}
+
+	if viper.GetBool(agentJSONKey) {
+		OutputJson(labels)
+		return
+	}
+
+	if len(labels) == 0 {
+		fmt.Println("No pool labels found in this org.")
+		return
+	}
+	fmt.Printf("%d pool label(s):\n", len(labels))
+	for _, label := range labels {
+		fmt.Printf("  %s\n", label)
 	}
 }
 

--- a/cmd/resim/commands/agents.go
+++ b/cmd/resim/commands/agents.go
@@ -120,6 +120,7 @@ const (
 	agentIntervalKey           = "interval"
 	agentTopExperiencesKey     = "top-experiences"
 	poolLabelsCompletedDaysKey = "completed-since-days"
+	poolLabelsAllKey           = "all"
 	poolLabelsNameKey          = "name"
 	poolLabelsOrderByKey       = "order-by"
 
@@ -159,6 +160,7 @@ func init() {
 	agentResultsCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of a table")
 
 	queuePoolLabelsCmd.Flags().Int(poolLabelsCompletedDaysKey, 7, "Window for completed batches, in days (1-30)")
+	queuePoolLabelsCmd.Flags().Bool(poolLabelsAllKey, false, "Show every pool label, including idle ones with no agents and no runs (hidden by default)")
 	queuePoolLabelsCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of grouped output")
 
 	listPoolLabelsCmd.Flags().String(poolLabelsNameKey, "", "Filter pool labels by name (substring/trigram match). Pair with --order-by rank for the closest matches first")
@@ -494,9 +496,7 @@ func queuePoolLabels(cmd *cobra.Command, args []string) {
 		fmt.Println("No pool labels in the queue right now.")
 		return
 	}
-	for _, item := range output.Items {
-		fmt.Print(formatPoolLabelQueueGroup(item, days))
-	}
+	fmt.Print(formatPoolLabelQueue(output.Items, days, viper.GetBool(poolLabelsAllKey), time.Now()))
 }
 
 // validatePoolLabelsOrderBy checks the raw --order-by value client-side so a
@@ -786,34 +786,155 @@ func formatListAgentUtilization(out api.ListAgentUtilizationOutput) string {
 	return b.String()
 }
 
-func formatPoolLabelQueueGroup(item api.PoolLabelQueueItem, completedSinceDays int) string {
+// staleActiveAge is how long a batch may sit in an active (non-terminal) status
+// before the queue view flags it "⚠ stale". A HiL batch still running after a
+// full day is far more often a stuck/zombie run than a genuinely long job, and
+// this is the cheapest place to catch one before it pins utilization at 100%.
+const staleActiveAge = 24 * time.Hour
+
+// queueNameWidth caps the batch-name column so a pathologically long name can't
+// shove the age/pill columns off screen; longer names are truncated with an
+// ellipsis, matching the top-experiences table.
+const queueNameWidth = 40
+
+// formatPoolLabelQueue renders the whole queue view. Labels with no agents and
+// no batches of any kind are noise, so they collapse into a single footer line
+// unless --all is set; the labels that actually carry signal render as cards.
+// Any label that looks like a mis-quoted flag is called out by name, since it
+// almost certainly got into the org's label set by accident.
+func formatPoolLabelQueue(items []api.PoolLabelQueueItem, completedSinceDays int, showAll bool, now time.Time) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "\n=== %s (%d agents) ===\n", item.PoolLabel, len(item.AssociatedAgentIDs))
-	if len(item.AssociatedAgentIDs) > 0 {
-		fmt.Fprintf(&b, "    agents: %s\n", strings.Join(item.AssociatedAgentIDs, ", "))
-	}
-	for _, batch := range item.ActiveBatches {
-		fmt.Fprintf(&b, "  ACTIVE   %s [%s]%s  %s\n",
-			batch.BatchName,
-			batch.ConflatedStatus,
-			priorityLabel(batch.Priority),
-			batch.Timestamp.Format("2006-01-02 15:04:05"),
-		)
-	}
-	for _, batch := range item.QueuedBatches {
-		pos := "QUEUED"
-		if batch.QueuePosition != nil {
-			pos = fmt.Sprintf("Queued %d", *batch.QueuePosition)
+	hidden := 0
+	var suspicious []string
+	for _, item := range items {
+		if looksLikeFlag(item.PoolLabel) {
+			suspicious = append(suspicious, item.PoolLabel)
 		}
-		fmt.Fprintf(&b, "  %s   %s [%s]%s  %s\n",
-			pos, batch.BatchName, batch.ConflatedStatus, priorityLabel(batch.Priority),
-			batch.Timestamp.Format("2006-01-02 15:04:05"),
-		)
+		if !showAll && isIdleLabel(item) {
+			hidden++
+			continue
+		}
+		b.WriteString(formatPoolLabelQueueGroup(item, completedSinceDays, now))
 	}
-	if len(item.CompletedBatches) > 0 {
-		fmt.Fprintf(&b, "  + %d completed in last %d days\n", len(item.CompletedBatches), completedSinceDays)
+	if hidden > 0 {
+		fmt.Fprintf(&b, "\n%s hidden (no agents, no runs) · --all to show\n",
+			pluralize(hidden, "idle label"))
+	}
+	if len(suspicious) > 0 {
+		b.WriteByte('\n')
+		for _, label := range suspicious {
+			fmt.Fprintf(&b, "⚠ suspicious label %q looks like a mis-quoted flag, not a real pool label\n", label)
+		}
 	}
 	return b.String()
+}
+
+// isIdleLabel reports whether a label carries no signal at all: no agents, no
+// active/queued runs, and nothing completed in the window.
+func isIdleLabel(item api.PoolLabelQueueItem) bool {
+	return len(item.AssociatedAgentIDs) == 0 &&
+		len(item.ActiveBatches) == 0 &&
+		len(item.QueuedBatches) == 0 &&
+		len(item.CompletedBatches) == 0
+}
+
+// looksLikeFlag reports whether a pool label looks like a shell-quoting mistake
+// — it starts with a dash or contains whitespace, i.e. almost certainly a flag
+// (or flag plus value) captured verbatim as a label rather than a real one.
+func looksLikeFlag(label string) bool {
+	return strings.HasPrefix(label, "-") || strings.ContainsAny(label, " \t")
+}
+
+func formatPoolLabelQueueGroup(item api.PoolLabelQueueItem, completedSinceDays int, now time.Time) string {
+	var b strings.Builder
+	agentCount := len(item.AssociatedAgentIDs)
+	fmt.Fprintf(&b, "\n%s · %s", item.PoolLabel, pluralize(agentCount, "agent"))
+	if agentCount > 0 {
+		fmt.Fprintf(&b, " · %s", strings.Join(item.AssociatedAgentIDs, ", "))
+	}
+	b.WriteByte('\n')
+
+	// Size the status/position and name columns across every rendered batch so
+	// active and queued rows line their ages up within the card.
+	tagW, nameW := 0, 0
+	consider := func(tag, name string) {
+		if w := utf8.RuneCountInString(tag); w > tagW {
+			tagW = w
+		}
+		if w := utf8.RuneCountInString(truncate(name, queueNameWidth)); w > nameW {
+			nameW = w
+		}
+	}
+	for _, batch := range item.ActiveBatches {
+		consider(string(batch.ConflatedStatus), batch.BatchName)
+	}
+	for _, batch := range item.QueuedBatches {
+		consider(queuePositionTag(batch), batch.BatchName)
+	}
+
+	for _, batch := range item.ActiveBatches {
+		trailer := priorityLabel(batch.Priority)
+		if now.Sub(batch.Timestamp) >= staleActiveAge {
+			trailer = "  ⚠ stale" + trailer
+		}
+		writeQueueBatchLine(&b, "●", string(batch.ConflatedStatus), batch.BatchName,
+			tagW, nameW, formatAge(batch.Timestamp, now), trailer)
+	}
+	for _, batch := range item.QueuedBatches {
+		writeQueueBatchLine(&b, "○", queuePositionTag(batch), batch.BatchName,
+			tagW, nameW, formatAge(batch.Timestamp, now), priorityLabel(batch.Priority))
+	}
+	if len(item.ActiveBatches) == 0 && len(item.QueuedBatches) == 0 {
+		b.WriteString("  idle — no active or queued runs\n")
+	}
+	if len(item.CompletedBatches) > 0 {
+		fmt.Fprintf(&b, "  + %d completed in the last %s\n",
+			len(item.CompletedBatches), pluralize(completedSinceDays, "day"))
+	}
+	return b.String()
+}
+
+// writeQueueBatchLine renders one batch row: a status dot, the status/position
+// tag, the (padded, possibly truncated) batch name, its age, and any trailing
+// markers (stale flag, priority pill).
+func writeQueueBatchLine(b *strings.Builder, marker, tag, name string, tagW, nameW int, age, trailer string) {
+	fmt.Fprintf(b, "  %s %-*s  %-*s  %s%s\n",
+		marker, tagW, tag, nameW, truncate(name, queueNameWidth), age, trailer)
+}
+
+// queuePositionTag renders a queued batch's 1-based slot ("Queued #3"), falling
+// back to a bare "QUEUED" when the server did not report a position.
+func queuePositionTag(batch api.PoolLabelQueueBatch) string {
+	if batch.QueuePosition != nil {
+		return fmt.Sprintf("Queued #%d", *batch.QueuePosition)
+	}
+	return "QUEUED"
+}
+
+// formatAge renders how long ago t was, relative to now, as a compact
+// right-hand annotation ("just now", "45m ago", "3h ago", "12d ago"). It is
+// deliberately coarse: the queue view cares about minutes-vs-days, not seconds.
+func formatAge(t, now time.Time) string {
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d/time.Hour))
+	default:
+		return fmt.Sprintf("%dd ago", int(d/(24*time.Hour)))
+	}
+}
+
+// pluralize renders a count and noun with the noun pluralized for everything but
+// exactly one: "1 agent", "0 agents", "4 agents".
+func pluralize(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
 }
 
 // priorityLabel maps the raw scheduler priority (ascending sort, default

--- a/cmd/resim/commands/agents.go
+++ b/cmd/resim/commands/agents.go
@@ -75,6 +75,17 @@ rack. Offline intervals are recorded from this feature's deployment onward;
 in earlier windows offline reads 0 and all non-running time appears as idle.`,
 		Run: agentUtilization,
 	}
+	agentResultsCmd = &cobra.Command{
+		Use:   "results",
+		Short: "results - Lists a HiL Agent's full results history",
+		Long: `results - Lists every test result a HiL Agent has run for the caller's org.
+
+This is the full, paginated history behind the agent detail page's Results tab;
+'agents get' shows only the most recent slice. Filter with --text (case-insensitive
+substring on the test/experience name) and --created-after (RFC3339 lower bound).
+All matching results are fetched and printed; the Total line counts them.`,
+		Run: agentResults,
+	}
 
 	poolLabelsCmd = &cobra.Command{
 		Use:     "pool-labels",
@@ -112,6 +123,9 @@ const (
 	poolLabelsNameKey          = "name"
 	poolLabelsOrderByKey       = "order-by"
 
+	agentResultsTextKey         = "text"
+	agentResultsCreatedAfterKey = "created-after"
+
 	completedSinceDaysMin = 1
 	completedSinceDaysMax = 30
 
@@ -138,6 +152,12 @@ func init() {
 	agentUtilizationCmd.Flags().Int(agentTopExperiencesKey, topExperiencesDefault, "How many top experiences (ranked by running time in the window) to include (0-50). 0 omits the list")
 	agentUtilizationCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of a table")
 
+	agentResultsCmd.Flags().String(agentIDKey, "", "Agent ID (as supplied at check-in)")
+	agentResultsCmd.MarkFlagRequired(agentIDKey)
+	agentResultsCmd.Flags().String(agentResultsTextKey, "", "Filter to results whose test (experience) name contains this substring (case-insensitive)")
+	agentResultsCmd.Flags().String(agentResultsCreatedAfterKey, "", "Only results at or after this instant (RFC3339, e.g. 2026-06-04T00:00:00Z)")
+	agentResultsCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of a table")
+
 	queuePoolLabelsCmd.Flags().Int(poolLabelsCompletedDaysKey, 7, "Window for completed batches, in days (1-30)")
 	queuePoolLabelsCmd.Flags().Bool(agentJSONKey, false, "Output raw JSON instead of grouped output")
 
@@ -149,6 +169,7 @@ func init() {
 	agentsCmd.AddCommand(getAgentCmd)
 	agentsCmd.AddCommand(archiveAgentCmd)
 	agentsCmd.AddCommand(agentUtilizationCmd)
+	agentsCmd.AddCommand(agentResultsCmd)
 	rootCmd.AddCommand(agentsCmd)
 
 	poolLabelsCmd.AddCommand(queuePoolLabelsCmd)
@@ -209,6 +230,81 @@ func getAgent(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Print(formatAgentDetail(*agent))
+}
+
+// parseAgentResultsParams validates the raw flag values client-side so a
+// malformed request never leaves the machine. Empty values stay unset so the
+// server returns the agent's full (unfiltered) history.
+func parseAgentResultsParams(text, createdAfterRaw string) (api.ListAgentResultsParams, error) {
+	params := api.ListAgentResultsParams{PageSize: Ptr(100)}
+	if text != "" {
+		params.Text = Ptr(text)
+	}
+	if createdAfterRaw != "" {
+		t, err := time.Parse(time.RFC3339, createdAfterRaw)
+		if err != nil {
+			return params, fmt.Errorf("invalid --%s value %q: expected RFC3339, e.g. 2026-06-04T00:00:00Z", agentResultsCreatedAfterKey, createdAfterRaw)
+		}
+		params.CreatedAfter = &t
+	}
+	return params, nil
+}
+
+func agentResults(cmd *cobra.Command, args []string) {
+	agentID := viper.GetString(agentIDKey)
+	params, err := parseAgentResultsParams(
+		viper.GetString(agentResultsTextKey),
+		viper.GetString(agentResultsCreatedAfterKey),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Auto-paginate the full (filtered) history. Validate and nil-check the
+	// body before reading the token so a null page can't panic. The CLI fetches
+	// every page, so the accumulated count is the exact, filter-correct total —
+	// the server's per-page `Total` is not needed to render the header.
+	var items []api.AgentRecentActivity
+	for {
+		response, err := Client.ListAgentResultsWithResponse(context.Background(), agentID, &params)
+		if err != nil {
+			log.Fatal("failed to list agent results:", err)
+		}
+		if response.HTTPResponse.StatusCode == http.StatusNotFound {
+			log.Fatalf("agent %q not found", agentID)
+		}
+		ValidateResponse(http.StatusOK, "failed to list agent results", response.HTTPResponse, response.Body)
+		if response.JSON200 == nil {
+			log.Fatal("empty response from listAgentResults")
+		}
+		items = append(items, response.JSON200.Items...)
+		if response.JSON200.NextPageToken == nil || *response.JSON200.NextPageToken == "" {
+			break
+		}
+		params.PageToken = response.JSON200.NextPageToken
+	}
+
+	if viper.GetBool(agentJSONKey) {
+		OutputJson(items)
+		return
+	}
+	fmt.Print(formatAgentResults(agentID, items))
+}
+
+// formatAgentResults renders the agent's results history: a header naming the
+// agent and the count of results returned, then the shared activity table.
+// Total is the number of rows actually fetched — because the CLI exhausts
+// pagination, that equals the full set matching the query.
+func formatAgentResults(agentID string, items []api.AgentRecentActivity) string {
+	var b strings.Builder
+	if len(items) == 0 {
+		fmt.Fprintf(&b, "No results for agent %q.\n", agentID)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Agent:  %s\n", agentID)
+	fmt.Fprintf(&b, "Total:  %d\n", len(items))
+	writeAgentActivityTable(&b, items, "")
+	return b.String()
 }
 
 // confirmArchiveAgent reads a yes/no answer from in. Anything other than an
@@ -474,11 +570,38 @@ func listPoolLabels(cmd *cobra.Command, args []string) {
 // values, matching the uppercase header style of the utilization tables.
 const agentListHeader = "NAME\tSTATUS\tVERSION\tPOOL LABELS\tLAST CHECK-IN\n"
 
-// agentActivityHeader labels the recent-activity table emitted by
-// formatAgentDetail. Like agentListHeader it is routed through the rows'
-// tabwriter so the labels align over their values; the leading indent nests
-// the table under the "Recent activity:" line.
-const agentActivityHeader = "  PROJECT\tBATCH\tBATCH STATUS\tTEST\tTEST STATUS\tBRANCH\tTIMESTAMP\n"
+// agentActivityColumns labels the agent-activity table shared by the
+// recent-activity block of `agents get` and the full history of
+// `agents results`. It carries no indent; writeAgentActivityTable prepends a
+// caller-supplied indent to the header and every row so each caller controls
+// nesting.
+const agentActivityColumns = "PROJECT\tBATCH\tBATCH STATUS\tTEST\tTEST STATUS\tBRANCH\tTIMESTAMP\n"
+
+// writeAgentActivityTable renders agent activity rows as a column-aligned
+// table on b. indent is prepended to the header and every row: `agents get`
+// nests its recent-activity table under the "Recent activity:" line with a
+// two-space indent, while `agents results` renders a flush top-level table
+// with no indent. A row with no branch leaves that cell empty so the
+// timestamp still aligns.
+func writeAgentActivityTable(b *strings.Builder, activity []api.AgentRecentActivity, indent string) {
+	tw := tabwriter.NewWriter(b, 0, 0, 2, ' ', 0)
+	fmt.Fprint(tw, indent+agentActivityColumns)
+	for _, r := range activity {
+		branch := ""
+		if r.BranchName != nil {
+			branch = *r.BranchName
+		}
+		fmt.Fprintf(tw, "%s%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			indent,
+			r.ProjectName,
+			r.BatchName, r.BatchConflatedStatus,
+			r.JobName, r.JobConflatedStatus,
+			branch,
+			r.Timestamp.Format("2006-01-02 15:04:05"),
+		)
+	}
+	tw.Flush()
+}
 
 // displayVersion renders a version string with exactly one leading "v",
 // regardless of whether the server already prefixed it. Without this the CLI
@@ -524,27 +647,7 @@ func formatAgentDetail(a api.Agent) string {
 		return b.String()
 	}
 	fmt.Fprintln(&b, "Recent activity:")
-	// Render the activity as a labeled, column-aligned table: a header row of
-	// column labels followed by bare values, all padded to a consistent width
-	// on Flush. The header carries the field names, so the rows drop the inline
-	// "batch"/"test"/"branch=" prefixes. Rows without a branch leave that cell
-	// empty so the timestamp still aligns.
-	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	fmt.Fprint(tw, agentActivityHeader)
-	for _, r := range a.RecentActivity {
-		branch := ""
-		if r.BranchName != nil {
-			branch = *r.BranchName
-		}
-		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.ProjectName,
-			r.BatchName, r.BatchConflatedStatus,
-			r.JobName, r.JobConflatedStatus,
-			branch,
-			r.Timestamp.Format("2006-01-02 15:04:05"),
-		)
-	}
-	tw.Flush()
+	writeAgentActivityTable(&b, a.RecentActivity, "  ")
 	return b.String()
 }
 

--- a/cmd/resim/commands/agents_test.go
+++ b/cmd/resim/commands/agents_test.go
@@ -323,6 +323,10 @@ func (s *CommandsSuite) TestValidateCompletedSinceDays() {
 	s.ErrorContains(validateCompletedSinceDays(31), "between 1 and 30")
 }
 
+// poolLabelQueueNow is a fixed "now" for the queue-format tests. The sample
+// batches are timestamped two hours earlier so they render fresh (not stale).
+var poolLabelQueueNow = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
 func samplePoolLabelQueueItem() api.PoolLabelQueueItem {
 	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
 	batch := func(name string, status api.ConflatedBatchStatus, priority int, queuePos *int) api.PoolLabelQueueBatch {
@@ -354,6 +358,17 @@ func samplePoolLabelQueueItem() api.PoolLabelQueueItem {
 	}
 }
 
+// lineWith returns the first line of out that contains needle, or "" if none
+// does. Used to tie a trailing marker (pill, stale flag) to its batch row.
+func lineWith(out, needle string) string {
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, needle) {
+			return ln
+		}
+	}
+	return ""
+}
+
 func (s *CommandsSuite) TestQueuePoolLabelsPassesWindow() {
 	viper.Reset()
 	viper.Set(poolLabelsCompletedDaysKey, 14)
@@ -366,35 +381,114 @@ func (s *CommandsSuite) TestQueuePoolLabelsPassesWindow() {
 		}, nil)
 
 	out := captureStdout(s, func() { queuePoolLabels(nil, nil) })
-	s.Contains(out, "=== RackHiLConfig")
-	s.Contains(out, "+ 3 completed in last 14 days")
+	s.Contains(out, "RackHiLConfig · 2 agents")
+	s.Contains(out, "+ 3 completed in the last 14 days")
 }
 
 func (s *CommandsSuite) TestFormatPoolLabelQueueGroup() {
-	out := formatPoolLabelQueueGroup(samplePoolLabelQueueItem(), 7)
+	out := formatPoolLabelQueueGroup(samplePoolLabelQueueItem(), 7, poolLabelQueueNow)
 
-	s.Contains(out, "=== RackHiLConfig (2 agents) ===")
-	s.Contains(out, "agents: agent-1, agent-2")
-	// Both active batches render, the elevated one with a High pill.
-	s.Contains(out, "ACTIVE   active-one [RUNNING]")
-	s.Contains(out, "ACTIVE   active-two [RUNNING] (High)")
+	// Header folds the agent count and IDs onto one line, count pluralized.
+	s.Contains(out, "RackHiLConfig · 2 agents · agent-1, agent-2")
+	// Both active batches render with a status dot; the elevated one gets a
+	// High pill, and the age is relative to now (two hours after the batch).
+	s.Contains(lineWith(out, "active-one"), "● RUNNING")
+	s.Contains(lineWith(out, "active-one"), "2h ago")
+	s.Contains(lineWith(out, "active-two"), "● RUNNING")
+	s.Contains(lineWith(out, "active-two"), "(High)")
 	// Queued batches carry their 1-based positions; deprioritised gets Low.
-	s.Contains(out, "Queued 1   queued-one [SUBMITTED]")
-	s.Contains(out, "Queued 2   queued-two [SUBMITTED] (Low)")
+	s.Contains(lineWith(out, "queued-one"), "○ Queued #1")
+	s.Contains(lineWith(out, "queued-two"), "○ Queued #2")
+	s.Contains(lineWith(out, "queued-two"), "(Low)")
 	// Completed batches collapse into a footnote interpolating the window.
-	s.Contains(out, "+ 3 completed in last 7 days")
+	s.Contains(out, "+ 3 completed in the last 7 days")
+	// Fresh batches are not flagged stale.
+	s.NotContains(out, "⚠ stale")
 }
 
 func (s *CommandsSuite) TestFormatPoolLabelQueueGroupWindowInterpolation() {
-	out := formatPoolLabelQueueGroup(samplePoolLabelQueueItem(), 14)
-	s.Contains(out, "+ 3 completed in last 14 days")
+	out := formatPoolLabelQueueGroup(samplePoolLabelQueueItem(), 14, poolLabelQueueNow)
+	s.Contains(out, "+ 3 completed in the last 14 days")
 }
 
 func (s *CommandsSuite) TestFormatPoolLabelQueueGroupNilQueuePosition() {
 	item := samplePoolLabelQueueItem()
 	item.QueuedBatches[0].QueuePosition = nil
-	out := formatPoolLabelQueueGroup(item, 7)
-	s.Contains(out, "QUEUED   queued-one [SUBMITTED]")
+	out := formatPoolLabelQueueGroup(item, 7, poolLabelQueueNow)
+	s.Contains(lineWith(out, "queued-one"), "○ QUEUED")
+}
+
+func (s *CommandsSuite) TestFormatPoolLabelQueueGroupStale() {
+	item := samplePoolLabelQueueItem()
+	// Age one active batch past the 24h stale threshold; the other stays fresh.
+	item.ActiveBatches[1].Timestamp = poolLabelQueueNow.Add(-12 * 24 * time.Hour)
+	out := formatPoolLabelQueueGroup(item, 7, poolLabelQueueNow)
+	s.Contains(lineWith(out, "active-two"), "12d ago")
+	s.Contains(lineWith(out, "active-two"), "⚠ stale")
+	s.NotContains(lineWith(out, "active-one"), "⚠ stale")
+}
+
+func (s *CommandsSuite) TestFormatPoolLabelQueueGroupIdle() {
+	item := api.PoolLabelQueueItem{
+		PoolLabel:          "hil-idle-with-agent",
+		AssociatedAgentIDs: []string{"hil-4"},
+	}
+	out := formatPoolLabelQueueGroup(item, 7, poolLabelQueueNow)
+	s.Contains(out, "hil-idle-with-agent · 1 agent · hil-4")
+	s.Contains(out, "idle — no active or queued runs")
+	s.NotContains(out, "completed in the last")
+}
+
+func (s *CommandsSuite) TestFormatPoolLabelQueueHidesIdleLabels() {
+	items := []api.PoolLabelQueueItem{
+		samplePoolLabelQueueItem(),
+		{PoolLabel: "empty-a"},
+		{PoolLabel: "empty-b"},
+	}
+	// Default: idle labels collapse into a footer, names suppressed.
+	out := formatPoolLabelQueue(items, 7, false, poolLabelQueueNow)
+	s.Contains(out, "RackHiLConfig · 2 agents")
+	s.Contains(out, "2 idle labels hidden (no agents, no runs) · --all to show")
+	s.NotContains(out, "empty-a")
+	s.NotContains(out, "empty-b")
+
+	// --all renders every label as its own card, no hidden footer.
+	all := formatPoolLabelQueue(items, 7, true, poolLabelQueueNow)
+	s.Contains(all, "empty-a · 0 agents")
+	s.Contains(all, "empty-b · 0 agents")
+	s.NotContains(all, "idle labels hidden")
+}
+
+func (s *CommandsSuite) TestFormatPoolLabelQueueFlagsSuspiciousLabel() {
+	items := []api.PoolLabelQueueItem{
+		{PoolLabel: "--pool-labels hil-test-system"},
+	}
+	out := formatPoolLabelQueue(items, 7, false, poolLabelQueueNow)
+	s.Contains(out, `⚠ suspicious label "--pool-labels hil-test-system"`)
+}
+
+func (s *CommandsSuite) TestFormatAge() {
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s.Equal("just now", formatAge(base, base))
+	s.Equal("just now", formatAge(base.Add(time.Minute), base)) // future clamps
+	s.Equal("45m ago", formatAge(base.Add(-45*time.Minute), base))
+	s.Equal("3h ago", formatAge(base.Add(-3*time.Hour), base))
+	s.Equal("12d ago", formatAge(base.Add(-12*24*time.Hour), base))
+}
+
+func (s *CommandsSuite) TestPluralize() {
+	s.Equal("0 agents", pluralize(0, "agent"))
+	s.Equal("1 agent", pluralize(1, "agent"))
+	s.Equal("4 agents", pluralize(4, "agent"))
+	s.Equal("1 day", pluralize(1, "day"))
+}
+
+func (s *CommandsSuite) TestLooksLikeFlag() {
+	s.True(looksLikeFlag("--pool-labels hil-test-system"))
+	s.True(looksLikeFlag("-x"))
+	s.True(looksLikeFlag("has space"))
+	s.False(looksLikeFlag("hil-test-system"))
+	s.False(looksLikeFlag("RackHiLConfig"))
 }
 
 func (s *CommandsSuite) TestPriorityLabel() {
@@ -415,8 +509,8 @@ func (s *CommandsSuite) TestQueuePoolLabelsRendersGroups() {
 		}, nil)
 
 	out := captureStdout(s, func() { queuePoolLabels(nil, nil) })
-	s.Contains(out, "=== RackHiLConfig (2 agents) ===")
-	s.Contains(out, "+ 3 completed in last 7 days")
+	s.Contains(out, "RackHiLConfig · 2 agents")
+	s.Contains(out, "+ 3 completed in the last 7 days")
 }
 
 func (s *CommandsSuite) TestQueuePoolLabelsJSONRoundTrips() {

--- a/cmd/resim/commands/agents_test.go
+++ b/cmd/resim/commands/agents_test.go
@@ -543,6 +543,175 @@ func (s *CommandsSuite) TestListPoolLabelsJSONRoundTrips() {
 	s.Equal([]string{"alpha", "beta"}, parsed)
 }
 
+// sampleAgentResult builds an AgentRecentActivity row for the results tests.
+// branch is optional (nil leaves the branch cell empty).
+func sampleAgentResult(batchName, jobName, projectName string, branch *string) api.AgentRecentActivity {
+	return api.AgentRecentActivity{
+		BatchID:              uuid.New(),
+		BatchName:            batchName,
+		BatchConflatedStatus: api.ConflatedBatchStatusCOMPLETE,
+		JobID:                uuid.New(),
+		JobName:              jobName,
+		JobConflatedStatus:   api.ConflatedJobStatusPASSED,
+		ProjectName:          projectName,
+		BranchName:           branch,
+		Timestamp:            time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
+	}
+}
+
+func (s *CommandsSuite) TestParseAgentResultsParams() {
+	// Empty flags stay unset so the server returns the full history.
+	params, err := parseAgentResultsParams("", "")
+	s.NoError(err)
+	s.Equal(Ptr(100), params.PageSize)
+	s.Nil(params.Text)
+	s.Nil(params.CreatedAfter)
+
+	// Text and a valid RFC3339 lower bound are forwarded.
+	params, err = parseAgentResultsParams("merge", "2026-06-01T00:00:00Z")
+	s.NoError(err)
+	s.Equal(Ptr("merge"), params.Text)
+	s.Require().NotNil(params.CreatedAfter)
+	s.True(params.CreatedAfter.Equal(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)))
+
+	// A malformed created-after fails before any request is built.
+	_, err = parseAgentResultsParams("", "notatime")
+	s.Require().Error(err)
+	s.Contains(err.Error(), agentResultsCreatedAfterKey)
+}
+
+func (s *CommandsSuite) TestAgentResultsMultiPageAccumulates() {
+	viper.Reset()
+	viper.Set(agentIDKey, "agent-1")
+	defer viper.Reset()
+	// Page 1 carries a next-page token; page 2 (sent with it) closes the series.
+	s.mockClient.On("ListAgentResultsWithResponse", matchContext, "agent-1",
+		&api.ListAgentResultsParams{PageSize: Ptr(100)}).Return(
+		&api.ListAgentResultsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListAgentResultsOutput{
+				Items: []api.AgentRecentActivity{
+					sampleAgentResult("batch-a", "test-a", "proj-a", Ptr("main")),
+					sampleAgentResult("batch-b", "test-b", "proj-b", nil),
+				},
+				NextPageToken: Ptr("p2"),
+				Total:         3,
+			},
+		}, nil)
+	s.mockClient.On("ListAgentResultsWithResponse", matchContext, "agent-1",
+		&api.ListAgentResultsParams{PageSize: Ptr(100), PageToken: Ptr("p2")}).Return(
+		&api.ListAgentResultsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListAgentResultsOutput{
+				Items: []api.AgentRecentActivity{
+					sampleAgentResult("batch-c", "test-c", "proj-c", nil),
+				},
+			},
+		}, nil)
+
+	out := captureStdout(s, func() { agentResults(nil, nil) })
+	s.Contains(out, "Agent:  agent-1")
+	s.Contains(out, "Total:  3")
+	s.Contains(out, "PROJECT")
+	s.Contains(out, "proj-a")
+	s.Contains(out, "batch-a")
+	s.Contains(out, "proj-b")
+	s.Contains(out, "proj-c")
+	s.Contains(out, "main")
+	// The branchless rows must not borrow the first row's branch.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "batch-b") || strings.Contains(line, "batch-c") {
+			s.NotContains(line, "main")
+		}
+	}
+}
+
+func (s *CommandsSuite) TestAgentResultsTotalReflectsFetchedRows() {
+	viper.Reset()
+	viper.Set(agentIDKey, "agent-1")
+	defer viper.Reset()
+	// Server Total is deliberately larger than the rows returned. Because the
+	// CLI fetches every page, the header counts the rows actually shown so it
+	// never overstates (the count is filter-correct regardless of server Total).
+	s.mockClient.On("ListAgentResultsWithResponse", matchContext, "agent-1",
+		&api.ListAgentResultsParams{PageSize: Ptr(100)}).Return(
+		&api.ListAgentResultsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListAgentResultsOutput{
+				Items: []api.AgentRecentActivity{
+					sampleAgentResult("batch-a", "test-a", "proj-a", nil),
+					sampleAgentResult("batch-b", "test-b", "proj-b", nil),
+				},
+				Total: 99,
+			},
+		}, nil)
+
+	out := captureStdout(s, func() { agentResults(nil, nil) })
+	s.Contains(out, "Total:  2")
+	s.NotContains(out, "Total:  99")
+}
+
+func (s *CommandsSuite) TestAgentResultsEmptyState() {
+	viper.Reset()
+	viper.Set(agentIDKey, "agent-1")
+	defer viper.Reset()
+	s.mockClient.On("ListAgentResultsWithResponse", matchContext, "agent-1",
+		&api.ListAgentResultsParams{PageSize: Ptr(100)}).Return(
+		&api.ListAgentResultsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      &api.ListAgentResultsOutput{Items: []api.AgentRecentActivity{}},
+		}, nil)
+
+	out := captureStdout(s, func() { agentResults(nil, nil) })
+	s.Contains(out, `No results for agent "agent-1".`)
+}
+
+func (s *CommandsSuite) TestAgentResultsJSONRoundTrips() {
+	viper.Reset()
+	viper.Set(agentIDKey, "agent-1")
+	viper.Set(agentJSONKey, true)
+	defer viper.Reset()
+	s.mockClient.On("ListAgentResultsWithResponse", matchContext, "agent-1",
+		&api.ListAgentResultsParams{PageSize: Ptr(100)}).Return(
+		&api.ListAgentResultsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListAgentResultsOutput{
+				Items: []api.AgentRecentActivity{sampleAgentResult("batch-a", "test-a", "proj-a", nil)},
+				Total: 1,
+			},
+		}, nil)
+
+	out := captureStdout(s, func() { agentResults(nil, nil) })
+	var parsed []api.AgentRecentActivity
+	s.Require().NoError(json.Unmarshal([]byte(out), &parsed))
+	s.Require().Len(parsed, 1)
+	s.Equal("batch-a", parsed[0].BatchName)
+}
+
+func (s *CommandsSuite) TestAgentResultsPassesFilters() {
+	viper.Reset()
+	viper.Set(agentIDKey, "agent-1")
+	viper.Set(agentResultsTextKey, "merge")
+	viper.Set(agentResultsCreatedAfterKey, "2026-06-01T00:00:00Z")
+	defer viper.Reset()
+	after := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	s.mockClient.On("ListAgentResultsWithResponse", matchContext, "agent-1",
+		mock.MatchedBy(func(p *api.ListAgentResultsParams) bool {
+			return p.Text != nil && *p.Text == "merge" &&
+				p.CreatedAfter != nil && p.CreatedAfter.Equal(after)
+		})).Return(
+		&api.ListAgentResultsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListAgentResultsOutput{
+				Items: []api.AgentRecentActivity{sampleAgentResult("batch-a", "merge-test", "proj-a", nil)},
+				Total: 1,
+			},
+		}, nil)
+
+	out := captureStdout(s, func() { agentResults(nil, nil) })
+	s.Contains(out, "merge-test")
+}
+
 func (s *CommandsSuite) TestParseAgentUtilizationParams() {
 	// All flags empty: the time/interval params stay unset so the server
 	// defaults apply; topExperiences is always sent explicitly.

--- a/cmd/resim/commands/agents_test.go
+++ b/cmd/resim/commands/agents_test.go
@@ -453,6 +453,96 @@ func (s *CommandsSuite) TestQueuePoolLabelsEmptyState() {
 	s.Contains(out, "No pool labels in the queue right now.")
 }
 
+func (s *CommandsSuite) TestValidatePoolLabelsOrderBy() {
+	// Empty stays unset (server default); rank and timestamp are accepted.
+	s.NoError(validatePoolLabelsOrderBy(""))
+	s.NoError(validatePoolLabelsOrderBy("rank"))
+	s.NoError(validatePoolLabelsOrderBy("timestamp"))
+	// Anything else is rejected client-side with the accepted values named.
+	err := validatePoolLabelsOrderBy("bogus")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "rank")
+	s.Contains(err.Error(), "timestamp")
+}
+
+func (s *CommandsSuite) TestListPoolLabelsMultiPageAccumulates() {
+	viper.Reset()
+	defer viper.Reset()
+	// Page 1 carries a next-page token; page 2 (sent with that token) closes
+	// the series. Labels from both pages must appear, proving accumulation.
+	s.mockClient.On("ListPoolLabelsWithResponse", matchContext,
+		&api.ListPoolLabelsParams{PageSize: Ptr(100)}).Return(
+		&api.ListPoolLabelsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListPoolLabelsOutput{
+				PoolLabels:    &[]api.PoolLabel{"alpha", "beta"},
+				NextPageToken: Ptr("page-2"),
+			},
+		}, nil)
+	s.mockClient.On("ListPoolLabelsWithResponse", matchContext,
+		&api.ListPoolLabelsParams{PageSize: Ptr(100), PageToken: Ptr("page-2")}).Return(
+		&api.ListPoolLabelsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &api.ListPoolLabelsOutput{
+				PoolLabels: &[]api.PoolLabel{"gamma"},
+			},
+		}, nil)
+
+	out := captureStdout(s, func() { listPoolLabels(nil, nil) })
+	s.Contains(out, "3 pool label(s):")
+	s.Contains(out, "alpha")
+	s.Contains(out, "beta")
+	s.Contains(out, "gamma")
+}
+
+func (s *CommandsSuite) TestListPoolLabelsPassesNameAndOrderBy() {
+	viper.Reset()
+	viper.Set(poolLabelsNameKey, "nav")
+	viper.Set(poolLabelsOrderByKey, "rank")
+	defer viper.Reset()
+	rank := api.ListPoolLabelsParamsOrderByRank
+	s.mockClient.On("ListPoolLabelsWithResponse", matchContext,
+		&api.ListPoolLabelsParams{PageSize: Ptr(100), Name: Ptr("nav"), OrderBy: &rank}).Return(
+		&api.ListPoolLabelsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      &api.ListPoolLabelsOutput{PoolLabels: &[]api.PoolLabel{"nav-rig"}},
+		}, nil)
+
+	out := captureStdout(s, func() { listPoolLabels(nil, nil) })
+	s.Contains(out, "nav-rig")
+}
+
+func (s *CommandsSuite) TestListPoolLabelsEmptyState() {
+	viper.Reset()
+	defer viper.Reset()
+	s.mockClient.On("ListPoolLabelsWithResponse", matchContext,
+		&api.ListPoolLabelsParams{PageSize: Ptr(100)}).Return(
+		&api.ListPoolLabelsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      &api.ListPoolLabelsOutput{PoolLabels: &[]api.PoolLabel{}},
+		}, nil)
+
+	out := captureStdout(s, func() { listPoolLabels(nil, nil) })
+	s.Contains(out, "No pool labels found in this org.")
+}
+
+func (s *CommandsSuite) TestListPoolLabelsJSONRoundTrips() {
+	viper.Reset()
+	viper.Set(agentJSONKey, true)
+	defer viper.Reset()
+	s.mockClient.On("ListPoolLabelsWithResponse", matchContext,
+		&api.ListPoolLabelsParams{PageSize: Ptr(100)}).Return(
+		&api.ListPoolLabelsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      &api.ListPoolLabelsOutput{PoolLabels: &[]api.PoolLabel{"alpha", "beta"}},
+		}, nil)
+
+	out := captureStdout(s, func() { listPoolLabels(nil, nil) })
+	var parsed []string
+	s.Require().NoError(json.Unmarshal([]byte(out), &parsed))
+	s.Equal([]string{"alpha", "beta"}, parsed)
+}
+
 func (s *CommandsSuite) TestParseAgentUtilizationParams() {
 	// All flags empty: the time/interval params stay unset so the server
 	// defaults apply; topExperiences is always sent explicitly.

--- a/docs/plans/2026-06-17-001-feat-agents-results-pool-labels-list-cli-plan.md
+++ b/docs/plans/2026-06-17-001-feat-agents-results-pool-labels-list-cli-plan.md
@@ -1,0 +1,282 @@
+---
+title: "feat: resim agents results + pool-labels list CLI subcommands"
+type: feat
+status: active
+date: 2026-06-17
+linear: https://linear.app/resim/issue/WOB-4131/api-client-hil-agent-status-agentspool-labels-cli-subcommands
+origin: gap analysis — current api-client CLI vs. deployed rerun agent/pool-label API
+---
+
+# feat: resim agents results + pool-labels list CLI subcommands
+
+Follow-up to the HiL agent-status CLI work (WOB-4131). The original status-page
+plan ([docs/plans/2026-05-05-001-feat-hil-agent-status-page-cli-plan.md](2026-05-05-001-feat-hil-agent-status-page-cli-plan.md))
+shipped `agents list/get/archive` and `pool-labels queue`, then explicitly
+deferred three additional shipped endpoints to follow-up work. The utilization
+plan ([docs/plans/2026-06-11-001-feat-hil-agent-utilization-metrics-cli-plan.md](2026-06-11-001-feat-hil-agent-utilization-metrics-cli-plan.md))
+added `agents utilization`. This plan closes the highest-value remaining gap:
+two read commands that have no CLI surface but are already served by deployed
+rerun and already callable through the committed generated client.
+
+## Summary
+
+Add two read-only subcommands that reach parity with the deployed rerun
+agent/pool-label API for the scripting-focused surface:
+
+- `resim pool-labels list` — the org's distinct pool labels (`GET /poolLabels`).
+- `resim agents results --agent-id <id>` — an agent's full results history
+  (`GET /agents/{agentID}/results`), the paginated superset of the capped
+  "recent activity" already shown by `resim agents get`.
+
+Both follow existing CLI conventions: pretty table/list by default, `--json`
+for raw output, auto-pagination (no page flags exposed), and friendly
+client-side validation. **No client regeneration is required** — the committed
+`api/client.gen.go` and `api/mocks/*` already expose both operations (see Key
+Technical Decisions). This is purely additive command code plus tests.
+
+---
+
+## What exists vs. the gap
+
+Deployed rerun (`main`, `api/customerapi/rerun.yml`) exposes ten agent/pool-label
+operations. The CLI covers six. This plan adds two of the four uncovered ones;
+the other two are deferred (see Scope Boundaries).
+
+| Rerun operation | CLI today | This plan |
+|---|---|---|
+| `listAgents` | `agents list` | — |
+| `getAgent` | `agents get` | — |
+| `archiveAgent` | `agents archive` | — |
+| `listAgentPoolLabelQueue` | `pool-labels queue` | — |
+| `getAgentUtilization` | `agents utilization --agent-id` | — |
+| `listAgentUtilization` | `agents utilization` (org-wide) | — |
+| `listPoolLabels` (`GET /poolLabels`) | **none** | **`pool-labels list`** |
+| `listAgentResults` (`GET /agents/{id}/results`) | **none** | **`agents results`** |
+| `listAgentResultBranches` (`GET /agents/{id}/result-branches`) | none | deferred (UI picker) |
+| `listAgentMarkdownHistory` (`GET /projects/{id}/agent-markdown-history`) | none | deferred |
+
+---
+
+## Problem Frame
+
+Ops, SREs, and platform engineers script against ReSim via the CLI. They can
+already enumerate agents, inspect one, archive one, read the pool-label queue,
+and pull utilization — but two things the UI surfaces have no CLI equivalent:
+
+1. **What pool labels exist?** There is no way to list the org's distinct pool
+   labels without inferring them from `agents list` rows or the queue. The
+   `GET /poolLabels` endpoint exists for exactly this (it backs the UI's
+   pool-label search/autocomplete).
+2. **What has an agent actually run?** `agents get` shows only the capped
+   recent-activity card. The agent detail page's "Results" tab is backed by
+   `GET /agents/{agentID}/results`, a paginated, filterable history with a
+   total count. Scripters who want "everything rack-1 has run since Monday,
+   filtered to the `nav` experience" have no CLI path today.
+
+Both endpoints are deployed and already wired into the committed client; the
+only missing piece is the command surface.
+
+---
+
+## Requirements
+
+- R1. `resim pool-labels list` — pretty list by default, `--json` for raw. Auto-paginates the full set (no page flags). Supports `--name <substr>` and `--order-by rank|timestamp`.
+- R2. `resim agents results --agent-id <id>` — pretty table by default, `--json` for raw. Auto-paginates the full history. Renders a `Total: N` header plus one row per result, reusing the recent-activity table shape from `agents get`.
+- R3. `agents results` supports the deployed filters that carry scripting value: `--text <substr>` (experience-name substring) and `--created-after <RFC3339>` (lower bound). Both are validated client-side; invalid values fail fast before any request.
+- R4. `--agent-id` is required on `agents results`; a 404 maps to a friendly "agent not found" error naming the ID; non-zero exit on failure, per CLI convention.
+- R5. `--order-by` (pool-labels) is validated client-side against `rank|timestamp`; omitted when unset so the server applies its documented `timestamp` default.
+- R6. Help text on every command is useful in isolation: explains org scope, the recent-activity-vs-full-history distinction, and the order-by tradeoff (`rank` recommended with `--name`).
+- R7. Output formatting and error handling consistent with existing CLI conventions (tabwriter table, `OutputJson`, `ValidateResponse`, empty-state messages).
+
+---
+
+## Scope Boundaries
+
+- Read-only. No mutation commands, no interactive pickers, no watch/follow mode.
+- No new output-format engine — reuse the existing tabwriter/`OutputJson` helpers.
+- No pagination flags exposed (`--page-size`/`--page-token`); the CLI auto-fetches all pages like every other list command.
+- No changes to the six existing agent/pool-label commands beyond an internal refactor to share the recent-activity row renderer (see U2).
+- No client/spec/codegen changes — the deployed spec and committed client already serve both operations.
+
+### Deferred to Follow-Up Work
+
+- **`resim agents result-branches`** (`GET /agents/{id}/result-branches`) — the spec itself describes this as backing the Results-tab branch *filter picker*; it is a UI-shaped concern with little standalone scripting value. Deferred (continues the 2026-05-05 plan's deferral).
+- **`resim agents markdown-history`** (`GET /projects/{id}/agent-markdown-history`) — newer, project-scoped; CLI value unproven and not covered by any prior plan. Deferred pending a concrete scripting use case.
+- **`agents results --branch-id <uuid>` filter** — maps directly to the `branchIds` param, but is awkward without `result-branches` to discover branch UUIDs. Revisit alongside `result-branches`.
+- **`pool-labels queue --project-id`** — rerun `main` keeps the queue org-wide (no `projectID` param); there is active rerun work re-introducing project scoping. When that ships and deploys, re-adding `--project-id` reverses the 2026-05-05 org-wide-only decision. Deferred, gated on the rerun change deploying.
+- **`agents utilization` by pool-label** — a pool-level utilization rollup (capacity planning per pool) is valuable but **not reachable against deployed rerun**: `listAgentUtilization` exposes no `poolLabel` filter, and the per-agent series (`AgentUtilizationSeries`) carries only `agentID` + `buckets`, no pool labels — so the CLI cannot group the existing data without a second `agents list` cross-reference. Even then, an agent belongs to *multiple* pool labels (summing per pool double-counts), and "pool utilization" has no server-defined aggregation (mean-of-fractions vs. capacity-weighted busy-seconds differ), so a CLI-only rollup would invent a metric that won't match the UI. Correct sequencing mirrors utilization itself: a rerun-side pool-label dimension first (a `poolLabel` filter param or pool labels on the series, with a defined aggregation), then a thin CLI flag. Deferred, gated on that rerun change.
+- **`agents archive --json`** and **`agents utilization --csv`** — carried-over deferred polish from the prior plans; out of scope here.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `cmd/resim/commands/agents.go` — the home of both new commands. Already defines the `agents` and `pool-labels` trees, the `agentActivityHeader` recent-activity table, `formatAgentDetail` (which renders capped recent activity), `displayVersion`, the tabwriter list pattern (`listAgents`), and client-side flag validation (`parseAgentUtilizationParams`, `validateCompletedSinceDays`).
+- `cmd/resim/commands/system.go` — canonical **auto-pagination** pattern: `listSystems` loops with `PageSize: Ptr(100)`, accumulates into a slice, breaks when `NextPageToken` is nil/empty, then `OutputJson(accumulated)`. Mirror the loop *shape*, but run `ValidateResponse` and nil-check `response.JSON200` **before** reading `NextPageToken`/`Items`/`PoolLabels`/`Total` — `listSystems` (`system.go:287-288`) assigns the token before its `JSON200 == nil` guard, a read-before-nil-check ordering the new commands should not copy. Note `ListPoolLabelsOutput.PoolLabels` is a pointer slice (`*[]PoolLabel`) needing the same nil-check `listSystems` applies to `Systems`, whereas `ListAgentResultsOutput.Items` is a non-pointer slice.
+- `cmd/resim/commands/agents_test.go` — the `CommandsSuite` testify-mock pattern: `s.mockClient.On("XWithResponse", matchContext, …)`, `captureStdout`, `sampleAgent`/`sampleUtilizationOutput` builders. Tests set the `Client` global to the mock.
+- `cmd/resim/commands/commands.go` / `utils` — `Client` global, `OutputJson`, `ValidateResponse`, viper flag plumbing.
+- `api/generate.go` — `go:generate` runs oapi-codegen against `https://api.resim.ai/v1/openapi.yaml` then mockery. **Not invoked by this plan** — the deployed spec already serves both operations and the committed artifacts already reflect them.
+
+### API surface (verified against committed client + deployed `rerun` spec)
+
+`GET /poolLabels` → `ListPoolLabelsWithResponse(ctx, *ListPoolLabelsParams)`:
+- Params: `Name *string` (≤256 chars, trigram search), `OrderBy *ListPoolLabelsParamsOrderBy` (`rank`|`timestamp`, server default `timestamp`), `PageSize`, `PageToken`.
+- Output `ListPoolLabelsOutput`: `PoolLabels *[]PoolLabel` (`PoolLabel = string`), `NextPageToken *string`.
+- Responses: 200, 400, 401 (no 404).
+
+`GET /agents/{agentID}/results` → `ListAgentResultsWithResponse(ctx, agentID, *ListAgentResultsParams)`:
+- Params: `PageSize`, `PageToken`, `BranchIds *[]uuid` (form/explode=false), `CreatedAfter *time.Time` (RFC3339), `Text *string` (experience-name substring).
+- Output `ListAgentResultsOutput`: `Items []AgentRecentActivity`, `NextPageToken *string`, `Total int`. **`AgentRecentActivity` is the same struct `agents get` already renders** (project/batch/test/status/branch/timestamp, plus optional buildVersion/errorSummary/system fields).
+- Responses: 200, 400, 401, 404.
+
+### Institutional Learnings
+
+- `docs/solutions/` does not exist in this repo — no prior learnings to carry forward (consistent with the 2026-05-05 plan's note).
+
+---
+
+## Key Technical Decisions
+
+- **No regeneration.** Confirmed `ListPoolLabelsWithResponse` and `ListAgentResultsWithResponse` are present in both the committed `api/client.gen.go` and `api/mocks/client_with_responses_interface.gen.go`. This plan adds no generated code — it is the first of the agent-CLI plans that needs no `go generate` unit, which removes the undeployed-endpoint risk the predecessors carried.
+- **Auto-paginate, hide the pagination.** Both commands loop internally with `PageSize: Ptr(100)` and accumulate, following the `listSystems` loop shape (with the nil-check ordering corrected — see Context & Research). No `--page-size`/`--page-token` flags — consistent with every existing list command, and avoids leaking pagination into a scripting surface.
+- **`--json` emits the accumulated items**, not the per-page envelope — matching `listSystems`' `OutputJson(allSystems)`. For `pool-labels list` that is a JSON array of label strings; for `agents results` a JSON array of `AgentRecentActivity` (the `Total` is then `len()`), so output round-trips against the item schema.
+- **Reuse the recent-activity renderer.** Extract the per-row rendering currently inline in `formatAgentDetail` into a shared helper, parameterized on indent, so `agents get` (indented, capped) and `agents results` (top-level, full, with a `Total: N` header) render identical columns. Minimal refactor; no behavior change to `get`.
+- **Filter flags follow the omit-when-empty precedent** of `parseAgentUtilizationParams`: unset flags are not sent so the server applies defaults; set flags are validated client-side (`--created-after` parsed via `time.RFC3339`, `--order-by` checked against the enum) and fail fast with a friendly message before any request leaves the machine.
+- **Flag naming follows existing precedent:** `--agent-id`, `--json`, `--name`, `--order-by`, `--text`, `--created-after`. Reuse the existing `agentIDKey`/`agentJSONKey` consts.
+- **Command placement:** `agents results` joins the `agents` tree and `pool-labels list` joins the `pool-labels` tree, both in `agents.go` (where the trees already live). Splitting the pool-labels tree into `pool_labels.go` stays at the implementer's discretion, matching the prior plan's stance.
+- **Auth:** existing `RESIM_ACCESS_TOKEN` / config-file flow; no new auth surface. Both endpoints require `projects:read`.
+
+---
+
+## Implementation Units
+
+### U1. `resim pool-labels list` subcommand
+
+**Goal:** List the org's distinct pool labels, auto-paginated, with `--name`/`--order-by` filters and `--json`.
+
+**Requirements:** R1, R5, R6, R7.
+
+**Dependencies:** none.
+
+**Files:**
+- Modify: `cmd/resim/commands/agents.go` (register `listPoolLabelsCmd` under `poolLabelsCmd`; add flag consts, `init()` wiring, run func, formatter).
+- Modify: `cmd/resim/commands/agents_test.go` (suite methods).
+
+**Approach:**
+- New `listPoolLabelsCmd` with flags `--name` (string), `--order-by` (string, empty default), `--json`.
+- Validate `--order-by` against `rank|timestamp` when non-empty; build `ListPoolLabelsParams` setting `Name`/`OrderBy` only when provided.
+- Auto-paginate (`PageSize: Ptr(100)`, nil-check `JSON200` then accumulate `*PoolLabels`, break on empty `NextPageToken`) per the corrected `listSystems` loop shape.
+- Pretty output: a `N pool labels:` header (or empty-state message) followed by one label per line. `--json`: the accumulated `[]string`.
+
+**Patterns to follow:** `listSystems` pagination loop (`system.go`); `listAgents` tabwriter/empty-state shape and `--json` branch (`agents.go`); `--order-by` validation mirrors `parseAgentUtilizationParams`' interval check.
+
+**Test scenarios:**
+- Happy path (multi-page): page 1 returns labels + a `nextPageToken`, page 2 returns more with empty token → output contains labels from *both* pages (proves accumulation) and the count header reflects the total.
+- Happy path (single page): 3 labels → 3 lines under an `N pool labels:` header.
+- Edge: zero labels → "No pool labels found." message, not an empty list.
+- Edge (`--json`): output parses as a JSON array of strings and includes labels from all pages.
+- Flag: `--order-by rank` → `OrderBy` param set to `rank`; `--name foo` → `Name` set.
+- Error path: `--order-by bogus` → client-side error naming `rank|timestamp`, no API call made.
+- Edge: `--order-by` unset → `OrderBy` omitted from the request (nil).
+
+**Verification:** `go test ./cmd/resim/commands/ -run TestCommandsSuite` passes; `./resim pool-labels list --help` shows `--name`, `--order-by`, `--json` and no page flags.
+
+### U2. `resim agents results` subcommand
+
+**Goal:** Render an agent's full, paginated results history with a total count and the deployed filters, reusing the recent-activity table.
+
+**Requirements:** R2, R3, R4, R6, R7.
+
+**Dependencies:** none (U1 independent; may land in either order).
+
+**Files:**
+- Modify: `cmd/resim/commands/agents.go` (register `agentResultsCmd` under `agentsCmd`; add flag consts, `init()` wiring, run func; extract a shared recent-activity row helper from `formatAgentDetail`).
+- Modify: `cmd/resim/commands/agents_test.go` (suite methods).
+
+**Approach:**
+- New `agentResultsCmd` with required `--agent-id` (via cobra `MarkFlagRequired`, enforced at `Execute()` like `getAgent`), plus `--text` (string), `--created-after` (RFC3339 string), `--json`.
+- Validate `--created-after` via `time.Parse(time.RFC3339, …)` and set `Text`/`CreatedAfter` only when provided.
+- Auto-paginate (`PageSize: Ptr(100)`, nil-check `JSON200` then accumulate `Items`, break on empty `NextPageToken`).
+- Map 404 → friendly "agent %q not found" (mirror `getAgent`/`archiveAgent`); other non-200 → `ValidateResponse`.
+- Pretty output: a header line with the agent ID and `Total: N` — use the server `Total` field as the authoritative count (not "server-or-accumulated"). Confirm during implementation whether server `Total` reflects the **filtered** count when `--text`/`--created-after` are set; if it is unfiltered, derive the displayed count from the rendered rows so the header never overstates what is shown. Then the recent-activity table via the shared row helper (top-level, non-indented). Empty-state: "No results for agent %q." `--json`: the accumulated `[]AgentRecentActivity` — consumers get the count via array length (no separate `Total`/`nextPageToken`), which equals the full set by design.
+- Refactor: pull the per-row formatting out of `formatAgentDetail` into a helper taking an indent prefix so `get` (indented, capped) and `results` (top-level, full) share columns; `get`'s output is unchanged.
+
+**Patterns to follow:** `formatAgentDetail`'s recent-activity table and `agentActivityHeader` (`agents.go`); `getAgent`'s 404 handling; `listSystems` pagination; `parseAgentUtilizationParams`' RFC3339 parsing.
+
+**Test scenarios:**
+- Happy path (multi-page): two pages of `AgentRecentActivity` → all rows render in the table; the `Total` header matches.
+- Happy path (columns): a result with project/test/status/branch set → row shows project name, test name, both conflated statuses, branch, timestamp; matches `get`'s columns.
+- Edge: zero results → "No results for agent %q." with `Total: 0`, no empty table.
+- Edge: result with nil `BranchName`/`BuildVersion`/`ErrorSummary` → renders without panic (empty branch cell).
+- Edge (`--json`): output parses as a JSON array and round-trips the item fields across pages.
+- Filter: `--text merge` → `Text` param set; `--created-after 2026-06-01T00:00:00Z` → `CreatedAfter` set.
+- Error path: `--created-after notatime` → client-side error before any API call.
+- Error path: 404 → non-zero exit, message includes the agent ID.
+- Flag wiring: `--agent-id` is registered with cobra `MarkFlagRequired` (enforced at `Execute()`, like `getAgent`/`archiveAgent`). `CommandsSuite` invokes run funcs directly and so does not assert the required-flag error — do not add a suite case for it.
+- Regression: `formatAgentDetail` output for `agents get` is unchanged after the row-helper extraction (existing `get` tests still pass).
+
+**Verification:** `go test ./cmd/resim/commands/ -run TestCommandsSuite` passes; `./resim agents results --help` shows `--agent-id` (required), `--text`, `--created-after`, `--json`; `./resim agents get` output is byte-identical to before.
+
+### U3. CHANGELOG entry and E2E smoke
+
+**Goal:** Document the new commands and add a light staging smoke check.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `CHANGELOG.md` (new unreleased "ReSim CLI" entry covering both commands).
+- Modify: the `end_to_end`-tagged tests under `testing/` (match the prior plan's E2E placement).
+
+**Approach:**
+- CHANGELOG: one bullet per command, noting org scope, auto-pagination, filters, and `--json`; plus a "Library consumers" note only if any exported surface changed (it should not — the client methods already shipped).
+- E2E: a happy-path check that `resim pool-labels list` exits 0 (empty-state output acceptable — staging may have no labels). No E2E for `agents results` (it needs a known agent ID; deriving one from `agents list` is brittle when the org has no agents) — note this explicitly rather than adding a flaky test.
+
+**Test scenarios:**
+- Happy path (E2E): `resim pool-labels list` against staging exits 0 with either labels or the empty-state message.
+- Test expectation (CHANGELOG): none — documentation only.
+
+**Verification:** `go build ./...`, `go vet ./...`, `go test ./...` pass; E2E runs in the existing CI E2E job or locally with staging credentials.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** adds one subcommand to each existing tree (`agents`, `pool-labels`); no removed or renamed commands; no shared state.
+- **Refactor blast radius:** extracting the recent-activity row helper touches `formatAgentDetail`; the `agents get` regression test (U2) gates against output drift.
+- **Error propagation:** customer-API errors map to non-zero exits with friendly stderr messages, preserving convention; 404 on `results` names the agent ID.
+- **API surface parity:** `pool-labels list` and `agents results` reach the deployed rerun surface for the scripting use cases; `result-branches`/`markdown-history` remain UI-shaped and deferred.
+- **No regenerated-client churn:** this plan regenerates nothing, so it adds no incidental-spec-drift of its own and carries no undeployed-endpoint risk (both operations are already live). The command code still depends on the generated types for these two operations, so a *future* canonical `go generate` (against the live spec) could drift them like any other call site — that risk is deferred, not eliminated.
+- **Unchanged invariants:** all existing CLI commands behave identically.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Recent-activity refactor changes `agents get` output | Regression test asserting `get`'s formatted output is unchanged (U2) |
+| Large results history → many pages / slow command | `PageSize: 100` like the rest of the CLI; `--text`/`--created-after` narrow the set; acceptable for a scripting command |
+| Staging has no pool labels → E2E ambiguous | Assert exit 0 + (labels OR empty-state message), per the prior plan's E2E convention |
+| `agents results` E2E needs an agent ID | Explicitly omit the E2E rather than add a flaky derive-an-ID test (documented in U3) |
+| Endpoints are deployed but org lacks data | Empty-state messages on both commands; no crash on empty/optional fields (tested) |
+
+---
+
+## Documentation / Operational Notes
+
+- `--help` output is the documentation; descriptions must stand alone (org scope, recent-activity-vs-full-history distinction, `rank`-with-`--name` tip).
+- No deploy gate: both endpoints are already live in production, so the release can ship as soon as the CLI lands (contrast with the utilization plan, which waited on a rerun deploy).
+
+---
+
+## Sources & References
+
+- **Linear:** [WOB-4131](https://linear.app/resim/issue/WOB-4131/api-client-hil-agent-status-agentspool-labels-cli-subcommands) — the agent-status CLI ticket whose "Deferred to Follow-Up Work" this plan continues.
+- **Predecessor plans:** [docs/plans/2026-05-05-001-feat-hil-agent-status-page-cli-plan.md](2026-05-05-001-feat-hil-agent-status-page-cli-plan.md) (deferred these endpoints), [docs/plans/2026-06-11-001-feat-hil-agent-utilization-metrics-cli-plan.md](2026-06-11-001-feat-hil-agent-utilization-metrics-cli-plan.md).
+- **Spec of record:** `rerun` `api/customerapi/rerun.yml` at `main`, deployed at `https://api.resim.ai/v1/openapi.yaml`; operations `listPoolLabels`, `listAgentResults`.
+- **Generated artifacts (already present):** `api/client.gen.go`, `api/mocks/client_with_responses_interface.gen.go`.
+- **Patterns:** `cmd/resim/commands/system.go` (auto-pagination), `cmd/resim/commands/agents.go` (trees, recent-activity table, flag validation).

--- a/docs/plans/2026-06-17-001-feat-agents-results-pool-labels-list-cli-plan.md
+++ b/docs/plans/2026-06-17-001-feat-agents-results-pool-labels-list-cli-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: resim agents results + pool-labels list CLI subcommands"
 type: feat
-status: active
+status: completed
 date: 2026-06-17
 linear: https://linear.app/resim/issue/WOB-4131/api-client-hil-agent-status-agentspool-labels-cli-subcommands
 origin: gap analysis — current api-client CLI vs. deployed rerun agent/pool-label API

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -2936,6 +2936,22 @@ func TestAgents(t *testing.T) {
 	queueCommand := CommandBuilder{Command: "queue"}
 	output = s.runCommand(ts, []CommandBuilder{poolLabelsCommand, queueCommand}, ExpectNoError)
 	ts.Empty(output.StdErr)
+
+	fmt.Println("Testing pool-labels list command")
+	// Like agents list, the org may have no pool labels: exit 0 with either a
+	// list or the empty-state message is a pass.
+	listPoolLabelsCommand := CommandBuilder{Command: "list"}
+	output = s.runCommand(ts, []CommandBuilder{poolLabelsCommand, listPoolLabelsCommand}, ExpectNoError)
+	ts.Empty(output.StdErr)
+
+	// --json emits a (possibly empty) JSON array of label strings.
+	listPoolLabelsJSONCommand := CommandBuilder{
+		Command: "list",
+		Flags:   []Flag{{Name: "--json", Value: ""}},
+	}
+	output = s.runCommand(ts, []CommandBuilder{poolLabelsCommand, listPoolLabelsJSONCommand}, ExpectNoError)
+	var poolLabelsOutput []string
+	ts.NoError(json.Unmarshal([]byte(strings.TrimSpace(output.StdOut)), &poolLabelsOutput))
 }
 
 func TestProjectCommands(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds two read-only CLI subcommands, closing the remaining gap between the `resim agents` / `pool-labels` CLI and rerun's **deployed** agent/pool-label API:

- **`resim pool-labels list`** — the org's distinct HiL pool labels (`GET /poolLabels`), auto-paginated. Flags: `--name` (substring/trigram filter), `--order-by rank|timestamp` (default `timestamp`, validated client-side), `--json`.
- **`resim agents results --agent-id <id>`** — an agent's full, paginated results history (`GET /agents/{id}/results`) — the complete set behind the agent detail page's Results tab, of which `agents get` shows only the most recent slice. Flags: `--text` (case-insensitive test-name substring), `--created-after` (RFC3339 lower bound), `--json`.

No client regeneration: both operations are already deployed, and the committed client + mocks already expose them. This is purely additive command code plus tests. Continues the deferred-to-follow-up work from the HiL agent-status CLI (WOB-4131).

Plan: `docs/plans/2026-06-17-001-feat-agents-results-pool-labels-list-cli-plan.md`

## Key decisions

- **Auto-paginate the full set, no page flags** — mirrors `listSystems`, but nil-checks `JSON200` *before* reading the next-page token (correcting `listSystems`' read-before-nil-check ordering rather than copying it).
- **Shared recent-activity renderer** — extracted `writeAgentActivityTable` so `agents get` (nested, indented) and `agents results` (flush, top-level) share columns; `agents get` output is byte-identical (regression-tested).
- **`Total:` header counts fetched rows** — because the CLI exhausts pagination, the materialized count is the exact, filter-correct total, which sidesteps whether the server's per-page `Total` reflects the filtered count.

## Testing

- Unit (`go test ./... -race`, green): multi-page accumulation, empty-state, `--json` round-trip, filter wiring, `--order-by` validation, and an `agents get` output-unchanged regression.
- E2E: `pool-labels list` smoke (exit 0, empty-state acceptable) added to `TestAgents`. No `agents results` E2E — it needs a known agent ID.
- `gofmt` / `go vet` clean.

## Post-Deploy Monitoring & Validation

Both endpoints are already live in production — no new server dependency, no migration.

- **Validate:** `resim pool-labels list` and `resim agents results --agent-id <known-agent>` return 200 and render (table + `--json`).
- **Healthy signal:** exit 0 with rows or the empty-state message.
- **Failure signal:** non-zero exit / 4xx–5xx surfaced as a friendly stderr message. No rollback infra needed (additive, read-only CLI); mitigation is reverting the CLI release.
- **Window / owner:** next CLI release smoke / @pete-resim.

## Stacked PR

Stacked on #211 (cosmetic `agents utilization` cleanup) — review/merge #211 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
