### PR TITLE
feat(cli): add metrics validate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.60.0 - June 29, 2026
+
+- Added `resim metrics validate`, which runs the same validations as `metrics sync` (schema, query building, and backwards-compatibility against the branch's current config) against an existing branch without persisting anything. Useful for checking a `metrics.yml` before committing to a sync.
+
 ### v0.59.0 - June 22, 2026
 
 - Commands that take a metrics set (`batches create`, `sweeps create`, `ingest`, `suites run --metrics-set-name-override`, and `dashboards create`) now validate that the metrics set exists on the branch before creating, failing fast with the available sets instead of silently creating work that produces no metrics. Validation is delegated to the BFF, so an unreachable BFF does not block creation.

--- a/bff/queries.gen.go
+++ b/bff/queries.gen.go
@@ -84,15 +84,16 @@ type GetDashboardResponse struct {
 func (v *GetDashboardResponse) GetDashboard() GetDashboardDashboard { return v.Dashboard }
 
 type MetricsTemplate struct {
+	Name string `json:"name"`
+	// base64 encoded template contents
 	Contents string `json:"contents"`
-	Name     string `json:"name"`
 }
-
-// GetContents returns MetricsTemplate.Contents, and is useful for accessing the field via an interface.
-func (v *MetricsTemplate) GetContents() string { return v.Contents }
 
 // GetName returns MetricsTemplate.Name, and is useful for accessing the field via an interface.
 func (v *MetricsTemplate) GetName() string { return v.Name }
+
+// GetContents returns MetricsTemplate.Contents, and is useful for accessing the field via an interface.
+func (v *MetricsTemplate) GetContents() string { return v.Contents }
 
 // UpdateMetricsConfigResponse is returned by UpdateMetricsConfig on success.
 type UpdateMetricsConfigResponse struct {
@@ -102,6 +103,17 @@ type UpdateMetricsConfigResponse struct {
 
 // GetUpdateMetricsConfig returns UpdateMetricsConfigResponse.UpdateMetricsConfig, and is useful for accessing the field via an interface.
 func (v *UpdateMetricsConfigResponse) GetUpdateMetricsConfig() string { return v.UpdateMetricsConfig }
+
+// ValidateMetricsConfigResponse is returned by ValidateMetricsConfig on success.
+type ValidateMetricsConfigResponse struct {
+	// Validates a metrics config against an existing branch without persisting it. Returns true when valid; otherwise errors with the validation messages.
+	ValidateMetricsConfig bool `json:"validateMetricsConfig"`
+}
+
+// GetValidateMetricsConfig returns ValidateMetricsConfigResponse.ValidateMetricsConfig, and is useful for accessing the field via an interface.
+func (v *ValidateMetricsConfigResponse) GetValidateMetricsConfig() bool {
+	return v.ValidateMetricsConfig
+}
 
 // ValidateMetricsSetResponse is returned by ValidateMetricsSet on success.
 type ValidateMetricsSetResponse struct {
@@ -191,6 +203,22 @@ func (v *__UpdateMetricsConfigInput) GetTemplateFiles() []MetricsTemplate { retu
 
 // GetBranch returns __UpdateMetricsConfigInput.Branch, and is useful for accessing the field via an interface.
 func (v *__UpdateMetricsConfigInput) GetBranch() string { return v.Branch }
+
+// __ValidateMetricsConfigInput is used internally by genqlient
+type __ValidateMetricsConfigInput struct {
+	BranchId      string            `json:"branchId"`
+	Config        string            `json:"config"`
+	TemplateFiles []MetricsTemplate `json:"templateFiles"`
+}
+
+// GetBranchId returns __ValidateMetricsConfigInput.BranchId, and is useful for accessing the field via an interface.
+func (v *__ValidateMetricsConfigInput) GetBranchId() string { return v.BranchId }
+
+// GetConfig returns __ValidateMetricsConfigInput.Config, and is useful for accessing the field via an interface.
+func (v *__ValidateMetricsConfigInput) GetConfig() string { return v.Config }
+
+// GetTemplateFiles returns __ValidateMetricsConfigInput.TemplateFiles, and is useful for accessing the field via an interface.
+func (v *__ValidateMetricsConfigInput) GetTemplateFiles() []MetricsTemplate { return v.TemplateFiles }
 
 // __ValidateMetricsSetInput is used internally by genqlient
 type __ValidateMetricsSetInput struct {
@@ -356,6 +384,42 @@ func UpdateMetricsConfig(
 	}
 
 	data_ = &UpdateMetricsConfigResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by ValidateMetricsConfig.
+const ValidateMetricsConfig_Operation = `
+query ValidateMetricsConfig ($branchId: String!, $config: String!, $templateFiles: [MetricsTemplate!]!) {
+	validateMetricsConfig(branchId: $branchId, config: $config, templateFiles: $templateFiles)
+}
+`
+
+func ValidateMetricsConfig(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	branchId string,
+	config string,
+	templateFiles []MetricsTemplate,
+) (data_ *ValidateMetricsConfigResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ValidateMetricsConfig",
+		Query:  ValidateMetricsConfig_Operation,
+		Variables: &__ValidateMetricsConfigInput{
+			BranchId:      branchId,
+			Config:        config,
+			TemplateFiles: templateFiles,
+		},
+	}
+
+	data_ = &ValidateMetricsConfigResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/bff/queries/validate_metrics_config.graphql
+++ b/bff/queries/validate_metrics_config.graphql
@@ -1,0 +1,3 @@
+query ValidateMetricsConfig($branchId: String!, $config: String!, $templateFiles: [MetricsTemplate!]!) {
+    validateMetricsConfig(branchId: $branchId, config: $config, templateFiles: $templateFiles)
+}

--- a/cmd/resim/commands/metrics.go
+++ b/cmd/resim/commands/metrics.go
@@ -29,6 +29,12 @@ var (
 		Long:  ``,
 		Run:   syncMetrics,
 	}
+	validateMetricsCmd = &cobra.Command{
+		Use:   "validate",
+		Short: "validate - validates your metrics config files against a branch without syncing",
+		Long:  "Runs the same validations as `sync` (schema, query building, and backwards-compatibility against the branch's current config) but does not persist anything. The branch must already exist.",
+		Run:   validateMetrics,
+	}
 	debugMetricsCmd = &cobra.Command{
 		Use:   "debug",
 		Short: "debug - creates a debug dashboard from an emissions file and metrics config",
@@ -58,6 +64,13 @@ func init() {
 	syncMetricsCmd.Flags().String(metricsTemplatesPathKey, ".resim/metrics/templates", "The path to the metrics templates directory. Default is .resim/metrics/templates")
 	syncMetricsCmd.MarkFlagRequired(metricsProjectKey)
 	metricsCmd.AddCommand(syncMetricsCmd)
+
+	validateMetricsCmd.Flags().String(metricsProjectKey, "", "The name or ID of the project")
+	validateMetricsCmd.Flags().String(metricsBranchNameKey, "main", "The name of the branch to validate against. The default is main")
+	validateMetricsCmd.Flags().StringSlice(metricsConfigPathAliasKey, []string{".resim/metrics/config.resim.yml"}, "The path(s) to the metrics config file(s). Supports glob patterns (e.g. \"metrics/*.yml\"). Can be specified multiple times or comma-separated. Files are merged in order. Default is .resim/metrics/config.resim.yml")
+	validateMetricsCmd.Flags().String(metricsTemplatesPathKey, ".resim/metrics/templates", "The path to the metrics templates directory. Default is .resim/metrics/templates")
+	validateMetricsCmd.MarkFlagRequired(metricsProjectKey)
+	metricsCmd.AddCommand(validateMetricsCmd)
 
 	debugMetricsCmd.Flags().String(metricsProjectKey, "", "The name or ID of the project")
 	debugMetricsCmd.Flags().String(metricsEmissionsFileKey, "", "The path to the emissions file")
@@ -100,6 +113,20 @@ func syncMetrics(cmd *cobra.Command, args []string) {
 	templatesPath := viper.GetString(metricsTemplatesPathKey)
 
 	if err := SyncMetricsConfig(projectID, branchID, configPaths, templatesPath, verboseMode); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func validateMetrics(cmd *cobra.Command, args []string) {
+	verboseMode := viper.GetBool(verboseKey)
+	projectID := getProjectID(Client, viper.GetString(metricsProjectKey))
+	branchName := viper.GetString(metricsBranchNameKey)
+	branchID := getBranchID(Client, projectID, branchName, true)
+
+	configPaths := viper.GetStringSlice(metricsConfigPathAliasKey)
+	templatesPath := viper.GetString(metricsTemplatesPathKey)
+
+	if err := ValidateMetricsConfig(branchID, configPaths, templatesPath, verboseMode); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/resim/commands/metrics_test.go
+++ b/cmd/resim/commands/metrics_test.go
@@ -46,6 +46,14 @@ func TestDebugMetricsCmdHasRequiredFlags(t *testing.T) {
 	}
 }
 
+func TestValidateMetricsCmdHasRequiredFlags(t *testing.T) {
+	flags := []string{"project", "branch", "metrics-config-path", "templates-path"}
+	for _, name := range flags {
+		flag := validateMetricsCmd.Flags().Lookup(name)
+		assert.NotNil(t, flag, "--%s flag should exist on validateMetricsCmd", name)
+	}
+}
+
 // mockGraphQLClient implements graphql.Client for testing.
 type mockGraphQLClient struct {
 	mock.Mock
@@ -137,6 +145,43 @@ func TestWaitForDashboardReady_APIError(t *testing.T) {
 	err := waitForDashboardReady(context.Background(), mockClient, "test-dashboard-id", 5*time.Second, 50*time.Millisecond, testSpinner())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "connection refused")
+	mockClient.AssertExpectations(t)
+}
+
+func isValidateMetricsConfigRequest(req *graphql.Request) bool {
+	return req.OpName == "ValidateMetricsConfig"
+}
+
+func TestValidateMetricsConfig_Success(t *testing.T) {
+	mockClient := new(mockGraphQLClient)
+
+	mockClient.On("MakeRequest", mock.Anything, mock.MatchedBy(isValidateMetricsConfigRequest), mock.Anything).
+		Run(func(args mock.Arguments) {
+			resp := args.Get(2).(*graphql.Response)
+			data := resp.Data.(*bff.ValidateMetricsConfigResponse)
+			data.ValidateMetricsConfig = true
+		}).
+		Return(nil).Once()
+
+	resp, err := bff.ValidateMetricsConfig(
+		context.Background(), mockClient, "branch-id", "config", []bff.MetricsTemplate{},
+	)
+	assert.NoError(t, err)
+	assert.True(t, resp.ValidateMetricsConfig)
+	mockClient.AssertExpectations(t)
+}
+
+func TestValidateMetricsConfig_SurfacesValidationError(t *testing.T) {
+	mockClient := new(mockGraphQLClient)
+
+	mockClient.On("MakeRequest", mock.Anything, mock.MatchedBy(isValidateMetricsConfigRequest), mock.Anything).
+		Return(fmt.Errorf("topic 'foo' is invalid")).Once()
+
+	_, err := bff.ValidateMetricsConfig(
+		context.Background(), mockClient, "branch-id", "config", []bff.MetricsTemplate{},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "topic 'foo' is invalid")
 	mockClient.AssertExpectations(t)
 }
 

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -445,3 +445,37 @@ func SyncMetricsConfig(projectID uuid.UUID, branchID uuid.UUID, configPaths []st
 	}
 	return nil
 }
+
+// ValidateMetricsConfig runs the same validations as a sync against an existing branch
+// without persisting anything. The branch must already exist.
+func ValidateMetricsConfig(branchID uuid.UUID, configPaths []string, templatesPath string, verbose bool) error {
+	configB64, err := prepareMetricsConfig(configPaths, verbose)
+	if err != nil {
+		return err
+	}
+
+	templates, err := readTemplates(templatesPath, verbose)
+	if err != nil {
+		return err
+	}
+
+	_, err = bff.ValidateMetricsConfig(
+		context.Background(),
+		BffClient,
+		branchID.String(),
+		configB64,
+		templates,
+	)
+	if err != nil {
+		return fmt.Errorf("metrics config validation failed: %w", err)
+	}
+
+	fmt.Println("Validation passed — no changes applied.")
+	if verbose && len(templates) > 0 {
+		fmt.Println("Validated templates:")
+		for _, t := range templates {
+			fmt.Printf("\t%s\n", t.Name)
+		}
+	}
+	return nil
+}

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -384,6 +384,34 @@ func syncMetrics(projectName string, branch string, verbose bool, username strin
 	return []CommandBuilder{metricsCommand, syncCommand}
 }
 
+func validateMetrics(projectName string, branch string, verbose bool, username string, password string) []CommandBuilder {
+	metricsCommand := CommandBuilder{Command: "metrics"}
+
+	flags := []Flag{
+		{Name: "--project", Value: projectName},
+	}
+	if branch != "" {
+		flags = append(flags, Flag{Name: "--branch", Value: branch})
+	}
+	if verbose {
+		flags = append(flags, Flag{Name: "--verbose"})
+	}
+	// The CI fails if we use a different authentication method since it will
+	// report a different auth0 id for the user. The bff api is expecting the
+	// auth0 id reported with username/password auth. This also matches the
+	// rerun CI setup
+	if username != "" {
+		flags = append(flags, Flag{Name: "--username", Value: username})
+	}
+	if password != "" {
+		flags = append(flags, Flag{Name: "--password", Value: password})
+	}
+
+	validateCommand := CommandBuilder{Command: "validate", Flags: flags}
+
+	return []CommandBuilder{metricsCommand, validateCommand}
+}
+
 func debugMetricsCommand(projectName string, emissionsFile string, configPath string, metricsSetName string, username string, password string) []CommandBuilder {
 	metricsCommand := CommandBuilder{Command: "metrics"}
 	flags := []Flag{
@@ -6481,6 +6509,15 @@ func TestMetricsSync(t *testing.T) {
 		ts.Contains(output.StdOut, "Looking for metrics config at .resim/metrics/config.resim.yml")
 		ts.Contains(output.StdOut, "Found template bar.liquid")
 		ts.Contains(output.StdOut, "Successfully synced metrics config, and the following templates:")
+	})
+
+	t.Run("ValidatesMetricsConfig", func(t *testing.T) {
+		// validate runs the same validations against the branch's existing config and
+		// reports success without persisting anything. Runs after the sync subtest so
+		// the branch already has a config to validate against.
+		output := s.runCommand(ts, validateMetrics(projectIDString, "", false, username, password), false)
+		ts.Equal("", output.StdErr)
+		ts.Contains(output.StdOut, "Validation passed")
 	})
 }
 


### PR DESCRIPTION
# Description of change

Adds `resim metrics validate`, a new subcommand that runs the **same validations as `metrics sync`** — schema/topics/columns/templates, query building, and backwards-compatibility against the branch's current config — against an **existing** branch **without persisting anything**. Useful for checking a `metrics.yml` before committing to a sync.

It's a dedicated command rather than a `--dry-run` flag on `sync`, mirroring the dedicated BFF query and leaving `sync` (and its callers) untouched.

Backed by the new BFF `validateMetricsConfig` query — resim-ai/rerun#3524. The branch must already exist; validating against an unknown branch fails fast.

```
resim metrics validate --project <project> --branch <branch> \
  --metrics-config-path .resim/metrics/config.resim.yml \
  --templates-path .resim/metrics/templates
```

> Depends on rerun#3524 reaching prod before this is released (the query must exist on the live BFF). The genqlient client was regenerated against the new schema.

## Guide to reproduce test results

```sh
go test ./cmd/resim/commands/ -run TestValidateMetrics
```

Manual (against a dev env where rerun#3524 is deployed): run `resim metrics validate` with (a) a valid config → "Validation passed", (b) a config with a bad query or breaking change → the validation errors are printed and the command exits non-zero, with no config version created.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.
