### PR TITLE
WOB-4322: warn when a metric is unused by any metrics set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.68.0 - July 28, 2026
+
+- `resim metrics sync` and `resim metrics validate` now warn (without failing) when a config defines a metric that isn't referenced by any metrics set: `WARNING: the following metrics are not used by any metrics set: <names>`.
+
 ### v0.67.0 - July 28, 2026
 
 - `resim metrics sync` now previews and confirms topic removal: if a config drop would remove a topic, sync prints the affected row count, chart count, and dashboards. Without `--allow-topic-removal` it then refuses to proceed; with the flag set it prints the same impact as a confirmation notice and proceeds.

--- a/bff/queries.gen.go
+++ b/bff/queries.gen.go
@@ -54,6 +54,15 @@ func (v *CreateDebugDashboardResponse) GetCreateDebugDashboard() CreateDebugDash
 	return v.CreateDebugDashboard
 }
 
+// FindUnusedMetricsResponse is returned by FindUnusedMetrics on success.
+type FindUnusedMetricsResponse struct {
+	// Lists metrics defined in a config's metrics: section that are not referenced by any metrics sets: entry. A pure function of the submitted config — no branch lookup or persistence.
+	FindUnusedMetrics []string `json:"findUnusedMetrics"`
+}
+
+// GetFindUnusedMetrics returns FindUnusedMetricsResponse.FindUnusedMetrics, and is useful for accessing the field via an interface.
+func (v *FindUnusedMetricsResponse) GetFindUnusedMetrics() []string { return v.FindUnusedMetrics }
+
 // GetConfigFileSchemaResponse is returned by GetConfigFileSchema on success.
 type GetConfigFileSchemaResponse struct {
 	// Returns the JSON Schema (Draft-07) describing the metrics configuration file format.
@@ -93,28 +102,26 @@ type GetDashboardResponse struct {
 func (v *GetDashboardResponse) GetDashboard() GetDashboardDashboard { return v.Dashboard }
 
 type MediaFileInput struct {
-	Name string `json:"name"`
-	// base64 encoded media file contents
 	Contents string `json:"contents"`
+	Name     string `json:"name"`
 }
-
-// GetName returns MediaFileInput.Name, and is useful for accessing the field via an interface.
-func (v *MediaFileInput) GetName() string { return v.Name }
 
 // GetContents returns MediaFileInput.Contents, and is useful for accessing the field via an interface.
 func (v *MediaFileInput) GetContents() string { return v.Contents }
 
-type MetricsTemplate struct {
-	Name string `json:"name"`
-	// base64 encoded template contents
-	Contents string `json:"contents"`
-}
+// GetName returns MediaFileInput.Name, and is useful for accessing the field via an interface.
+func (v *MediaFileInput) GetName() string { return v.Name }
 
-// GetName returns MetricsTemplate.Name, and is useful for accessing the field via an interface.
-func (v *MetricsTemplate) GetName() string { return v.Name }
+type MetricsTemplate struct {
+	Contents string `json:"contents"`
+	Name     string `json:"name"`
+}
 
 // GetContents returns MetricsTemplate.Contents, and is useful for accessing the field via an interface.
 func (v *MetricsTemplate) GetContents() string { return v.Contents }
+
+// GetName returns MetricsTemplate.Name, and is useful for accessing the field via an interface.
+func (v *MetricsTemplate) GetName() string { return v.Name }
 
 // PreviewTopicRemovalPreviewTopicRemovalTopicRemovalPreview includes the requested fields of the GraphQL type TopicRemovalPreview.
 type PreviewTopicRemovalPreviewTopicRemovalTopicRemovalPreview struct {
@@ -255,6 +262,14 @@ func (v *__CreateDebugDashboardInput) GetMetricsSetName() string { return v.Metr
 
 // GetMediaFiles returns __CreateDebugDashboardInput.MediaFiles, and is useful for accessing the field via an interface.
 func (v *__CreateDebugDashboardInput) GetMediaFiles() []MediaFileInput { return v.MediaFiles }
+
+// __FindUnusedMetricsInput is used internally by genqlient
+type __FindUnusedMetricsInput struct {
+	Config string `json:"config"`
+}
+
+// GetConfig returns __FindUnusedMetricsInput.Config, and is useful for accessing the field via an interface.
+func (v *__FindUnusedMetricsInput) GetConfig() string { return v.Config }
 
 // __GetDashboardInput is used internally by genqlient
 type __GetDashboardInput struct {
@@ -407,6 +422,38 @@ func CreateDebugDashboard(
 	}
 
 	data_ = &CreateDebugDashboardResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by FindUnusedMetrics.
+const FindUnusedMetrics_Operation = `
+query FindUnusedMetrics ($config: String!) {
+	findUnusedMetrics(config: $config)
+}
+`
+
+func FindUnusedMetrics(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	config string,
+) (data_ *FindUnusedMetricsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "FindUnusedMetrics",
+		Query:  FindUnusedMetrics_Operation,
+		Variables: &__FindUnusedMetricsInput{
+			Config: config,
+		},
+	}
+
+	data_ = &FindUnusedMetricsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/bff/queries/find_unused_metrics.graphql
+++ b/bff/queries/find_unused_metrics.graphql
@@ -1,0 +1,3 @@
+query FindUnusedMetrics($config: String!) {
+    findUnusedMetrics(config: $config)
+}

--- a/cmd/resim/commands/metrics_test.go
+++ b/cmd/resim/commands/metrics_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -187,6 +190,118 @@ func TestValidateMetricsConfig_Success(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+// captureStderr runs f while capturing everything written to os.Stderr.
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	f()
+
+	w.Close()
+	var b strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := r.Read(buf)
+		b.Write(buf[:n])
+		if readErr != nil {
+			break
+		}
+	}
+	return b.String()
+}
+
+func writeMetricsConfigFixture(t *testing.T, unusedMetric bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.resim.yml")
+	config := `version: 1
+metrics:
+  Average Speed:
+    type: test
+    query_string: SELECT AVG(speed) FROM ok
+    template_type: system
+    template: scalar
+metrics sets:
+  woot:
+    metrics:
+      - Average Speed
+`
+	if unusedMetric {
+		config += `  Max Speed:
+    type: test
+    query_string: SELECT MAX(speed) FROM ok
+    template_type: system
+    template: scalar
+`
+	}
+	assert.NoError(t, os.WriteFile(path, []byte(config), 0644))
+	return path
+}
+
+func isFindUnusedMetricsRequest(req *graphql.Request) bool {
+	return req.OpName == "FindUnusedMetrics"
+}
+
+func withValidateMetricsConfigResult(valid bool) func(args mock.Arguments) {
+	return func(args mock.Arguments) {
+		resp := args.Get(2).(*graphql.Response)
+		data := resp.Data.(*bff.ValidateMetricsConfigResponse)
+		data.ValidateMetricsConfig = valid
+	}
+}
+
+func withFindUnusedMetricsResult(unusedMetrics []string) func(args mock.Arguments) {
+	return func(args mock.Arguments) {
+		resp := args.Get(2).(*graphql.Response)
+		data := resp.Data.(*bff.FindUnusedMetricsResponse)
+		data.FindUnusedMetrics = unusedMetrics
+	}
+}
+
+func TestValidateMetricsConfig_PrintsUnusedMetricsWarning(t *testing.T) {
+	mockClient := new(mockGraphQLClient)
+	mockClient.On("MakeRequest", mock.Anything, mock.MatchedBy(isValidateMetricsConfigRequest), mock.Anything).
+		Run(withValidateMetricsConfigResult(true)).
+		Return(nil).Once()
+	mockClient.On("MakeRequest", mock.Anything, mock.MatchedBy(isFindUnusedMetricsRequest), mock.Anything).
+		Run(withFindUnusedMetricsResult([]string{"Max Speed"})).
+		Return(nil).Once()
+	withMockBffClient(t, mockClient)
+
+	configPath := writeMetricsConfigFixture(t, true)
+	stderr := captureStderr(t, func() {
+		err := ValidateMetricsConfig(uuid.New(), []string{configPath}, "templates", false)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, stderr, "WARNING: the following metrics are not used by any metrics set: Max Speed")
+	mockClient.AssertExpectations(t)
+}
+
+func TestValidateMetricsConfig_NoWarningWhenAllMetricsUsed(t *testing.T) {
+	mockClient := new(mockGraphQLClient)
+	mockClient.On("MakeRequest", mock.Anything, mock.MatchedBy(isValidateMetricsConfigRequest), mock.Anything).
+		Run(withValidateMetricsConfigResult(true)).
+		Return(nil).Once()
+	mockClient.On("MakeRequest", mock.Anything, mock.MatchedBy(isFindUnusedMetricsRequest), mock.Anything).
+		Run(withFindUnusedMetricsResult(nil)).
+		Return(nil).Once()
+	withMockBffClient(t, mockClient)
+
+	configPath := writeMetricsConfigFixture(t, false)
+	stderr := captureStderr(t, func() {
+		err := ValidateMetricsConfig(uuid.New(), []string{configPath}, "templates", false)
+		assert.NoError(t, err)
+	})
+
+	assert.Empty(t, stderr)
+	mockClient.AssertExpectations(t)
+}
+
 func TestValidateMetricsConfig_SurfacesValidationError(t *testing.T) {
 	mockClient := new(mockGraphQLClient)
 
@@ -309,6 +424,9 @@ func TestSyncMetricsConfig_NoTopicsRemoved_SucceedsWithoutFlag(t *testing.T) {
 	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isUpdateMetricsConfigRequest), mock.Anything).
 		Run(withUpdateMetricsConfigSuccess()).
 		Return(nil).Once()
+	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isFindUnusedMetricsRequest), mock.Anything).
+		Run(withFindUnusedMetricsResult(nil)).
+		Return(nil).Once()
 
 	err := SyncMetricsConfig(uuid.New(), uuid.New(), []string{"testdata/config.yml"}, "testdata/templates", false, false)
 	assert.NoError(t, err)
@@ -352,6 +470,9 @@ func TestSyncMetricsConfig_TopicsWouldBeRemoved_ProceedsWithFlag(t *testing.T) {
 	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isUpdateMetricsConfigRequest), mock.Anything).
 		Run(withUpdateMetricsConfigSuccess()).
 		Return(nil).Once()
+	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isFindUnusedMetricsRequest), mock.Anything).
+		Run(withFindUnusedMetricsResult(nil)).
+		Return(nil).Once()
 
 	err := SyncMetricsConfig(uuid.New(), uuid.New(), []string{"testdata/config.yml"}, "testdata/templates", true, false)
 	assert.NoError(t, err)
@@ -369,6 +490,9 @@ func TestSyncMetricsConfig_PreviewTransportErrorSoftFails(t *testing.T) {
 		Return(fmt.Errorf("bff unavailable")).Once()
 	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isUpdateMetricsConfigRequest), mock.Anything).
 		Run(withUpdateMetricsConfigSuccess()).
+		Return(nil).Once()
+	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isFindUnusedMetricsRequest), mock.Anything).
+		Run(withFindUnusedMetricsResult(nil)).
 		Return(nil).Once()
 
 	err := SyncMetricsConfig(uuid.New(), uuid.New(), []string{"testdata/config.yml"}, "testdata/templates", false, false)

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -460,6 +460,20 @@ func readTemplates(templatesPath string, verbose bool) ([]bff.MetricsTemplate, e
 	return templates, nil
 }
 
+// warnUnusedMetrics prints a non-blocking warning listing metrics that aren't referenced by
+// any metrics set. This is purely informational: a transport or BFF error here is logged and
+// swallowed rather than returned, so it never fails an otherwise-successful sync/validate.
+func warnUnusedMetrics(configB64 string) {
+	resp, err := bff.FindUnusedMetrics(context.Background(), BffClient, configB64)
+	if err != nil {
+		log.Printf("warning: could not check for unused metrics, continuing: %v", err)
+		return
+	}
+	if len(resp.FindUnusedMetrics) > 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: the following metrics are not used by any metrics set: %s\n", strings.Join(resp.FindUnusedMetrics, ", "))
+	}
+}
+
 func SyncMetricsConfig(projectID uuid.UUID, branchID uuid.UUID, configPaths []string, templatesPath string, allowTopicRemoval bool, verbose bool) error {
 	branch, err := Client.GetBranchForProjectWithResponse(context.Background(), projectID, branchID)
 	if err != nil {
@@ -501,6 +515,8 @@ func SyncMetricsConfig(projectID uuid.UUID, branchID uuid.UUID, configPaths []st
 		return fmt.Errorf("failed to sync metrics config: %w", err)
 	}
 
+	warnUnusedMetrics(configB64)
+
 	if verbose {
 		fmt.Print("Successfully synced metrics config")
 		if len(templates) > 0 {
@@ -538,6 +554,8 @@ func ValidateMetricsConfig(branchID uuid.UUID, configPaths []string, templatesPa
 	if err != nil {
 		return fmt.Errorf("metrics config validation failed: %w", err)
 	}
+
+	warnUnusedMetrics(configB64)
 
 	fmt.Println("Validation passed — no changes applied.")
 	if verbose && len(templates) > 0 {

--- a/docs/plans/2026-07-28-001-feat-wob-4322-warn-unused-metrics-cli-plan.md
+++ b/docs/plans/2026-07-28-001-feat-wob-4322-warn-unused-metrics-cli-plan.md
@@ -1,0 +1,93 @@
+# WOB-4322: Warn when a metrics config defines a metric unused by any metrics set (CLI)
+
+## Context
+
+`resim metrics sync`/`resim metrics validate` let a user define `metrics:` and
+`metrics sets:` in a config file, but nothing today tells them when a metric is
+defined and never referenced by any set — it silently exists but never
+produces data anywhere. We want a non-blocking warning surfaced from both
+commands.
+
+The check is computed server-side (BFF), following the existing
+`unusedBuilds` precedent on `workflows runs create` — computed server-side,
+returned as response data, printed by the CLI as `WARNING: ...` on stderr
+without failing the command. This keeps the CLI consistent with how it
+already delegates all other metrics-config semantics (schema, query building,
+backwards-compat) to the BFF rather than validating locally.
+
+This is the CLI half of a two-repo change; the BFF half is planned separately
+in `~/resim/rerun` (worktree `.worktrees/wob-4322-warn-unused-metrics`).
+
+**Revision note:** the original design added `unusedMetrics` directly onto
+the `updateMetricsConfig`/`validateMetricsConfig` response by changing those
+fields from bare scalars to result objects. That turned out to be a breaking
+GraphQL schema change — it broke an internal consumer in the `rerun` repo we
+hadn't accounted for, and there's no way to audit every caller of the BFF's
+GraphQL API from either repo alone. The BFF side now exposes a new,
+purely-additive `findUnusedMetrics(config: String!): [String!]!` query
+instead, leaving `updateMetricsConfig`/`validateMetricsConfig` untouched. The
+CLI change below reflects that: one extra query call after a successful
+sync/validate, rather than reading the field off the existing response.
+
+## Plan
+
+**1. Query documents** — `bff/queries/update_metrics_config.graphql` and
+`bff/queries/validate_metrics_config.graphql` are unchanged. Add a new
+`bff/queries/find_unused_metrics.graphql`:
+```graphql
+query FindUnusedMetrics($config: String!) {
+    findUnusedMetrics(config: $config)
+}
+```
+
+**2. Regenerate the client:** `bff/cmd/generate.go` fetches the schema live
+via introspection from `GRAPHQL_API_ENDPOINT` (defaults to
+`https://bff.resim.ai/graphql`) — it does not read a local schema file. To
+pick up the new field before it's deployed, run a local BFF
+(`mix phx.server` in the rerun worktree, default `http://localhost:4000`) and
+regenerate against it:
+```
+GRAPHQL_API_ENDPOINT=http://localhost:4000/graphql go generate ./bff/...
+```
+This generates `bff.FindUnusedMetrics(ctx, client, configB64)` returning
+`*FindUnusedMetricsResponse{FindUnusedMetrics []string}`.
+
+**3. Print the warning** — `cmd/resim/commands/utils.go`: a new
+`warnUnusedMetrics(configB64 string)` helper calls `bff.FindUnusedMetrics`
+and prints to stderr if non-empty, mirroring `workflows.go:758-764`'s
+`WARNING: ...` convention. A transport/BFF error here is logged
+(`log.Printf`) and swallowed, not returned — this call is purely
+informational and must never fail an otherwise-successful sync/validate
+(same soft-fail precedent as `validateMetricsSetExists`). Called from
+`SyncMetricsConfig` right after `bff.UpdateMetricsConfig` succeeds, and from
+`ValidateMetricsConfig` right after `bff.ValidateMetricsConfig` succeeds.
+
+**4. Tests:**
+- `cmd/resim/commands/metrics_test.go`: `TestValidateMetricsConfig_PrintsUnusedMetricsWarning`
+  / `_NoWarningWhenAllMetricsUsed` mock both the `ValidateMetricsConfig` and
+  `FindUnusedMetrics` GraphQL calls and assert on captured stderr. Added a
+  `captureStderr` helper (no existing helper captured stderr; only
+  `captureStdout` in `agents_test.go:32-52`, which swaps `os.Stdout`).
+- `testing/end_to_end_test.go`: `TestMetricsSync`'s new
+  `"WarnsOnMetricUnusedByAnyMetricsSet"` subtest, using a dedicated fixture
+  (`testing/.resim/metrics/config_unused_metric.resim.yml`) with a metric
+  that isn't in any set, asserting stderr contains
+  `"WARNING: the following metrics are not used by any metrics set"` on both
+  `sync` and `validate`.
+
+**5. Changelog** — bump `CHANGELOG.md` with a new version entry (pattern:
+`### vX.Y.Z - <Month DD, YYYY>`) describing the new warning on both `sync`
+and `validate`. User-visible behavior is unchanged by the revision — still
+one warning line, same wording, same non-fatal semantics.
+
+## Verification
+
+- `go test ./...`, plus the extended e2e subtest
+  (`go test ./testing/... -run TestMetricsSync`) against a local BFF running
+  the new backend code, confirming `sync` and `validate` both print the
+  `WARNING: the following metrics are not used by any metrics set: ...` line
+  for a config with an unreferenced metric, and print nothing extra when
+  every metric is used.
+- Manual: run `resim metrics sync`/`validate` locally against the fixture
+  config with an intentionally-unused metric and visually confirm the warning
+  and that the command still exits 0.

--- a/testing/.resim/metrics/config_unused_metric.resim.yml
+++ b/testing/.resim/metrics/config_unused_metric.resim.yml
@@ -1,0 +1,20 @@
+version: 1
+topics:
+  ok:
+    schema:
+      speed: float
+metrics:
+  Average Speed:
+    type: test
+    query_string: SELECT AVG(speed) FROM ok
+    template_type: system
+    template: scalar
+  Max Speed:
+    type: test
+    query_string: SELECT MAX(speed) FROM ok
+    template_type: system
+    template: scalar
+metrics sets:
+  woot:
+    metrics:
+      - Average Speed

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -409,7 +409,7 @@ func syncMetricsWithConfig(projectName string, branch string, configPath string,
 	return []CommandBuilder{metricsCommand, syncCommand}
 }
 
-func validateMetrics(projectName string, branch string, verbose bool, username string, password string) []CommandBuilder {
+func validateMetrics(projectName string, branch string, configPath string, verbose bool, username string, password string) []CommandBuilder {
 	metricsCommand := CommandBuilder{Command: "metrics"}
 
 	flags := []Flag{
@@ -417,6 +417,9 @@ func validateMetrics(projectName string, branch string, verbose bool, username s
 	}
 	if branch != "" {
 		flags = append(flags, Flag{Name: "--branch", Value: branch})
+	}
+	if configPath != "" {
+		flags = append(flags, Flag{Name: "--metrics-config-path", Value: configPath})
 	}
 	if verbose {
 		flags = append(flags, Flag{Name: "--verbose"})
@@ -6559,7 +6562,7 @@ func TestMetricsSync(t *testing.T) {
 		// validate runs the same validations against the branch's existing config and
 		// reports success without persisting anything. Runs after the sync subtest so
 		// the branch already has a config to validate against.
-		output := s.runCommand(ts, validateMetrics(projectIDString, "", false, username, password), false)
+		output := s.runCommand(ts, validateMetrics(projectIDString, "", "", false, username, password), false)
 		ts.Equal("", output.StdErr)
 		ts.Contains(output.StdOut, "Validation passed")
 	})
@@ -6580,6 +6583,22 @@ func TestMetricsSync(t *testing.T) {
 
 		output := s.runCommand(ts, syncMetricsWithConfig(projectIDString, "", absConfigPath, true, username, password), false)
 		ts.Equal("", output.StdErr)
+	})
+
+	t.Run("WarnsOnMetricUnusedByAnyMetricsSet", func(t *testing.T) {
+		// config_unused_metric.resim.yml defines "Max Speed" but no metrics set
+		// references it; both sync and validate should warn without failing.
+		configPath := ".resim/metrics/config_unused_metric.resim.yml"
+		const warning = "WARNING: the following metrics are not used by any metrics set: Max Speed"
+
+		syncCmd := syncMetrics(projectIDString, "", false, username, password)
+		syncCmd[1].Flags = append(syncCmd[1].Flags, Flag{Name: "--metrics-config-path", Value: configPath})
+		output := s.runCommand(ts, syncCmd, false)
+		ts.Contains(output.StdErr, warning)
+
+		output = s.runCommand(ts, validateMetrics(projectIDString, "", configPath, false, username, password), false)
+		ts.Contains(output.StdErr, warning)
+		ts.Contains(output.StdOut, "Validation passed")
 	})
 }
 


### PR DESCRIPTION
# Description of change

WOB-4322: `resim metrics sync` and `resim metrics validate` now print a non-blocking warning when a config defines a metric that isn't referenced by any metrics set:

```
WARNING: the following metrics are not used by any metrics set: Max Speed
```

**Revision note:** the first version of this PR read `unusedMetrics` directly off the existing `updateMetricsConfig`/`validateMetricsConfig` GraphQL response. The companion backend PR (resim-ai/rerun#3699) changed those fields' return types to carry it, which turned out to be a breaking GraphQL schema change — it broke an internal `rerun` consumer neither repo could fully audit for other callers. The backend reverted to leaving those fields untouched and instead added a new, purely-additive `findUnusedMetrics(config: String!): [String!]!` query. This PR now calls that query once after a successful sync/validate via a new `warnUnusedMetrics` helper in `utils.go`, instead of reading the field off the existing response. Two GraphQL calls instead of one, but zero risk to any other consumer of either repo's existing API surface. User-visible CLI behavior is unchanged — same warning, same wording, same non-fatal semantics.

The `findUnusedMetrics` call is soft-fail: a transport/BFF error there is logged and swallowed, never returned, so it can't turn a successful sync/validate into a failure (same precedent as `validateMetricsSetExists`).

Full design: `docs/plans/2026-07-28-001-feat-wob-4322-warn-unused-metrics-cli-plan.md` (this PR).

**Depends on** resim-ai/rerun#3699 merging/deploying — `bff/queries.gen.go` reflects that PR's schema.

## Guide to reproduce test results

`go test ./... -race`

E2E (needs the backend PR deployed): `go test -v -tags end_to_end -count 1 ./testing -run TestMetricsSync`

Manual: `resim metrics sync`/`validate --metrics-config-path testing/.resim/metrics/config_unused_metric.resim.yml` against a local or dev BFF running the backend change, confirm the WARNING prints and the command still exits 0.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change.
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.