### PR TITLE
Fix resim metrics sync silently dropping the dashboards: config section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.65.0 - July 24, 2026
+
+- Fixes `resim metrics sync` silently dropping a config's `dashboards:` section. Merging config files (even a single one) round-tripped the parsed config through a struct with no `dashboards` field, so config-driven dashboards were never created or updated by the CLI.
+
 ### v0.64.0 - July 21, 2026
 
 - Adds `resim blueprints`, a new command for managing blueprints in your org. Subcommands: `create` (creates a new blueprint from a CUE file; fails if a blueprint with the same name already exists), `revise` (creates a new version of an existing blueprint from a CUE file; fails if no blueprint with the name exists), `list` (a table of name/version/created-at showing the most recent version of each blueprint by default; `--all-versions` shows every version, and `--json` emits raw JSON without the CUE content), `get` (view information about a specific blueprint, or just its CUE content with `--cue-only`), and `archive` (blueprint removal).

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -34,6 +34,7 @@ type MetricsConfig struct {
 	Topics      map[string]interface{} `yaml:"topics"`
 	Metrics     map[string]interface{} `yaml:"metrics"`
 	MetricsSets map[string]interface{} `yaml:"metrics sets"`
+	Dashboards  map[string]interface{} `yaml:"dashboards"`
 }
 
 func applyGlobalSettings(config *MetricsConfig) {
@@ -61,6 +62,7 @@ func mergeConfigs(configs []MetricsConfig) (MetricsConfig, error) {
 		Topics:      make(map[string]interface{}),
 		Metrics:     make(map[string]interface{}),
 		MetricsSets: make(map[string]interface{}),
+		Dashboards:  make(map[string]interface{}),
 	}
 
 	for i, cfg := range configs {
@@ -89,6 +91,13 @@ func mergeConfigs(configs []MetricsConfig) (MetricsConfig, error) {
 				return MetricsConfig{}, fmt.Errorf("duplicate metrics set name %q found across config files", k)
 			}
 			result.MetricsSets[k] = v
+		}
+
+		for k, v := range cfg.Dashboards {
+			if _, exists := result.Dashboards[k]; exists {
+				return MetricsConfig{}, fmt.Errorf("duplicate dashboard name %q found across config files", k)
+			}
+			result.Dashboards[k] = v
 		}
 	}
 

--- a/cmd/resim/commands/utils_test.go
+++ b/cmd/resim/commands/utils_test.go
@@ -278,6 +278,7 @@ func TestMergeConfigs(t *testing.T) {
 				MetricsSets: map[string]interface{}{"set_a": map[string]interface{}{
 					"metrics": []interface{}{"metric_a"},
 				}},
+				Dashboards: map[string]interface{}{},
 			},
 		},
 		{
@@ -300,6 +301,7 @@ func TestMergeConfigs(t *testing.T) {
 				Topics:      map[string]interface{}{"topic_a": "val_a", "topic_b": "val_b"},
 				Metrics:     map[string]interface{}{"metric_a": "val_a", "metric_b": "val_b"},
 				MetricsSets: map[string]interface{}{"set_b": "val_b"},
+				Dashboards:  map[string]interface{}{},
 			},
 		},
 		{
@@ -330,6 +332,28 @@ func TestMergeConfigs(t *testing.T) {
 			errContains: "duplicate metrics set name",
 		},
 		{
+			name: "Dashboards merge across configs",
+			configs: []MetricsConfig{
+				{Dashboards: map[string]interface{}{"dash_a": "val_a"}},
+				{Dashboards: map[string]interface{}{"dash_b": "val_b"}},
+			},
+			expected: MetricsConfig{
+				Topics:      map[string]interface{}{},
+				Metrics:     map[string]interface{}{},
+				MetricsSets: map[string]interface{}{},
+				Dashboards:  map[string]interface{}{"dash_a": "val_a", "dash_b": "val_b"},
+			},
+		},
+		{
+			name: "Duplicate dashboard name causes error",
+			configs: []MetricsConfig{
+				{Dashboards: map[string]interface{}{"dup_dash": "a"}},
+				{Dashboards: map[string]interface{}{"dup_dash": "b"}},
+			},
+			shouldError: true,
+			errContains: "duplicate dashboard name",
+		},
+		{
 			name: "Mismatched versions cause error",
 			configs: []MetricsConfig{
 				{Version: 1},
@@ -349,6 +373,7 @@ func TestMergeConfigs(t *testing.T) {
 				Topics:      map[string]interface{}{},
 				Metrics:     map[string]interface{}{},
 				MetricsSets: map[string]interface{}{},
+				Dashboards:  map[string]interface{}{},
 			},
 		},
 	}
@@ -365,6 +390,7 @@ func TestMergeConfigs(t *testing.T) {
 				assert.Equal(t, tc.expected.Topics, result.Topics)
 				assert.Equal(t, tc.expected.Metrics, result.Metrics)
 				assert.Equal(t, tc.expected.MetricsSets, result.MetricsSets)
+				assert.Equal(t, tc.expected.Dashboards, result.Dashboards)
 			}
 		})
 	}
@@ -379,6 +405,21 @@ func TestMergeConfigFiles(t *testing.T) {
 		data, err := mergeConfigFiles([]string{file1}, false)
 		assert.NoError(t, err)
 		assert.Contains(t, string(data), "t1")
+	})
+
+	t.Run("dashboards section survives the merge round-trip", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		file1 := fmt.Sprintf("%s/config.resim.yml", tmpDir)
+		os.WriteFile(file1, []byte(
+			"version: 1\ntopics:\n  t1:\n    type: float\n"+
+				"dashboards:\n  My Dashboard:\n    description: test\n    metrics_set: set_a\n",
+		), 0644)
+
+		data, err := mergeConfigFiles([]string{file1}, false)
+		assert.NoError(t, err)
+		content := string(data)
+		assert.Contains(t, content, "My Dashboard")
+		assert.Contains(t, content, "metrics_set")
 	})
 
 	t.Run("Two files with additive content", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `MetricsConfig` (the Go struct `mergeConfigFiles` unmarshals a metrics config into before re-serializing it) had no `dashboards` field, so every `resim metrics sync` — even with a single config file — silently dropped the entire `dashboards:` section before submitting it to the BFF.
- Config-driven dashboards were therefore never created or updated via the CLI, even though the BFF correctly handles the section when it's actually present in the submitted config.
- Discovered while live-testing WOB-4284 topic archival (rerun#3630): a config-driven dashboard's charts never picked up config changes synced through the CLI, while syncing the same config via a raw GraphQL call (bypassing the CLI) worked fine.

## Test plan
- [x] Added `TestMergeConfigFiles/dashboards_section_survives_the_merge_round-trip` — fails on `main`, passes with this fix.
- [x] Added `TestMergeConfigs` cases for dashboards merging and duplicate-name detection.
- [x] `go test ./cmd/resim/commands/...` passes.