### PR TITLE
fix(cli): sync metrics config before validating the metrics set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ReSim CLI
 
+### v0.69.0 - August 4, 2026
+
+- Fixes `--sync-metrics-config` and `--metrics-set` being unusable together on a branch with no metrics config yet. The metrics-set precheck ran before the config sync, so it rejected the branch with `No metrics config exists on this branch. Sync a metrics config to the branch first.` and the sync that would have created the config never ran. This broke CI pipelines that create a build with `builds create --auto-create-branch` and then create a batch on the new branch. The sync now runs first, so a metrics set defined in the config being synced is visible to the precheck. Affects `batches create`, `sweeps create`, `suites run`, and `ingest`.
+
 ### v0.68.0 - July 28, 2026
 
 - `resim metrics sync` and `resim metrics validate` now warn (without failing) when a config defines a metric that isn't referenced by any metrics set: `WARNING: the following metrics are not used by any metrics set: <names>`.

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -757,7 +757,7 @@ func createBatch(ccmd *cobra.Command, args []string) {
 		ConfigPaths:   viper.GetStringSlice(batchMetricsConfigPath),
 		TemplatesPath: viper.GetString(batchMetricsTemplatesPath),
 	}); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to create batch: %v", err)
 	}
 
 	// Build the request body

--- a/cmd/resim/commands/batch.go
+++ b/cmd/resim/commands/batch.go
@@ -751,17 +751,13 @@ func createBatch(ccmd *cobra.Command, args []string) {
 
 	metricsSet := ProcessMetricsSet(batchMetricsSetKey, &poolLabels)
 
-	if HasMetricsSetName(metricsSet) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		if build.JSON200 == nil || build.JSON200.BranchID == uuid.Nil {
-			log.Fatal("build has no branch associated with it")
-		}
-		if err := validateMetricsSetExists(build.JSON200.BranchID, metricsSet); err != nil {
-			log.Fatal(err)
-		}
+	// Sync metrics2.0 config, then validate the metrics set against the synced branch.
+	if err := syncAndValidateMetricsSet(projectID, buildID, metricsSet, metricsConfigSync{
+		Enabled:       viper.GetBool(batchSyncMetricsConfigKey),
+		ConfigPaths:   viper.GetStringSlice(batchMetricsConfigPath),
+		TemplatesPath: viper.GetString(batchMetricsTemplatesPath),
+	}); err != nil {
+		log.Fatal(err)
 	}
 
 	// Build the request body
@@ -819,24 +815,6 @@ func createBatch(ccmd *cobra.Command, args []string) {
 
 	if len(poolLabels) != 0 {
 		body.PoolLabels = &poolLabels
-	}
-
-	// Sync metrics2.0 config
-	if viper.GetBool(batchSyncMetricsConfigKey) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		branchID := build.JSON200.BranchID
-		if branchID == uuid.Nil {
-			log.Fatal("build has no branch associated with it")
-		}
-
-		metricsConfigPaths := viper.GetStringSlice(batchMetricsConfigPath)
-		metricsTemplatesPath := viper.GetString(batchMetricsTemplatesPath)
-		if err := SyncMetricsConfig(projectID, branchID, metricsConfigPaths, metricsTemplatesPath, false, false); err != nil {
-			log.Fatalf("failed to sync metrics before batch: %v", err)
-		}
 	}
 
 	// Make the request

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -261,17 +261,13 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 	poolLabels := getAndValidatePoolLabels(ingestPoolLabelsKey)
 	metricsSet := ProcessMetricsSet(ingestMetricsSetKey, &poolLabels)
 
-	if HasMetricsSetName(metricsSet) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		if build.JSON200 == nil || build.JSON200.BranchID == uuid.Nil {
-			log.Fatal("build has no branch associated with it")
-		}
-		if err := validateMetricsSetExists(build.JSON200.BranchID, metricsSet); err != nil {
-			log.Fatal(err)
-		}
+	// Sync metrics2.0 config, then validate the metrics set against the synced branch.
+	if err := syncAndValidateMetricsSet(projectID, buildID, metricsSet, metricsConfigSync{
+		Enabled:       viper.GetBool(ingestSyncMetricsConfigKey),
+		ConfigPaths:   viper.GetStringSlice(ingestMetricsConfigPathKey),
+		TemplatesPath: viper.GetString(ingestMetricsTemplatesPathKey),
+	}); err != nil {
+		log.Fatal(err)
 	}
 
 	// Finally, create a batch to process the log(s)
@@ -301,21 +297,6 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 	}
 	if priority := getRequestPriority(ingestPriorityKey); priority != nil {
 		batchBody.Priority = priority
-	}
-
-	// Sync metrics2.0 config
-	if viper.GetBool(ingestSyncMetricsConfigKey) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		branchID := build.JSON200.BranchID
-
-		metricsConfigPaths := viper.GetStringSlice(ingestMetricsConfigPathKey)
-		metricsTemplatesPath := viper.GetString(ingestMetricsTemplatesPathKey)
-		if err := SyncMetricsConfig(projectID, branchID, metricsConfigPaths, metricsTemplatesPath, false, false); err != nil {
-			log.Fatalf("failed to sync metrics before ingest: %v", err)
-		}
 	}
 
 	batchResponse, err := Client.CreateBatchWithResponse(context.Background(), projectID, batchBody)

--- a/cmd/resim/commands/ingest.go
+++ b/cmd/resim/commands/ingest.go
@@ -267,7 +267,7 @@ func ingestLog(ccmd *cobra.Command, args []string) {
 		ConfigPaths:   viper.GetStringSlice(ingestMetricsConfigPathKey),
 		TemplatesPath: viper.GetString(ingestMetricsTemplatesPathKey),
 	}); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to ingest log: %v", err)
 	}
 
 	// Finally, create a batch to process the log(s)

--- a/cmd/resim/commands/sweep.go
+++ b/cmd/resim/commands/sweep.go
@@ -218,17 +218,13 @@ func createSweep(ccmd *cobra.Command, args []string) {
 
 	metricsSet := ProcessMetricsSet(sweepMetricsSetKey, &poolLabels)
 
-	if HasMetricsSetName(metricsSet) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		if build.JSON200 == nil || build.JSON200.BranchID == uuid.Nil {
-			log.Fatal("build has no branch associated with it")
-		}
-		if err := validateMetricsSetExists(build.JSON200.BranchID, metricsSet); err != nil {
-			log.Fatal(err)
-		}
+	// Sync metrics2.0 config, then validate the metrics set against the synced branch.
+	if err := syncAndValidateMetricsSet(projectID, buildID, metricsSet, metricsConfigSync{
+		Enabled:       viper.GetBool(sweepSyncMetricsConfigKey),
+		ConfigPaths:   viper.GetStringSlice(sweepMetricsConfigPathKey),
+		TemplatesPath: viper.GetString(sweepMetricsTemplatesPathKey),
+	}); err != nil {
+		log.Fatal(err)
 	}
 
 	// Process the associated account: by default, we try to get from CI/CD environment variables
@@ -272,23 +268,6 @@ func createSweep(ccmd *cobra.Command, args []string) {
 		body.PoolLabels = &poolLabels
 	}
 
-	// Sync metrics2.0 config
-	if viper.GetBool(sweepSyncMetricsConfigKey) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		branchID := build.JSON200.BranchID
-		if branchID == uuid.Nil {
-			log.Fatal("build has no branch associated with it")
-		}
-
-		metricsConfigPaths := viper.GetStringSlice(sweepMetricsConfigPathKey)
-		metricsTemplatesPath := viper.GetString(sweepMetricsTemplatesPathKey)
-		if err := SyncMetricsConfig(projectID, branchID, metricsConfigPaths, metricsTemplatesPath, false, false); err != nil {
-			log.Fatalf("failed to sync metrics before batch: %v", err)
-		}
-	}
 	// Make the request
 	response, err := Client.CreateParameterSweepWithResponse(context.Background(), projectID, body)
 	if err != nil {

--- a/cmd/resim/commands/sweep.go
+++ b/cmd/resim/commands/sweep.go
@@ -224,7 +224,7 @@ func createSweep(ccmd *cobra.Command, args []string) {
 		ConfigPaths:   viper.GetStringSlice(sweepMetricsConfigPathKey),
 		TemplatesPath: viper.GetString(sweepMetricsTemplatesPathKey),
 	}); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to create sweep: %v", err)
 	}
 
 	// Process the associated account: by default, we try to get from CI/CD environment variables

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -629,7 +629,7 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 		ConfigPaths:   viper.GetStringSlice(testSuitesMetricsConfigPathKey),
 		TemplatesPath: viper.GetString(testSuitesMetricsTemplatesPathKey),
 	}); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to run test suite: %v", err)
 	}
 
 	// Process the associated account: by default, we try to get from CI/CD environment variables

--- a/cmd/resim/commands/test_suites.go
+++ b/cmd/resim/commands/test_suites.go
@@ -615,20 +615,21 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 
 	poolLabels := getAndValidatePoolLabels(testSuitePoolLabelsKey)
 	effectiveMetricsSetName := NormalizeMetricsSetName(testSuite.MetricsSetName)
+	// Only an explicit override is prechecked here; a set inherited from the test suite is
+	// left to the server, as it was before this precheck existed.
+	var metricsSetToValidate *string
 	if viper.IsSet(testSuiteMetricsSetOverrideKey) {
 		effectiveMetricsSetName = NormalizeMetricsSetName(Ptr(viper.GetString(testSuiteMetricsSetOverrideKey)))
-		if HasMetricsSetName(effectiveMetricsSetName) {
-			build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-			if err != nil {
-				log.Fatal("unable to retrieve build:", err)
-			}
-			if build.JSON200 == nil || build.JSON200.BranchID == uuid.Nil {
-				log.Fatal("build has no branch associated with it")
-			}
-			if err := validateMetricsSetExists(build.JSON200.BranchID, effectiveMetricsSetName); err != nil {
-				log.Fatal(err)
-			}
-		}
+		metricsSetToValidate = effectiveMetricsSetName
+	}
+
+	// Sync metrics2.0 config, then validate the metrics set against the synced branch.
+	if err := syncAndValidateMetricsSet(projectID, buildID, metricsSetToValidate, metricsConfigSync{
+		Enabled:       viper.GetBool(testSuiteSyncMetricsConfigKey),
+		ConfigPaths:   viper.GetStringSlice(testSuitesMetricsConfigPathKey),
+		TemplatesPath: viper.GetString(testSuitesMetricsTemplatesPathKey),
+	}); err != nil {
+		log.Fatal(err)
 	}
 
 	// Process the associated account: by default, we try to get from CI/CD environment variables
@@ -636,23 +637,6 @@ func runTestSuite(ccmd *cobra.Command, args []string) {
 	associatedAccount := GetCIEnvironmentVariableAccount()
 	if viper.IsSet(testSuiteAccountKey) {
 		associatedAccount = viper.GetString(testSuiteAccountKey)
-	}
-
-	// Sync metrics2.0 config
-	if viper.GetBool(testSuiteSyncMetricsConfigKey) {
-		build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
-		if err != nil {
-			log.Fatal("unable to retrieve build:", err)
-		}
-		branchID := build.JSON200.BranchID
-		if branchID == uuid.Nil {
-			log.Fatal("build has no branch associated with it")
-		}
-		metricsConfigPaths := viper.GetStringSlice(testSuitesMetricsConfigPathKey)
-		metricsTemplatesPath := viper.GetString(testSuitesMetricsTemplatesPathKey)
-		if err := SyncMetricsConfig(projectID, branchID, metricsConfigPaths, metricsTemplatesPath, false, false); err != nil {
-			log.Fatalf("failed to sync metrics before batch: %v", err)
-		}
 	}
 
 	var batch api.Batch

--- a/cmd/resim/commands/utils.go
+++ b/cmd/resim/commands/utils.go
@@ -256,6 +256,47 @@ func validateMetricsSetExists(branchID uuid.UUID, metricsSetName *string) error 
 	return nil
 }
 
+// metricsConfigSync describes a --sync-metrics-config request. Enabled mirrors the flag;
+// the paths are only read when it is set.
+type metricsConfigSync struct {
+	Enabled       bool
+	ConfigPaths   []string
+	TemplatesPath string
+}
+
+// syncAndValidateMetricsSet syncs the metrics config (when requested) and then validates the
+// metrics set name (when one is set), for the branch the given build belongs to.
+//
+// The order is load-bearing. A metrics set is defined by the metrics config, so a set named on
+// the command line often exists only in the config this same invocation is about to sync.
+// Validating first made --sync-metrics-config and --metrics-set mutually unusable on a branch
+// with no config yet — the precheck rejected the branch and the sync that would have fixed it
+// never ran (WOB-4358).
+//
+// Both steps need the build's branch, so it is resolved once, and only when there is work to do.
+func syncAndValidateMetricsSet(projectID uuid.UUID, buildID uuid.UUID, metricsSetName *string, sync metricsConfigSync) error {
+	if !sync.Enabled && !HasMetricsSetName(metricsSetName) {
+		return nil
+	}
+
+	build, err := Client.GetBuildWithResponse(context.Background(), projectID, buildID)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve build: %w", err)
+	}
+	if build.JSON200 == nil || build.JSON200.BranchID == uuid.Nil {
+		return errors.New("build has no branch associated with it")
+	}
+	branchID := build.JSON200.BranchID
+
+	if sync.Enabled {
+		if err := SyncMetricsConfig(projectID, branchID, sync.ConfigPaths, sync.TemplatesPath, false, false); err != nil {
+			return fmt.Errorf("failed to sync metrics config: %w", err)
+		}
+	}
+
+	return validateMetricsSetExists(branchID, metricsSetName)
+}
+
 // previewTopicRemovalImpact calls the BFF's previewTopicRemoval query and, if any
 // topics would be removed by this config, prints the impact (row count, chart count,
 // dashboards) so the user sees it either way. When allowTopicRemoval is false this

--- a/cmd/resim/commands/validate_metrics_set_test.go
+++ b/cmd/resim/commands/validate_metrics_set_test.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/uuid"
+	"github.com/resim-ai/api-client/api"
+	mockapiclient "github.com/resim-ai/api-client/api/mocks"
 	"github.com/resim-ai/api-client/bff"
 	. "github.com/resim-ai/api-client/ptr"
 	"github.com/stretchr/testify/assert"
@@ -77,4 +80,138 @@ func TestValidateMetricsSetExists_TransportErrorSoftFails(t *testing.T) {
 	// A non-GraphQL (transport) error must not block creation — the server stays the backstop.
 	assert.NoError(t, validateMetricsSetExists(uuid.New(), Ptr("safety")))
 	mockBff.AssertExpectations(t)
+}
+
+// withMockClientForBuild stubs the package-level REST Client with a mock that resolves
+// buildID to branchID, and branchID to branchName — the two REST lookups
+// syncAndValidateMetricsSet makes before it ever reaches the BFF.
+func withMockClientForBuild(t *testing.T, projectID, buildID, branchID uuid.UUID, branchName string) *mockapiclient.ClientWithResponsesInterface {
+	t.Helper()
+	mockClient := mockapiclient.NewClientWithResponsesInterface(t)
+	mockClient.On("GetBuildWithResponse", mock.Anything, projectID, buildID).
+		Return(&api.GetBuildResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      &api.Build{BranchID: branchID},
+		}, nil).Maybe()
+	mockClient.On("GetBranchForProjectWithResponse", mock.Anything, projectID, branchID).
+		Return(&api.GetBranchForProjectResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      &api.Branch{Name: branchName},
+		}, nil).Maybe()
+
+	origClient := Client
+	Client = mockClient
+	t.Cleanup(func() { Client = origClient })
+	return mockClient
+}
+
+// recordingBffClient answers every BFF operation involved in a sync-then-validate run
+// and records the operation names in the order they were issued.
+func recordingBffClient(t *testing.T, ops *[]string) *mockGraphQLClient {
+	t.Helper()
+	mockBff := new(mockGraphQLClient)
+	mockBff.On("MakeRequest", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*graphql.Request)
+			*ops = append(*ops, req.OpName)
+
+			switch data := args.Get(2).(*graphql.Response).Data.(type) {
+			case *bff.PreviewTopicRemovalResponse:
+				data.PreviewTopicRemoval = nil
+			case *bff.UpdateMetricsConfigResponse:
+				data.UpdateMetricsConfig = "Success"
+			case *bff.FindUnusedMetricsResponse:
+				data.FindUnusedMetrics = nil
+			case *bff.ValidateMetricsSetResponse:
+				data.ValidateMetricsSet = true
+			}
+		}).
+		Return(nil)
+	withMockBffClient(t, mockBff)
+	return mockBff
+}
+
+func indexOfOp(ops []string, name string) int {
+	for i, op := range ops {
+		if op == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// The regression guard for WOB-4358: when both flags are supplied, the config must be
+// synced before the metrics set is validated. Validating first makes --sync-metrics-config
+// and --metrics-set mutually unusable on a branch that has no metrics config yet, because
+// the set being validated is defined in the very config the sync is about to upload.
+func TestSyncAndValidateMetricsSet_SyncsBeforeValidating(t *testing.T) {
+	projectID, buildID, branchID := uuid.New(), uuid.New(), uuid.New()
+	withMockClientForBuild(t, projectID, buildID, branchID, "main")
+
+	var ops []string
+	recordingBffClient(t, &ops)
+
+	err := syncAndValidateMetricsSet(projectID, buildID, Ptr("woot"), metricsConfigSync{
+		Enabled:       true,
+		ConfigPaths:   []string{"testdata/config.yml"},
+		TemplatesPath: "testdata/templates",
+	})
+	assert.NoError(t, err)
+
+	syncedAt := indexOfOp(ops, "UpdateMetricsConfig")
+	validatedAt := indexOfOp(ops, "ValidateMetricsSet")
+	assert.NotEqual(t, -1, syncedAt, "expected the metrics config to be synced, got ops %v", ops)
+	assert.NotEqual(t, -1, validatedAt, "expected the metrics set to be validated, got ops %v", ops)
+	assert.Less(t, syncedAt, validatedAt,
+		"the metrics config must be synced before the metrics set is validated, got ops %v", ops)
+}
+
+// A sync failure must stop the run before the set is validated: validating against a
+// half-synced branch would report a confusing "set not found" instead of the sync error.
+func TestSyncAndValidateMetricsSet_SyncFailureSkipsValidation(t *testing.T) {
+	projectID, buildID, branchID := uuid.New(), uuid.New(), uuid.New()
+	withMockClientForBuild(t, projectID, buildID, branchID, "main")
+
+	mockBff := new(mockGraphQLClient)
+	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isPreviewTopicRemovalRequest), mock.Anything).
+		Run(withPreviewTopicRemovalResponse(nil)).
+		Return(nil).Once()
+	mockBff.On("MakeRequest", mock.Anything, mock.MatchedBy(isUpdateMetricsConfigRequest), mock.Anything).
+		Return(gqlerror.List{{Message: "config is invalid"}}).Once()
+	withMockBffClient(t, mockBff)
+
+	err := syncAndValidateMetricsSet(projectID, buildID, Ptr("woot"), metricsConfigSync{
+		Enabled:       true,
+		ConfigPaths:   []string{"testdata/config.yml"},
+		TemplatesPath: "testdata/templates",
+	})
+	assert.ErrorContains(t, err, "config is invalid")
+	mockBff.AssertNotCalled(t, "MakeRequest", mock.Anything, mock.MatchedBy(isValidateMetricsSetRequest), mock.Anything)
+}
+
+// Without --sync-metrics-config the precheck still runs on its own, unchanged.
+func TestSyncAndValidateMetricsSet_ValidatesWithoutSync(t *testing.T) {
+	projectID, buildID, branchID := uuid.New(), uuid.New(), uuid.New()
+	withMockClientForBuild(t, projectID, buildID, branchID, "main")
+
+	var ops []string
+	recordingBffClient(t, &ops)
+
+	err := syncAndValidateMetricsSet(projectID, buildID, Ptr("woot"), metricsConfigSync{Enabled: false})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"ValidateMetricsSet"}, ops)
+}
+
+// With neither a metrics set nor a sync requested there is nothing to do, and in
+// particular no build lookup to pay for.
+func TestSyncAndValidateMetricsSet_NoWorkSkipsBuildLookup(t *testing.T) {
+	projectID, buildID, branchID := uuid.New(), uuid.New(), uuid.New()
+	mockClient := withMockClientForBuild(t, projectID, buildID, branchID, "main")
+
+	var ops []string
+	recordingBffClient(t, &ops)
+
+	assert.NoError(t, syncAndValidateMetricsSet(projectID, buildID, nil, metricsConfigSync{Enabled: false}))
+	assert.Empty(t, ops)
+	mockClient.AssertNotCalled(t, "GetBuildWithResponse", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/docs/plans/2026-08-04-001-fix-wob-4358-sync-before-metrics-set-precheck.md
+++ b/docs/plans/2026-08-04-001-fix-wob-4358-sync-before-metrics-set-precheck.md
@@ -1,0 +1,84 @@
+# Sync the metrics config before the metrics-set precheck (WOB-4358)
+
+## Context
+
+`resim batch create --sync-metrics-config --metrics-set <name>` fails on any branch that does not
+already have a metrics config:
+
+```
+No metrics config exists on this branch. Sync a metrics config to the branch first.
+```
+
+The two flags are mutually unusable on a new branch. The `--metrics-set` precheck added by WOB-4051
+runs *before* the `--sync-metrics-config` block, so the precheck rejects the branch and the sync that
+would have created the config never runs. This breaks CI pipelines that create a build with
+`builds create --auto-create-branch` and then create a batch on the freshly-created branch — found by
+Bear Flag Robotics CI.
+
+The precheck itself is correct; only its position is wrong. A metrics set is *defined by* the metrics
+config, so a set named on the command line frequently exists only in the config that the same
+invocation is about to sync. Validating first can only ever see the branch's previous state.
+
+## Regression
+
+- Introduced by `6de71bd` — "feat(cli): validate metrics set exists before create (#213)", 2026-06-29
+  (WOB-4051, planned in `2026-06-18-001-cli-metrics-set-validation.md`).
+- The sync block it front-runs is much older: `81ab746` — "Wob 3667: Sync config before running a
+  batch/test/suite (#166)", 2025-10-17.
+- First shipped in v0.59.0 (2026-06-29); present through v0.68.0.
+
+PR #213 tested `--metrics-set <real>`, `--metrics-set bogus`, and no flag — all three assume a branch
+that already has a config, which is why its e2e passed. The untested combination is the broken one.
+
+## Approach
+
+Extract the two ordering-coupled steps into one shared helper, `syncAndValidateMetricsSet`
+(`cmd/resim/commands/utils.go`), so the ordering is stated once and cannot drift back apart
+per-command:
+
+1. Return early when there is neither a sync nor a metrics set — no build lookup.
+2. Resolve the build's branch **once** (both steps previously issued their own `GetBuild`).
+3. Sync the config when `--sync-metrics-config` is set.
+4. Validate the metrics set against the now-current branch.
+
+A sync failure returns before validation, so the user sees the sync error rather than a confusing
+"set not found" from a half-synced branch.
+
+The helper returns errors instead of calling `log.Fatal` itself, which is what makes the ordering
+unit-testable; callers keep their existing `log.Fatal` behaviour.
+
+## Scope
+
+The four commands that accept both flags:
+
+- `batch create`
+- `sweep create`
+- `suites run`
+- `ingest log`
+
+`report create` and `dashboards create` take `--metrics-set` but have no `--sync-metrics-config`, so
+they are unaffected.
+
+Behaviour deliberately preserved:
+
+- **`suites run`** only prechecks an *explicit* `--metrics-set-name-override`. A set inherited from the
+  test suite is still left to the server, exactly as before; only the override is passed to the helper.
+- A failed precheck now leaves an already-synced config on the branch. This is accepted: the sync was
+  explicitly requested, it is idempotent, and the alternative ordering is the bug being fixed.
+
+## Verification
+
+- `go build ./... && go vet ./... && gofmt -l`
+- `go test ./... -race`
+- Unit (`cmd/resim/commands/validate_metrics_set_test.go`) — four tests on the helper, keyed on the
+  order of BFF operations: sync-before-validate, sync failure skips validation, validate works without
+  a sync, and no work means no build lookup. The ordering guard was confirmed to fail when the old
+  order is restored.
+- E2E (`testing/end_to_end_test.go`, `TestBatchAndLogs`) — extends the existing WOB-4051 precheck
+  coverage rather than adding a separate test: creates a build on a fresh auto-created branch with no
+  config, then runs `batch create --sync-metrics-config --metrics-set woot` in a single invocation and
+  asserts the batch is created with that set. A bogus set through the same path is still rejected, so
+  the precheck is not merely being skipped when `--sync-metrics-config` is present.
+- Manual: reproduced against staging before the fix (project `metrics-set-sync-ordering-repro`,
+  `65365e82-3b3b-4117-80fe-fc5ad4698923`) — the same command failed on a fresh branch, succeeded after
+  a separate sync had populated the branch.

--- a/testing/end_to_end_test.go
+++ b/testing/end_to_end_test.go
@@ -1803,6 +1803,26 @@ func createBatchWithMetricsSet(projectID uuid.UUID, buildID string, experiences 
 	return cmds
 }
 
+// createBatchWithSyncedMetricsSet builds a batch create command that syncs the metrics config and
+// selects a metrics set from that same config in one invocation. The set only exists on the branch
+// once the sync has run, so this is the combination that breaks if the metrics-set precheck runs
+// first (WOB-4358).
+func createBatchWithSyncedMetricsSet(projectID uuid.UUID, buildID string, experiences []string, metricsSet string, configPath string, batchName *string, username string, password string) []CommandBuilder {
+	cmds := createBatchWithMetricsSet(projectID, buildID, experiences, metricsSet, batchName)
+	cmds[1].Flags = append(cmds[1].Flags,
+		Flag{Name: "--sync-metrics-config"},
+		Flag{Name: "--metrics-config-path", Value: configPath},
+	)
+	// The sync mutation is authenticated the same way as `metrics sync`; see syncMetrics.
+	if username != "" {
+		cmds[1].Flags = append(cmds[1].Flags, Flag{Name: "--username", Value: username})
+	}
+	if password != "" {
+		cmds[1].Flags = append(cmds[1].Flags, Flag{Name: "--password", Value: password})
+	}
+	return cmds
+}
+
 func createIngestedLog(projectID uuid.UUID, system *string, branchname *string, version *string, metricsBuildID uuid.UUID, logName *string, logLocation *string, logsList []string, configFileLocation *string, experienceTags []string, buildID *uuid.UUID, batchName *string, github bool, reingest bool) []CommandBuilder {
 	ingestCommand := CommandBuilder{
 		Command: "ingest",
@@ -4220,6 +4240,33 @@ func TestBatchAndLogs(t *testing.T) {
 	bogusBatchName := fmt.Sprintf("bogus-metrics-set-batch-%s", uuid.New().String())
 	bogusMetricsSet := fmt.Sprintf("does-not-exist-%s", uuid.New().String())
 	output = s.runCommand(ts, createBatchWithMetricsSet(projectID, buildIDString, []string{experienceIDString1}, bogusMetricsSet, &bogusBatchName), ExpectError)
+	ts.Contains(output.StdErr, "not found")
+
+	// --sync-metrics-config and --metrics-set must work together in a single invocation on a branch
+	// that has no metrics config yet (WOB-4358). The set being selected is defined in the very config
+	// being synced, so the sync has to run before the precheck; otherwise the precheck rejects the
+	// branch and the sync that would have fixed it never runs. A fresh auto-created branch reproduces
+	// what CI does with `builds create --auto-create-branch`.
+	unsyncedBranchName := fmt.Sprintf("test-branch-no-config-%s", uuid.New().String())
+	output = s.runCommand(ts, createBuild(projectName, unsyncedBranchName, systemName, "description", "public.ecr.aws/resim/open-builds/log-ingest:latest", []string{}, "1.0.1", GithubTrue, AutoCreateBranchTrue), ExpectNoError)
+	ts.Contains(output.StdOut, GithubCreatedBuild)
+	unsyncedBranchBuildID := output.StdOut[len(GithubCreatedBuild) : len(output.StdOut)-1]
+	uuid.MustParse(unsyncedBranchBuildID)
+
+	syncedSetBatchName := fmt.Sprintf("synced-metrics-set-batch-%s", uuid.New().String())
+	output = s.runCommand(ts, createBatchWithSyncedMetricsSet(projectID, unsyncedBranchBuildID, []string{experienceIDString1}, "woot", ".resim/metrics/config.resim.yml", &syncedSetBatchName, metricsUsername, metricsPassword), ExpectNoError)
+	ts.Contains(output.StdOut, CreatedBatch)
+
+	output = s.runCommand(ts, getBatchByName(projectID, syncedSetBatchName, ExitStatusFalse), ExpectNoError)
+	var syncedSetBatch api.Batch
+	ts.NoError(json.Unmarshal([]byte(output.StdOut), &syncedSetBatch))
+	ts.NotNil(syncedSetBatch.MetricsSetName)
+	ts.Equal("woot", *syncedSetBatch.MetricsSetName)
+
+	// A set that is absent from the synced config is still rejected, so the precheck keeps working
+	// after the sync rather than being skipped whenever --sync-metrics-config is present.
+	bogusSyncedBatchName := fmt.Sprintf("bogus-synced-metrics-set-batch-%s", uuid.New().String())
+	output = s.runCommand(ts, createBatchWithSyncedMetricsSet(projectID, unsyncedBranchBuildID, []string{experienceIDString1}, bogusMetricsSet, ".resim/metrics/config.resim.yml", &bogusSyncedBatchName, metricsUsername, metricsPassword), ExpectError)
 	ts.Contains(output.StdErr, "not found")
 
 	// Now create a batch without the github flag, but with metrics


### PR DESCRIPTION
# Description of change

`--sync-metrics-config` and `--metrics-set` are mutually unusable on a branch that has no metrics config yet:

```
No metrics config exists on this branch. Sync a metrics config to the branch first.
```

The metrics-set precheck runs *before* the config sync, so it rejects the branch and the sync that would have created the config never runs. This breaks CI pipelines that create a build with `builds create --auto-create-branch` and then create a batch on the new branch. Found by Bear Flag Robotics CI (`resim-ai/metrics-runner-bearflagrobotics` PR #104).

The precheck itself is fine; only its position is wrong. A metrics set is *defined by* the metrics config, so a set named on the command line often exists only in the config the same invocation is about to sync. Validating first can only ever see the branch's previous state.

Closes [WOB-4358](https://linear.app/resim/issue/WOB-4358).

## Regression

Introduced by 6de71bd — "feat(cli): validate metrics set exists before create (#213)", 2026-06-29 (WOB-4051). The sync block it front-runs is much older: 81ab746 (#166), 2025-10-17. First shipped in **v0.59.0**; present in every release through v0.68.0 (~5 weeks).

#213 tested `--metrics-set <real>`, `--metrics-set bogus`, and no flag — all three assume a branch that already has a config, which is why its e2e passed. The untested combination is the broken one.

## Approach

Both ordering-coupled steps move into one shared `syncAndValidateMetricsSet` helper, so the ordering is stated once instead of drifting apart across four commands. It also resolves the build's branch a single time (each block previously issued its own `GetBuild`) and skips the lookup entirely when there is neither a sync nor a metrics set. A sync failure returns before validation, so you see the sync error rather than a confusing "set not found" from a half-synced branch.

The helper returns errors rather than calling `log.Fatal` itself, which is what makes the ordering unit-testable; callers keep their existing behaviour. The four command files each shrink by ~22 lines.

Applies to `batches create`, `sweeps create`, `suites run`, and `ingest log`. `reports create` / `dashboards create` take `--metrics-set` but have no `--sync-metrics-config`, so they're unaffected.

Behaviour deliberately preserved:

- **`suites run`** still prechecks only an explicit `--metrics-set-name-override`; a set inherited from the test suite is left to the server, exactly as before.
- A failed precheck now leaves an already-synced config on the branch. Accepted: the sync was explicitly requested, it's idempotent, and the alternative ordering is the bug.

## Guide to reproduce test results

`go build ./... && go vet ./... && go test ./... -race` — all green, `gofmt` clean.

Verified against **staging** with a locally-built binary, A/B on the *same* fresh auto-created branch (project `metrics-set-sync-ordering-repro`, `65365e82-3b3b-4117-80fe-fc5ad4698923`). The buggy binary fails before syncing, so it leaves the branch untouched for the second run:

| Run | Binary | Result |
|---|---|---|
| A | v0.68.0 (released) | `No metrics config exists on this branch...` — dies at the precheck |
| B | this branch | syncs, passes the precheck, reaches the API (fails only on a deliberately bogus experience name) |
| C | this branch, bogus set | `Metrics set 'Definitely Not A Real Set' was not found in the latest metrics config (available sets: BFR Static Metrics).` |

Run C is the important guard: the precheck is not merely skipped when `--sync-metrics-config` is present, and it now validates against the *just-synced* config.

Coverage added:

- **Unit** (`validate_metrics_set_test.go`) — four tests on the helper keyed on BFF operation order: sync-before-validate, sync failure skips validation, validate works without a sync, no work means no build lookup. The ordering guard was confirmed to fail when the old order is restored (`got ops [ValidateMetricsSet PreviewTopicRemoval UpdateMetricsConfig FindUnusedMetrics]`).
- **E2E** (`TestBatchAndLogs`) — extends the existing WOB-4051 precheck block rather than adding a separate test: builds on a fresh auto-created branch with no config, runs both flags in one invocation, asserts the batch is created with that set, and asserts a bogus set through the same path is still rejected.

## Checklist

- [x] I have self-reviewed this change.
- [x] I have tested this change (unit + race, and manually against staging).
- [x] This change is covered by tests that are already landed, or in this PR.
- [x] I have updated the changelog, if appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)