### PR TITLE
feat(metrics): add 'resim metrics config-schema' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.59.0 - June 22, 2026
+
+- Adds `resim metrics config-schema`, which prints the JSON Schema for the metrics configuration file to stdout (pipe to a file to use for editor validation and autocomplete).
+
 ### v0.58.0 - June 16, 2026
 
 - Cosmetic clean-up of `agents utilization`

--- a/bff/queries.gen.go
+++ b/bff/queries.gen.go
@@ -54,6 +54,15 @@ func (v *CreateDebugDashboardResponse) GetCreateDebugDashboard() CreateDebugDash
 	return v.CreateDebugDashboard
 }
 
+// GetConfigFileSchemaResponse is returned by GetConfigFileSchema on success.
+type GetConfigFileSchemaResponse struct {
+	// Returns the JSON Schema (Draft-07) describing the metrics configuration file format.
+	ConfigFileSchema string `json:"configFileSchema"`
+}
+
+// GetConfigFileSchema returns GetConfigFileSchemaResponse.ConfigFileSchema, and is useful for accessing the field via an interface.
+func (v *GetConfigFileSchemaResponse) GetConfigFileSchema() string { return v.ConfigFileSchema }
+
 // GetDashboardDashboard includes the requested fields of the GraphQL type Dashboard.
 type GetDashboardDashboard struct {
 	Id        string `json:"id"`
@@ -84,15 +93,16 @@ type GetDashboardResponse struct {
 func (v *GetDashboardResponse) GetDashboard() GetDashboardDashboard { return v.Dashboard }
 
 type MetricsTemplate struct {
+	Name string `json:"name"`
+	// base64 encoded template contents
 	Contents string `json:"contents"`
-	Name     string `json:"name"`
 }
-
-// GetContents returns MetricsTemplate.Contents, and is useful for accessing the field via an interface.
-func (v *MetricsTemplate) GetContents() string { return v.Contents }
 
 // GetName returns MetricsTemplate.Name, and is useful for accessing the field via an interface.
 func (v *MetricsTemplate) GetName() string { return v.Name }
+
+// GetContents returns MetricsTemplate.Contents, and is useful for accessing the field via an interface.
+func (v *MetricsTemplate) GetContents() string { return v.Contents }
 
 // UpdateMetricsConfigResponse is returned by UpdateMetricsConfig on success.
 type UpdateMetricsConfigResponse struct {
@@ -260,6 +270,34 @@ func CreateDebugDashboard(
 	}
 
 	data_ = &CreateDebugDashboardResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by GetConfigFileSchema.
+const GetConfigFileSchema_Operation = `
+query GetConfigFileSchema {
+	configFileSchema
+}
+`
+
+func GetConfigFileSchema(
+	ctx_ context.Context,
+	client_ graphql.Client,
+) (data_ *GetConfigFileSchemaResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "GetConfigFileSchema",
+		Query:  GetConfigFileSchema_Operation,
+	}
+
+	data_ = &GetConfigFileSchemaResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/bff/queries/get_config_file_schema.graphql
+++ b/bff/queries/get_config_file_schema.graphql
@@ -1,0 +1,3 @@
+query GetConfigFileSchema {
+    configFileSchema
+}

--- a/cmd/resim/commands/metrics.go
+++ b/cmd/resim/commands/metrics.go
@@ -35,6 +35,12 @@ var (
 		Long:  "Creates an ephemeral debug dashboard by uploading an emissions file and metrics config. Polls until the dashboard is ready, then prints its URL. Note: debug dashboards may be cleaned up after 24 hours.",
 		Run:   debugMetrics,
 	}
+	configSchemaMetricsCmd = &cobra.Command{
+		Use:   "config-schema",
+		Short: "config-schema - prints the JSON schema for the metrics config file",
+		Long:  "Fetches and prints the JSON Schema describing the metrics configuration file format. Pipe to a file to use it for editor validation and autocomplete.",
+		Run:   getMetricsConfigSchema,
+	}
 )
 
 const (
@@ -72,7 +78,18 @@ func init() {
 	debugMetricsCmd.MarkFlagRequired(metricsSetNameKey)
 	metricsCmd.AddCommand(debugMetricsCmd)
 
+	metricsCmd.AddCommand(configSchemaMetricsCmd)
+
 	rootCmd.AddCommand(metricsCmd)
+}
+
+func getMetricsConfigSchema(cmd *cobra.Command, args []string) {
+	resp, err := bff.GetConfigFileSchema(context.Background(), BffClient)
+	if err != nil {
+		log.Fatal("failed to fetch metrics config schema: ", err)
+	}
+
+	fmt.Println(resp.ConfigFileSchema)
 }
 
 // Read the given file and return a base64 encoded string of the file contents

--- a/cmd/resim/commands/metrics_test.go
+++ b/cmd/resim/commands/metrics_test.go
@@ -46,6 +46,17 @@ func TestDebugMetricsCmdHasRequiredFlags(t *testing.T) {
 	}
 }
 
+func TestConfigSchemaCmdIsRegistered(t *testing.T) {
+	var found bool
+	for _, sub := range metricsCmd.Commands() {
+		if sub.Name() == "config-schema" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "config-schema subcommand should be registered under metricsCmd")
+}
+
 // mockGraphQLClient implements graphql.Client for testing.
 type mockGraphQLClient struct {
 	mock.Mock


### PR DESCRIPTION
# Description of change

WOB-4241. Adds `resim metrics config-schema`, which fetches the metrics configuration file's JSON Schema (Draft-07) from the BFF and prints it to stdout. Customers can pipe it to a file and point their editor's `# yaml-language-server: $schema=<file>` at it for validation and autocomplete of their config files.

- New GraphQL operation `bff/queries/get_config_file_schema.graphql` (`configFileSchema`), with the regenerated `bff/queries.gen.go`.
- New `config-schema` subcommand under the existing `metrics` group; prints the raw schema JSON verbatim (no re-encoding).
- Changelog entry (`v0.59.0`).

Depends on the BFF query (`configFileSchema`), added in resim-ai/rerun#3496. This CLI command only works at runtime once that change reaches production.

## Guide to reproduce test results

- `go test ./cmd/resim/commands/ -run TestConfigSchemaCmdIsRegistered`
- Against an environment where the BFF change is deployed: `resim metrics config-schema | jq '."$schema"'` prints the Draft-07 schema URL.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.
